### PR TITLE
Polish trust/claim UX from fresh-user testing

### DIFF
--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -232,6 +232,16 @@ export async function claim(options: ClaimOptions): Promise<number> {
 
   // Resolve package name
   let packageName = options.packageName;
+
+  // Auto-detect GitHub URLs
+  if (packageName && packageName.startsWith('https://github.com/')) {
+    const match = packageName.match(/github\.com\/([^/]+\/[^/]+)/);
+    if (match) {
+      packageName = match[1].replace(/\.git$/, '');
+      if (!options.source) options.source = 'github';
+    }
+  }
+
   if (!packageName) {
     packageName = _internals.readLocalPackageName() ?? undefined;
     if (!packageName) {
@@ -269,6 +279,12 @@ export async function claim(options: ClaimOptions): Promise<number> {
         process.stdout.write(JSON.stringify({ error: 'not_found', package: packageName, message: msg }) + '\n');
       } else {
         process.stdout.write(yellow(msg) + '\n');
+        if (options.verbose) {
+          const params = new URLSearchParams({ package: packageName });
+          if (options.source) params.set('source', options.source);
+          process.stdout.write(dim(`Registry: ${registryUrl}`) + '\n');
+          process.stdout.write(dim(`Request: GET /v1/trust/lookup?${params}`) + '\n');
+        }
       }
       return 1;
     }
@@ -280,6 +296,10 @@ export async function claim(options: ClaimOptions): Promise<number> {
       process.stdout.write(JSON.stringify({ error: 'lookup_failed', message: errMsg }) + '\n');
     } else {
       process.stderr.write(red(`Failed to look up trust profile: ${errMsg}`) + '\n');
+      if (options.verbose) {
+        process.stderr.write(dim(`Registry: ${registryUrl}`) + '\n');
+        process.stderr.write(dim(`Full error: ${err instanceof Error ? err.stack ?? err.message : String(err)}`) + '\n');
+      }
     }
     return 1;
   }
@@ -445,6 +465,9 @@ export async function claim(options: ClaimOptions): Promise<number> {
     } else {
       process.stderr.write(red(`Failed to submit claim: ${errMsg}`) + '\n');
       process.stderr.write(dim(`Registry: ${registryUrl}`) + '\n');
+      if (options.verbose) {
+        process.stderr.write(dim(`Full error: ${err instanceof Error ? err.stack ?? err.message : String(err)}`) + '\n');
+      }
     }
     return 1;
   }

--- a/packages/cli/src/commands/trust.ts
+++ b/packages/cli/src/commands/trust.ts
@@ -92,6 +92,15 @@ export async function trust(options: TrustOptions): Promise<number> {
   // Resolve package name
   let packageName = options.packageName;
 
+  // Auto-detect GitHub URLs
+  if (packageName && packageName.startsWith('https://github.com/')) {
+    const match = packageName.match(/github\.com\/([^/]+\/[^/]+)/);
+    if (match) {
+      packageName = match[1].replace(/\.git$/, '');
+      if (!options.source) options.source = 'github';
+    }
+  }
+
   // Handle empty/whitespace-only input
   if (packageName !== undefined && packageName.trim() === '') {
     packageName = undefined;
@@ -137,6 +146,12 @@ export async function trust(options: TrustOptions): Promise<number> {
         process.stdout.write(yellow(notFoundMsg) + '\n');
         process.stdout.write(dim(registerHint) + '\n');
         process.stdout.write(dim('Learn more: https://opena2a.org/docs/cli/trust') + '\n');
+        if (options.verbose) {
+          const params = new URLSearchParams({ package: packageName });
+          if (options.source) params.set('source', options.source);
+          process.stdout.write(dim(`Registry: ${registryUrl}`) + '\n');
+          process.stdout.write(dim(`Request: GET /v1/trust/lookup?${params}`) + '\n');
+        }
       }
       return 1;
     }
@@ -160,6 +175,9 @@ export async function trust(options: TrustOptions): Promise<number> {
       process.stderr.write(red(`Failed to query trust profile: ${errMsg}`) + '\n');
       process.stderr.write(dim(`Registry: ${registryUrl}`) + '\n');
       process.stderr.write(dim('Check your registry URL in ~/.opena2a/config.json or use --registry-url <url>') + '\n');
+      if (options.verbose) {
+        process.stderr.write(dim(`Full error: ${err instanceof Error ? err.stack ?? err.message : String(err)}`) + '\n');
+      }
     }
     return 1;
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -449,9 +449,16 @@ Learn more: https://opena2a.org/docs`);
   program
     .command('trust [package]')
     .description('Look up the trust profile for an AI agent or MCP server')
-    .option('--source <source>', 'Package source: npm, pypi, github')
+    .option('--source <source>', 'Package source (npm, pypi, github)')
     .option('--registry-url <url>', 'Registry URL')
     .option('--json', 'Output as JSON (alias for --format json)')
+    .addHelpText('after', `
+Examples:
+  $ opena2a trust express                    Look up npm package
+  $ opena2a trust langchain --source pypi    Look up PyPI package
+  $ opena2a trust                            Auto-detect from package.json
+  $ opena2a trust express --json             JSON output
+  $ opena2a trust https://github.com/org/repo   GitHub URL (auto-detected)`)
     .action(async (packageArg: string | undefined, opts) => {
       const { trust: runTrust } = await import('./commands/trust.js');
       const globalOpts = program.opts();
@@ -471,9 +478,15 @@ Learn more: https://opena2a.org/docs`);
   program
     .command('claim [package]')
     .description('Claim ownership of a discovered agent in the trust registry')
-    .option('--source <source>', 'Package source: npm, pypi, github')
+    .option('--source <source>', 'Package source (npm, pypi, github)')
     .option('--registry-url <url>', 'Registry URL')
     .option('--json', 'Output as JSON (alias for --format json)')
+    .addHelpText('after', `
+Examples:
+  $ opena2a claim my-agent                   Claim via npm ownership
+  $ opena2a claim my-agent --source github   Claim via GitHub ownership
+  $ opena2a claim                            Auto-detect from package.json
+  $ opena2a claim https://github.com/org/repo   GitHub URL (auto-detected)`)
     .action(async (packageArg: string | undefined, opts) => {
       const { claim: runClaim } = await import('./commands/claim.js');
       const globalOpts = program.opts();


### PR DESCRIPTION
## Summary
- Add `--verbose` output on error paths in both `trust` and `claim` commands (shows registry URL, request path, full error stack)
- Add help text examples for `trust` and `claim` commands via `.addHelpText('after', ...)`
- Auto-parse GitHub URLs (`https://github.com/org/repo`) into `org/repo` with `--source github` auto-detection
- Improve `--source` option description from colon-separated to parenthesized format

## Test plan
- [x] `npm run build` compiles cleanly
- [x] `npm test` -- all 728 tests pass
- [ ] Manual: `opena2a trust --help` shows examples section
- [ ] Manual: `opena2a claim --help` shows examples section
- [ ] Manual: `opena2a trust https://github.com/anthropics/mcp --verbose` auto-detects GitHub source