### PR TITLE
Clarify init vs shield init for first-time users

### DIFF
--- a/packages/cli/__tests__/natural/intent-map.test.ts
+++ b/packages/cli/__tests__/natural/intent-map.test.ts
@@ -37,8 +37,8 @@ describe('intent map', () => {
   });
 
   it('matches setup intents', () => {
-    expect(matchIntent('get started')?.command).toBe('opena2a init');
-    expect(matchIntent('how do I start')?.command).toBe('opena2a init');
+    expect(matchIntent('get started')?.command).toBe('opena2a shield init');
+    expect(matchIntent('how do I start')?.command).toBe('opena2a shield init');
   });
 
   it('returns null for unrecognized input', () => {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -320,6 +320,9 @@ export async function init(options: InitOptions): Promise<number> {
     process.stdout.write(dim(wrappedTipText) + '\n');
     process.stdout.write('\n');
 
+    // Shield init hint
+    process.stdout.write(dim('  To set up full Shield protection (11-step orchestration): opena2a shield init') + '\n');
+
     // Deeper analysis hint
     process.stdout.write(dim('  For deeper analysis (147 checks): opena2a scan --deep') + '\n');
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,8 +30,8 @@ async function main(): Promise<void> {
     .option('--contribute', 'Share anonymized scan results with OpenA2A community')
     .addHelpText('after', `
 Quick Start:
-  $ opena2a shield init          Unified security setup (scan, policy, hooks)
-  $ opena2a init                 Assess your project's security posture
+  $ opena2a shield init          Full 11-step security setup (scan, protect, sign, policy, hooks)
+  $ opena2a init                 Read-only security assessment (no changes to your project)
   $ opena2a protect              Detect and migrate hardcoded credentials
   $ opena2a guard sign           Sign config files for tamper detection
   $ opena2a scan secure          Run 147 security checks on your AI agent
@@ -188,7 +188,7 @@ Learn more: https://opena2a.org/docs`);
   // Init command (direct, not adapter-based)
   program
     .command('init [directory]')
-    .description('Initialize OpenA2A security in your project')
+    .description('Assess your project security posture (read-only scan; use "shield init" for full setup)')
     .option('--dir <path>', 'Target directory')
     .action(async (directory: string | undefined, opts) => {
       const { init } = await import('./commands/init.js');
@@ -289,7 +289,7 @@ Learn more: https://opena2a.org/docs`);
   // Shield command (unified security orchestration)
   program
     .command('shield <subcommand> [args...]')
-    .description('Unified security orchestration (init|status|log|selfcheck|policy|evaluate|recover|report|session|baseline|suggest|explain|triage)')
+    .description('Unified security orchestration ("shield init" runs full 11-step setup; also:|status|log|selfcheck|policy|evaluate|recover|report|session|baseline|suggest|explain|triage)')
     .allowUnknownOption(true)
     .option('--dir <path>', 'Target directory')
     .option('--agent <name>', 'Agent name filter')
@@ -714,7 +714,7 @@ Valid actions:
 
 function getIntentDescription(intent: string): string {
   switch (intent) {
-    case 'init': return 'Initialize OpenA2A security in your project';
+    case 'init': return 'Assess your project security posture (read-only scan)';
     case 'check': return 'Quick security check (alias for scan secure)';
     case 'protect': return 'Detect and migrate credentials to encrypted vault';
     case 'status': return 'Show security status of current project';

--- a/packages/cli/src/natural/intent-map.ts
+++ b/packages/cli/src/natural/intent-map.ts
@@ -152,8 +152,8 @@ const INTENT_MAPPINGS: IntentMapping[] = [
       /\bhow\s+do\s+i\s+(start|begin|use)\b/i,
       /\bquick\s*start\b/i,
     ],
-    command: 'opena2a init',
-    description: 'Initialize OpenA2A security in your project',
+    command: 'opena2a shield init',
+    description: 'Full security setup: scan, protect, sign, policy, hooks (11 steps)',
   },
 ];
 

--- a/packages/cli/src/semantic/command-index.json
+++ b/packages/cli/src/semantic/command-index.json
@@ -137,11 +137,20 @@
   {
     "id": "init",
     "path": "opena2a init",
-    "description": "Initialize OpenA2A security in a project -- scan for credentials, detect scope drift, check hygiene, calculate trust score",
-    "tags": ["init", "setup", "initialize", "onboard", "start", "drift", "trust-score"],
-    "synonyms": ["setup", "start", "onboard", "configure", "assess"],
+    "description": "Read-only security assessment -- scan for credentials, detect scope drift, check hygiene, calculate trust score (no changes made)",
+    "tags": ["init", "assess", "scan", "drift", "trust-score", "posture"],
+    "synonyms": ["assess", "audit", "evaluate", "check posture"],
     "domains": ["project", "config", "credentials"],
-    "examples": ["set up security", "initialize project", "get started", "check my project"]
+    "examples": ["assess my project", "check security posture", "security audit", "scan project"]
+  },
+  {
+    "id": "shield-init",
+    "path": "opena2a shield init",
+    "description": "Full 11-step security setup -- scan, protect credentials, sign configs, generate policy, install git hooks",
+    "tags": ["shield", "init", "setup", "initialize", "onboard", "start", "full-setup"],
+    "synonyms": ["setup", "start", "onboard", "configure", "initialize", "get started"],
+    "domains": ["project", "config", "credentials", "policy", "hooks"],
+    "examples": ["set up security", "initialize project", "get started", "full security setup", "install shield"]
   },
   {
     "id": "status",


### PR DESCRIPTION
## Summary
- `init` command description now says "read-only scan" with pointer to `shield init` for full setup
- Quick Start in `--help` output labels `shield init` as "Full 11-step security setup" and `init` as "Read-only security assessment"
- Natural language intent "get started" / "how do I start" now routes to `shield init` instead of `init`
- `init` output now ends with a hint: "To set up full Shield protection (11-step orchestration): opena2a shield init"
- Added `shield-init` entry to semantic command index so `~setup` and `~initialize` searches find it
- Shield command description mentions "shield init runs full 11-step setup"

## Test plan
- [x] All 728 CLI tests pass (46 test files)
- [x] Updated intent-map test expectations to match new `shield init` routing
- [x] Build passes cleanly (tsc + turbo)