### PR TITLE
Rename AGS to ABGS in CLI descriptions and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Every OpenA2A project is accessible through `opena2a <command>`. Each tool also 
 │  opena2a secrets / broker  → Secretless AI (credential mgmt)   │
 │  opena2a identity          → AIM  (agent identity & access)    │
 │  opena2a runtime           → ARP  (runtime protection)         │
-│  opena2a scan-soul         → AGS  (behavioral governance)      │
+│  opena2a scan-soul         → ABGS (behavioral governance)      │
 │  opena2a benchmark oasb-2  → OASB (compliance benchmarks)      │
 │  opena2a train             → DVAA (vulnerable agent training)  │
 │                                                                 │
@@ -47,7 +47,7 @@ Every OpenA2A project is accessible through `opena2a <command>`. Each tool also 
 | `secrets`, `broker`, `dlp` | [Secretless AI](https://github.com/opena2a-org/secretless-ai) | Credential management for Claude Code, Cursor, Windsurf |
 | `identity` | [AIM](https://github.com/opena2a-org/agent-identity-management) | Ed25519 keypairs, capability policies, audit logging |
 | `runtime` | ARP ([in HMA](https://github.com/opena2a-org/hackmyagent)) | Process, network, filesystem monitoring |
-| `scan-soul`, `harden-soul` | AGS ([in HMA](https://github.com/opena2a-org/hackmyagent)) | Behavioral governance — SOUL.md, 68 controls |
+| `scan-soul`, `harden-soul` | ABGS ([in HMA](https://github.com/opena2a-org/hackmyagent)) | Behavioral governance -- SOUL.md, 68 controls |
 | `benchmark oasb-2` | OASB ([in HMA](https://github.com/opena2a-org/hackmyagent)) | 222 test scenarios, compliance scoring |
 | `train` | [DVAA](https://github.com/opena2a-org/damn-vulnerable-ai-agent) | Deliberately vulnerable AI agents for training |
 | `guard` | ConfigGuard (built-in) | Config file integrity, SHA-256 signing |
@@ -132,7 +132,7 @@ One command sets up credential protection, agent identity, config integrity, run
 |---------|------|------|
 | `scan` | [HackMyAgent](https://github.com/opena2a-org/hackmyagent) — 150+ security checks, attack simulation | [docs](https://opena2a.org/docs/hackmyagent) |
 | `benchmark` | [HackMyAgent](https://github.com/opena2a-org/hackmyagent) — OASB-1 + OASB-2 compliance scoring | [docs](https://opena2a.org/docs/oasb) |
-| `scan-soul` / `harden-soul` | [HackMyAgent](https://github.com/opena2a-org/hackmyagent) — AGS behavioral governance, 68 controls | [docs](https://opena2a.org/docs/hackmyagent) |
+| `scan-soul` / `harden-soul` | [HackMyAgent](https://github.com/opena2a-org/hackmyagent) -- ABGS behavioral governance, 68 controls | [docs](https://opena2a.org/docs/hackmyagent) |
 | `secrets` / `broker` / `dlp` | [Secretless AI](https://github.com/opena2a-org/secretless-ai) — credential management for AI dev tools | [docs](https://opena2a.org/docs/secretless) |
 | `identity` | [AIM](https://github.com/opena2a-org/agent-identity-management) — agent identity and access management | [docs](https://opena2a.org/docs/aim) |
 | `train` | [DVAA](https://github.com/opena2a-org/damn-vulnerable-ai-agent) — vulnerable AI agent for security training | [docs](https://opena2a.org/docs/dvaa) |
@@ -441,7 +441,7 @@ Each tool in the ecosystem can be used independently — the CLI is optional.
 
 | Tool | Install Standalone | Purpose |
 |------|-------------------|---------|
-| [HackMyAgent](https://github.com/opena2a-org/hackmyagent) | `npx hackmyagent secure` | Security scanner, attack simulation, OASB, ARP, AGS |
+| [HackMyAgent](https://github.com/opena2a-org/hackmyagent) | `npx hackmyagent secure` | Security scanner, attack simulation, OASB, ARP, ABGS |
 | [Secretless AI](https://github.com/opena2a-org/secretless-ai) | `npx secretless-ai init` | Credential management for AI coding tools |
 | [AIM](https://github.com/opena2a-org/agent-identity-management) | `pip install aim-sdk` | Agent identity, keypairs, capability policies |
 | [DVAA](https://github.com/opena2a-org/damn-vulnerable-ai-agent) | `docker pull opena2a/dvaa` | Deliberately vulnerable AI agent for training |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -441,7 +441,7 @@ The CLI orchestrates these specialized tools through a unified interface:
 | Command | Tool | Description |
 |---------|------|-------------|
 | `opena2a scan` | [HackMyAgent](https://github.com/opena2a-org/hackmyagent) | 150+ security checks, attack simulation, auto-fix |
-| `opena2a scan-soul` | [HackMyAgent](https://github.com/opena2a-org/hackmyagent) | Behavioral governance scan against AGS (SOUL.md) |
+| `opena2a scan-soul` | [HackMyAgent](https://github.com/opena2a-org/hackmyagent) | Behavioral governance scan against ABGS (SOUL.md) |
 | `opena2a harden-soul` | [HackMyAgent](https://github.com/opena2a-org/hackmyagent) | Generate or improve SOUL.md governance file |
 | `opena2a secrets` | [Secretless AI](https://github.com/opena2a-org/secretless-ai) | Credential management for AI coding tools |
 | `opena2a benchmark` | [OASB](https://github.com/opena2a-org/oasb) | 222 attack scenarios, compliance scoring |
@@ -456,11 +456,11 @@ Adapters install tools on first use. Each tool works standalone or through the C
 
 ## Behavioral Governance
 
-The [Agent Governance Specification (AGS)](https://github.com/opena2a-org/agent-governance-spec) defines a tiered behavioral safety framework for AI agents across 8 domains and 68 controls (OASB v2). OpenA2A CLI integrates AGS scanning through HackMyAgent.
+The [Agent Behavioral Governance Specification (ABGS)](https://github.com/opena2a-org/agent-governance-spec) defines a tiered behavioral safety framework for AI agents across 8 domains and 68 controls (OASB v2). OpenA2A CLI integrates ABGS scanning through HackMyAgent.
 
 ### `opena2a scan-soul`
 
-Scan your governance file (SOUL.md or equivalent) against AGS controls for your agent's capability tier. Auto-detects tier from file content.
+Scan your governance file (SOUL.md or equivalent) against ABGS controls for your agent's capability tier. Auto-detects tier from file content.
 
 ```bash
 opena2a scan-soul                          # Scan SOUL.md in current directory
@@ -501,7 +501,7 @@ opena2a harden-soul --dry-run      # Preview what would be added, no writes
 opena2a harden-soul --json         # Machine-readable output
 ```
 
-The 8 AGS behavioral domains (OASB v2, domains 7–14):
+The 8 ABGS behavioral domains (OASB v2, domains 7-14):
 
 | Domain | What it governs |
 |--------|----------------|

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -340,7 +340,7 @@ Learn more: https://opena2a.org/docs`);
   // Scan-soul command (governance scanner, uses hackmyagent SoulScanner API)
   program
     .command('scan-soul [directory]')
-    .description('Scan governance file for behavioral safety coverage (AGS)')
+    .description('Scan governance file for behavioral safety coverage (ABGS)')
     .option('--dir <path>', 'Target directory')
     .option('--profile <name>', 'Agent profile (conversational|code-assistant|tool-agent|autonomous|orchestrator)')
     .option('--tier <level>', 'Force tier (BASIC|STANDARD|AGENTIC)')
@@ -363,7 +363,7 @@ Learn more: https://opena2a.org/docs`);
   // Harden-soul command (governance generator, uses hackmyagent SoulScanner API)
   program
     .command('harden-soul [directory]')
-    .description('Generate or improve governance file with AGS templates')
+    .description('Generate or improve governance file with ABGS templates')
     .option('--dir <path>', 'Target directory')
     .option('--profile <name>', 'Agent profile (conversational|code-assistant|tool-agent|autonomous|orchestrator)')
     .option('--tier <level>', 'Force tier (BASIC|STANDARD|AGENTIC)')


### PR DESCRIPTION
## Summary
- Rename Agent Governance Specification (AGS) to Agent Behavioral Governance Specification (ABGS) in scan-soul/harden-soul command descriptions and README

## Test plan
- [x] Build passes
- [x] Tests pass