### PR TITLE
Rename CLI package to @opena2a/cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opena2a",
+  "name": "@opena2a/cli",
   "version": "0.1.0",
   "description": "Unified CLI for the OpenA2A security platform",
   "main": "dist/index.js",


### PR DESCRIPTION
npm rejected 'opena2a' as too similar to 'openai'. Published as @opena2a/cli@0.1.0. Binary name remains 'opena2a'.