### PR TITLE
Remove 'product' language from user-facing text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Shield `init` orchestration: unified security setup that runs scan, policy, and hooks
 - Cross-tab navigation for finding IDs in HTML dashboard
-- Standardized product nav bar ordering across repos
+- Standardized tool nav bar ordering across repos
 
 ### Fixed
 - Fix CI security checks: sync lock file, remove redundant secret-scan job

--- a/README.md
+++ b/README.md
@@ -356,9 +356,9 @@ Shield stores events in a local tamper-evident log at `.opena2a/shield/events.js
 
 ## Adapter Commands
 
-The CLI orchestrates specialized tools through a unified interface. Each command maps to a standalone product that can also be used independently.
+The CLI orchestrates specialized tools through a unified interface. Each command maps to a standalone tool that can also be used independently.
 
-| Command | Product | Docs | Description |
+| Command | Tool | Docs | Description |
 |---------|---------|------|-------------|
 | `opena2a scan` | [HackMyAgent](https://github.com/opena2a-org/hackmyagent) | [docs](https://opena2a.org/docs/hackmyagent) | 150+ security checks, attack simulation, auto-fix |
 | `opena2a secrets` | [Secretless AI](https://github.com/opena2a-org/secretless-ai) | [docs](https://opena2a.org/docs/secretless) | Credential management for AI coding tools |
@@ -372,9 +372,9 @@ The CLI orchestrates specialized tools through a unified interface. Each command
 
 Adapters install tools on first use. Each tool works standalone or through the CLI.
 
-**Command-to-product mapping:**
+**Command-to-tool mapping:**
 
-| Product | CLI Commands |
+| Tool | CLI Commands |
 |---------|-------------|
 | [HackMyAgent](https://github.com/opena2a-org/hackmyagent) | `scan`, `benchmark` |
 | [Secretless AI](https://github.com/opena2a-org/secretless-ai) | `secrets`, `broker`, `dlp` |
@@ -422,7 +422,7 @@ opena2a CLI
   |
   +-- shield        Unified orchestration layer
   |     +-- init        11-step setup (secretless + aim-core + guard + policy + arp + ai-tools)
-  |     +-- status      Unified product status view
+  |     +-- status      Unified tool status view
   |     +-- log         Tamper-evident event log (SHA-256 hash chain)
   |     +-- report      Weekly security posture report
   |     +-- selfcheck   Integrity verification + self-healing
@@ -478,8 +478,8 @@ Language-aware replacements:
 
 OpenA2A is a platform of specialized security tools, each usable standalone or through the CLI.
 
-| Product | Install | Purpose |
-|---------|---------|---------|
+| Tool | Install | Purpose |
+|------|---------|---------|
 | [HackMyAgent](https://github.com/opena2a-org/hackmyagent) | `npx hackmyagent secure` | Security scanner, attack simulation, benchmarks, runtime protection |
 | [Secretless AI](https://github.com/opena2a-org/secretless-ai) | `npx secretless-ai init` | Credential management, broker, DLP for AI coding tools |
 | [AIM](https://github.com/opena2a-org/agent-identity-management) | Self-hosted (Go) | Agent identity and access management |
@@ -487,7 +487,7 @@ OpenA2A is a platform of specialized security tools, each usable standalone or t
 | [DVAA](https://github.com/opena2a-org/damn-vulnerable-ai-agent) | `docker pull opena2a/dvaa` | Deliberately vulnerable AI agent for security training |
 | [Trust Registry](https://registry.opena2a.org) | `registry.opena2a.org` | Supply chain verification, trust scores, package metadata |
 
-All products are open source under Apache-2.0.
+All tools are open source under Apache-2.0.
 
 ## Upstream Contributions
 

--- a/UNBUILT_FEATURES.md
+++ b/UNBUILT_FEATURES.md
@@ -56,12 +56,12 @@ Displayed in scan output: `Conformance: ESSENTIAL`
 
 ---
 
-## Non-Priority (Wrong Product Attribution)
+## Non-Priority (Wrong Tool Attribution)
 
-The following features were claimed in blogs but actually belong to **separate products** (AIM Platform, Python SDK). These are correct as positioned — they're not CLI features.
+The following features were claimed in blogs but actually belong to **separate tools** (AIM Platform, Python SDK). These are correct as positioned — they're not CLI features.
 
-| Feature | Blog | Actual Product |
-|---------|------|----------------|
+| Feature | Blog | Actual Tool |
+|---------|------|-------------|
 | Ed25519 keypair generation | how-do-you-give-an-ai-agent-a-verifiable-identity | AIM Platform (agent-identity-management) |
 | MCP server attestation | owasp-agentic-top-10-nhi-governance | AIM Platform |
 | Behavioral trust scoring (8-factor) | echoleak-one-line-secure-ai-agents | AIM Platform |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -193,11 +193,11 @@ opena2a config llm on             # Enable LLM-powered command matching
 
 ## Shield: Unified Security Orchestration
 
-Shield ties all OpenA2A products into a single security layer for AI coding assistants. It provides a tamper-evident event log, policy evaluation, runtime monitoring, session identification, integrity verification, and LLM-powered analysis.
+Shield ties all OpenA2A tools into a single security layer for AI coding assistants. It provides a tamper-evident event log, policy evaluation, runtime monitoring, session identification, integrity verification, and LLM-powered analysis.
 
 ```bash
 opena2a shield init              # Full environment scan + policy generation
