### PR TITLE
Fix CLI command naming and vault migration prefix

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,9 @@ import { getVersion } from './util/version.js';
 
 const VERSION = getVersion();
 
+// Tell downstream tools (hackmyagent, secretless) to use 'opena2a' in user-facing messages
+process.env.HMA_CLI_PREFIX = 'opena2a scan';
+
 async function main(): Promise<void> {
   const program = new Command();
 


### PR DESCRIPTION
## Summary
- Set `HMA_CLI_PREFIX=opena2a scan` env var so HackMyAgent fix messages show `opena2a scan secure --fix` instead of `hackmyagent secure --fix`
- Fix vault migration prefix from `'secret'` to `''` so all local secrets are found during migration

## Test plan
- [x] Build passes
- [x] Tests pass
- [x] HMA fix messages use `opena2a scan` prefix when invoked through opena2a CLI
- [x] Vault migration reads all secrets from local store (not just prefix-matched)