-opena2a shield status            # Product availability and integrity state
+opena2a shield status            # Tool availability and integrity state
 opena2a shield selfcheck         # Run integrity checks across all subsystems
 ```
 
@@ -212,7 +212,7 @@ opena2a shield selfcheck         # Run integrity checks across all subsystems
 | **Session identification** | Detects which AI assistant is running (Claude Code, Cursor, Copilot, Windsurf) | Active |
 | **Config integrity** | Signs config files and detects unauthorized modifications | Active |
 | **ARP bridge** | Imports runtime protection events from HackMyAgent's ARP into Shield's log | Active |
-| **Posture scoring** | 0-100 security score based on active products, policy, hooks, credentials | Active |
+| **Posture scoring** | 0-100 security score based on active tools, policy, hooks, credentials | Active |
 | **LLM intelligence** | AI-powered policy suggestions, anomaly explanations, incident triage | Active (opt-in) |
 | **Integrity selfcheck** | Verifies policy, shell hooks, event chain, process, and artifact signatures | Active |
 | **Lockdown mode** | Enters lockdown when integrity checks fail; requires explicit recovery | Active |
@@ -239,7 +239,7 @@ opena2a shield init --format json      # Machine-readable output
 
 #### `opena2a shield status`
 
-Shows product availability, policy mode, shell integration, and integrity state.
+Shows tool availability, policy mode, shell integration, and integrity state.
 
 ```bash
 opena2a shield status


### PR DESCRIPTION
## Summary

- Replaces all user-facing instances of "product" with context-appropriate alternatives ("tool", "tools") across README files, CHANGELOG, and documentation
- Affects: `README.md`, `CHANGELOG.md`, `UNBUILT_FEATURES.md`, `packages/cli/README.md`
- Does not touch: technical code (variable/function/type names), test assertions, mathematical terms (`product(1 - c_i)` in session.ts), or third-party API references

## Changes

| File | Change |
|------|--------|
| `README.md` | "standalone product" -> "standalone tool"; "Product" column headers -> "Tool"; "Command-to-product mapping" -> "Command-to-tool mapping"; "Unified product status view" -> "Unified tool status view"; "All products are open source" -> "All tools are open source" |
| `packages/cli/README.md` | "all OpenA2A products" -> "all OpenA2A tools"; "Product availability" -> "Tool availability"; "active products" -> "active tools" |
| `CHANGELOG.md` | "product nav bar" -> "tool nav bar" |
| `UNBUILT_FEATURES.md` | "Wrong Product Attribution" -> "Wrong Tool Attribution"; "separate products" -> "separate tools"; "Actual Product" column -> "Actual Tool" |

## Test plan

- [ ] Verify no remaining user-facing "product" instances in README files
- [ ] Verify mathematical use of "product" in `session.ts` is unchanged
- [ ] Verify test comment in `review.test.ts` is unchanged (internal, not user-facing)
- [ ] Build passes (validated by pre-push hook)