### PR TITLE
Add .mcp/ detection and replace punitive grades

### DIFF
--- a/packages/aim-core/src/trust.ts
+++ b/packages/aim-core/src/trust.ts
@@ -63,7 +63,7 @@ export function calculateTrust(
   overall = Math.round(Math.min(overall, 1.0) * 100) / 100;
 
   const score = Math.round(overall * 100);
-  const grade = score >= 80 ? 'A' : score >= 60 ? 'B' : score >= 40 ? 'C' : score >= 20 ? 'D' : 'F';
+  const grade = score >= 80 ? 'strong' : score >= 60 ? 'good' : score >= 40 ? 'moderate' : score >= 20 ? 'improving' : 'needs-attention';
 
   return {
     overall,

--- a/packages/aim-core/src/types.ts
+++ b/packages/aim-core/src/types.ts
@@ -79,7 +79,7 @@ export interface TrustScore {
   overall: number;
   /** Trust score as integer (0-100) */
   score: number;
-  /** Letter grade: A (80-100), B (60-79), C (40-59), D (20-39), F (0-19) */
+  /** Descriptive grade: strong (80-100), good (60-79), moderate (40-59), improving (20-39), needs-attention (0-19) */
   grade: string;
   /** Individual factor scores */
   factors: TrustFactors;

--- a/packages/cli/__tests__/commands/init.test.ts
+++ b/packages/cli/__tests__/commands/init.test.ts
@@ -50,7 +50,7 @@ describe('init', () => {
     // Unified score: clean project scores well but environmental factors
     // (running LLM servers, HMA shell findings) may lower it on real machines
     expect(report.securityScore).toBeGreaterThanOrEqual(70);
-    expect(['A', 'B', 'C']).toContain(report.securityGrade);
+    expect(['strong', 'good', 'moderate']).toContain(report.securityGrade);
     // Backward compat aliases
     expect(report.trustScore).toBe(report.securityScore);
     expect(report.grade).toBe(report.securityGrade);
@@ -172,7 +172,7 @@ describe('init', () => {
     }));
 
     const report = JSON.parse(output);
-    expect(report.securityGrade).toMatch(/^[A-F]$/);
+    expect(['strong', 'good', 'moderate', 'improving', 'needs-attention']).toContain(report.securityGrade);
     expect(report.securityScore).toBeGreaterThanOrEqual(0);
     expect(report.securityScore).toBeLessThanOrEqual(100);
   });

--- a/packages/cli/__tests__/commands/review.test.ts
+++ b/packages/cli/__tests__/commands/review.test.ts
@@ -51,7 +51,7 @@ describe('review', () => {
     // Score depends on Shield product detection and guard signing status.
     // A clean project without Shield products or signatures scores ~65-75.
     expect(report.compositeScore).toBeGreaterThanOrEqual(60);
-    expect(report.grade).toMatch(/^[A-D]$/);
+    expect(['strong', 'good', 'moderate', 'improving']).toContain(report.grade);
     expect(report.phases).toHaveLength(5);
   });
 

--- a/packages/cli/__tests__/commands/security-score.test.ts
+++ b/packages/cli/__tests__/commands/security-score.test.ts
@@ -13,7 +13,7 @@ describe('calculateSecurityScore', () => {
   it('returns 100 + bonus for clean project with security config', () => {
     const { score, grade } = calculateSecurityScore({}, cleanChecks);
     expect(score).toBe(100);
-    expect(grade).toBe('A');
+    expect(grade).toBe('strong');
   });
 
   it('applies diminishing returns for critical findings', () => {
@@ -61,10 +61,10 @@ describe('calculateSecurityScore', () => {
   });
 
   it('assigns correct grades', () => {
-    expect(calculateSecurityScore({}, cleanChecks).grade).toBe('A');
-    expect(calculateSecurityScore({ critical: 1 }, cleanChecks).grade).toBe('B');
-    expect(calculateSecurityScore({ critical: 2 }, cleanChecks).grade).toBe('C');
-    expect(calculateSecurityScore({ critical: 3, high: 2 }, cleanChecks).grade).toBe('F');
+    expect(calculateSecurityScore({}, cleanChecks).grade).toBe('strong');
+    expect(calculateSecurityScore({ critical: 1 }, cleanChecks).grade).toBe('good');
+    expect(calculateSecurityScore({ critical: 2 }, cleanChecks).grade).toBe('moderate');
+    expect(calculateSecurityScore({ critical: 3, high: 2 }, cleanChecks).grade).toBe('needs-attention');
   });
 
   it('includes HMA findings in environment deduction', () => {

--- a/packages/cli/__tests__/report/interactive-html.test.ts
+++ b/packages/cli/__tests__/report/interactive-html.test.ts
@@ -13,7 +13,7 @@ function sampleData(overrides?: Partial<InteractiveReportData>): InteractiveRepo
       totalFindings: 3,
       bySeverity: { critical: 1, high: 1, medium: 1, low: 0, info: 0 },
       score: 52,
-      grade: 'C',
+      grade: 'moderate',
     },
     findings: [
       {
@@ -155,7 +155,7 @@ describe('generateInteractiveHtml', () => {
 
   it('handles empty findings', () => {
     const html = generateInteractiveHtml(sampleData({
-      summary: { totalFindings: 0, bySeverity: {}, score: 100, grade: 'A' },
+      summary: { totalFindings: 0, bySeverity: {}, score: 100, grade: 'strong' },
       findings: [],
     }));
     expect(html).toContain('<!DOCTYPE html>');

--- a/packages/cli/__tests__/shield/report-html.test.ts
+++ b/packages/cli/__tests__/shield/report-html.test.ts
@@ -91,7 +91,7 @@ function sampleReport(overrides?: Partial<WeeklyReport>): WeeklyReport {
 
     posture: {
       score: 77,
-      grade: 'C',
+      grade: 'moderate',
       factors: [
         { name: 'severity', score: 77, weight: 0.4, detail: '0 critical, 1 high' },
         { name: 'enforcement', score: 80, weight: 0.3, detail: '3 blocked' },
@@ -192,7 +192,7 @@ describe('generateShieldHtmlReport', () => {
   it('contains the posture grade in embedded data', () => {
     const html = generateShieldHtmlReport(sampleReport());
     const parsed = parseEmbeddedData(html);
-    expect(parsed.report.posture.grade).toBe('C');
+    expect(parsed.report.posture.grade).toBe('moderate');
   });
 
   it('embeds report data as JSON', () => {
@@ -285,7 +285,7 @@ describe('generateShieldHtmlReport', () => {
       },
       posture: {
         score: 100,
-        grade: 'A',
+        grade: 'strong',
         factors: [],
         trend: null,
         comparative: null,
@@ -360,7 +360,7 @@ describe('generateShieldHtmlReport', () => {
     const html = generateShieldHtmlReport(sampleReport({
       posture: {
         score: 95,
-        grade: 'A',
+        grade: 'strong',
         factors: [],
         trend: 'stable',
         comparative: null,
@@ -368,14 +368,14 @@ describe('generateShieldHtmlReport', () => {
     }));
     const parsed = parseEmbeddedData(html);
     expect(parsed.report.posture.score).toBe(95);
-    expect(parsed.report.posture.grade).toBe('A');
+    expect(parsed.report.posture.grade).toBe('strong');
   });
 
   it('handles low score (<50) report', () => {
     const html = generateShieldHtmlReport(sampleReport({
       posture: {
         score: 25,
-        grade: 'F',
+        grade: 'needs-attention',
         factors: [],
         trend: 'declining',
         comparative: null,
@@ -383,6 +383,6 @@ describe('generateShieldHtmlReport', () => {
     }));
     const parsed = parseEmbeddedData(html);
     expect(parsed.report.posture.score).toBe(25);
-    expect(parsed.report.posture.grade).toBe('F');
+    expect(parsed.report.posture.grade).toBe('needs-attention');
   });
 });

--- a/packages/cli/__tests__/util/scoring.test.ts
+++ b/packages/cli/__tests__/util/scoring.test.ts
@@ -18,7 +18,7 @@ describe('calculateSecurityScore (shared module)', () => {
   it('returns 100 for clean project with security config', () => {
     const { score, grade } = calculateSecurityScore({}, cleanChecks);
     expect(score).toBe(100);
-    expect(grade).toBe('A');
+    expect(grade).toBe('strong');
   });
 
   it('applies diminishing returns for critical findings', () => {

--- a/packages/cli/src/commands/detect.ts
+++ b/packages/cli/src/commands/detect.ts
@@ -73,7 +73,7 @@ const MCP_CONFIG_LOCATIONS: McpConfigLocation[] = [
   { path: '.config/windsurf/mcp.json', label: '~/.config/windsurf/mcp.json' },
 ];
 
-const PROJECT_MCP_FILES = ['mcp.json', '.mcp.json'];
+const PROJECT_MCP_FILES = ['mcp.json', '.mcp.json', '.mcp/config.json'];
 
 /**
  * Scan running processes for AI agents.

--- a/packages/cli/src/commands/guard-policy.ts
+++ b/packages/cli/src/commands/guard-policy.ts
@@ -42,7 +42,7 @@ const HEARTBEAT_DISABLED_FILE = 'heartbeat-disabled';
 const SIGNATURES_FILE = 'signatures.json';
 
 const DEFAULT_CONFIG_FILES = [
-  'mcp.json', '.mcp.json', '.claude/settings.json',
+  'mcp.json', '.mcp.json', '.mcp/config.json', '.claude/settings.json',
   'package.json', 'package-lock.json',
   'arp.yaml', 'arp.yml', 'arp.json',
   'openclaw.json', '.openclaw/config.json',

--- a/packages/cli/src/commands/guard.ts
+++ b/packages/cli/src/commands/guard.ts
@@ -85,7 +85,7 @@ export interface ConfigIntegritySummary {
 // --- Default guarded files ---
 
 const GUARD_FILES = [
-  'mcp.json', '.mcp.json', '.claude/settings.json',
+  'mcp.json', '.mcp.json', '.mcp/config.json', '.claude/settings.json',
   'package.json', 'package-lock.json',
   'arp.yaml', 'arp.yml', 'arp.json',
   'openclaw.json', '.openclaw/config.json',

--- a/packages/cli/src/commands/identity.ts
+++ b/packages/cli/src/commands/identity.ts
@@ -126,7 +126,7 @@ async function handleTrust(options: IdentityOptions): Promise<number> {
     process.stdout.write(bold('Trust Score') + '\n');
     process.stdout.write(gray('-'.repeat(50)) + '\n');
     const displayScore = trust.score ?? Math.round((trust.overall ?? 0) * 100);
-    const displayGrade = trust.grade ?? (displayScore >= 80 ? 'A' : displayScore >= 60 ? 'B' : displayScore >= 40 ? 'C' : displayScore >= 20 ? 'D' : 'F');
+    const displayGrade = trust.grade ?? (displayScore >= 80 ? 'strong' : displayScore >= 60 ? 'good' : displayScore >= 40 ? 'moderate' : displayScore >= 20 ? 'improving' : 'needs-attention');
     process.stdout.write(`  Score:  ${bold(String(displayScore))}  Grade: ${bold(displayGrade)}\n`);
     process.stdout.write('\n');
     process.stdout.write('  Factors:\n');

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -801,7 +801,7 @@ function getVerificationCommand(
   }
   if (finding.findingId === 'MCP-TOOLS') {
     // Show the first MCP config file found
-    for (const f of ['mcp.json', '.mcp.json', '.claude/settings.json', '.cursor/mcp.json']) {
+    for (const f of ['mcp.json', '.mcp.json', '.mcp/config.json', '.claude/settings.json', '.cursor/mcp.json']) {
       if (fs.existsSync(path.join(reportDir, f))) {
         return `cat ${f}`;
       }
@@ -809,7 +809,7 @@ function getVerificationCommand(
     return 'cat mcp.json';
   }
   if (finding.findingId === 'MCP-CRED') {
-    for (const f of ['mcp.json', '.mcp.json', '.claude/settings.json', '.cursor/mcp.json']) {
+    for (const f of ['mcp.json', '.mcp.json', '.mcp/config.json', '.claude/settings.json', '.cursor/mcp.json']) {
       if (fs.existsSync(path.join(reportDir, f))) {
         return `cat ${f}`;
       }

--- a/packages/cli/src/commands/mcp-audit.ts
+++ b/packages/cli/src/commands/mcp-audit.ts
@@ -71,6 +71,7 @@ function getConfigSources(targetDir: string): ConfigSource[] {
     { filePath: path.join(home, '.config', 'windsurf', 'mcp.json'), label: 'Windsurf' },
     { filePath: path.join(targetDir, 'mcp.json'), label: 'project-local' },
     { filePath: path.join(targetDir, '.mcp.json'), label: 'project-local' },
+    { filePath: path.join(targetDir, '.mcp', 'config.json'), label: 'project-local (.mcp/)' },
   ];
 }
 

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -573,11 +573,11 @@ function computeCompositeScore(
 
 function scoreToGrade(score: number): string {
   // Kept for JSON backward compatibility; not displayed in CLI or HTML output
-  if (score >= 90) return 'A';
-  if (score >= 80) return 'B';
-  if (score >= 70) return 'C';
-  if (score >= 60) return 'D';
-  return 'F';
+  if (score >= 90) return 'strong';
+  if (score >= 80) return 'good';
+  if (score >= 70) return 'moderate';
+  if (score >= 60) return 'improving';
+  return 'needs-attention';
 }
 
 function computeRecoverySummary(
@@ -858,11 +858,11 @@ function calculateTrustScore(
   score = Math.max(0, Math.min(100, score));
 
   let grade: string;
-  if (score >= 90) grade = 'A';
-  else if (score >= 80) grade = 'B';
-  else if (score >= 70) grade = 'C';
-  else if (score >= 60) grade = 'D';
-  else grade = 'F';
+  if (score >= 90) grade = 'strong';
+  else if (score >= 80) grade = 'good';
+  else if (score >= 70) grade = 'moderate';
+  else if (score >= 60) grade = 'improving';
+  else grade = 'needs-attention';
 
   return { score, grade };
 }

--- a/packages/cli/src/commands/shield.ts
+++ b/packages/cli/src/commands/shield.ts
@@ -822,7 +822,7 @@ async function buildWeeklyReport(
 
   let score = Math.round(severityScore * 0.5 + enforcementScore * 0.25 + coverageScore * 0.25);
   score = Math.max(0, Math.min(100, score));
-  const grade = score >= 90 ? 'A' : score >= 80 ? 'B' : score >= 70 ? 'C' : score >= 60 ? 'D' : 'F';
+  const grade = score >= 90 ? 'strong' : score >= 80 ? 'good' : score >= 70 ? 'moderate' : score >= 60 ? 'improving' : 'needs-attention';
 
   const report: import('../shield/types.js').WeeklyReport = {
     version: 1,

--- a/packages/cli/src/shield/detect.ts
+++ b/packages/cli/src/shield/detect.ts
@@ -264,6 +264,7 @@ function mcpConfigPaths(targetDir: string): { label: string; path: string }[] {
   return [
     { label: 'mcp.json', path: join(targetDir, 'mcp.json') },
     { label: '.mcp.json', path: join(targetDir, '.mcp.json') },
+    { label: '.mcp/config.json', path: join(targetDir, '.mcp', 'config.json') },
     { label: '.claude/settings.json', path: join(targetDir, '.claude', 'settings.json') },
     { label: '.cursor/mcp.json', path: join(targetDir, '.cursor', 'mcp.json') },
     { label: '~/.claude/settings.json', path: join(homedir(), '.claude', 'settings.json') },

--- a/packages/cli/src/util/ai-config.ts
+++ b/packages/cli/src/util/ai-config.ts
@@ -21,7 +21,7 @@ export interface AiConfigFinding {
 
 // --- Constants ---
 
-export const MCP_CONFIG_FILES = ['mcp.json', '.mcp.json', '.claude/settings.json', '.cursor/mcp.json'];
+export const MCP_CONFIG_FILES = ['mcp.json', '.mcp.json', '.mcp/config.json', '.claude/settings.json', '.cursor/mcp.json'];
 
 const HIGH_RISK_SERVER_PATTERNS = [
   'filesystem', 'shell', 'bash', 'database', 'exec',

--- a/packages/cli/src/util/detect.ts
+++ b/packages/cli/src/util/detect.ts
@@ -90,7 +90,8 @@ export function detectProject(dir: string): ProjectInfo {
   // Check for MCP configuration
   info.hasMcp =
     existsSync(resolve(dir, 'mcp.json')) ||
-    existsSync(resolve(dir, '.mcp.json'));
+    existsSync(resolve(dir, '.mcp.json')) ||
+    existsSync(resolve(dir, '.mcp', 'config.json'));
 
   if (info.hasMcp) {
     info.frameworkHints.push('MCP server');

--- a/packages/cli/src/util/report-submission.ts
+++ b/packages/cli/src/util/report-submission.ts
@@ -70,7 +70,7 @@ export function normalizeGovernanceReport(raw: Record<string, unknown>): ScanRep
   if (!raw.domains || !raw.grade) return null;
 
   const score = (raw.score as number) ?? 0;
-  const grade = (raw.grade as string) ?? 'F';
+  const grade = (raw.grade as string) ?? 'needs-attention';
   const domains = raw.domains as Array<{
     domain: string;
     controls: Array<{ id: string; name: string; passed: boolean }>;

--- a/packages/cli/src/util/scoring.ts
+++ b/packages/cli/src/util/scoring.ts
@@ -115,11 +115,11 @@ export function calculateSecurityScore(
   const score = Math.max(0, Math.min(100, 100 - credDeduction - envDeduction - configDeduction + configBonus));
 
   let grade: string;
-  if (score >= 90) grade = 'A';
-  else if (score >= 80) grade = 'B';
-  else if (score >= 70) grade = 'C';
-  else if (score >= 60) grade = 'D';
-  else grade = 'F';
+  if (score >= 90) grade = 'strong';
+  else if (score >= 80) grade = 'good';
+  else if (score >= 70) grade = 'moderate';
+  else if (score >= 60) grade = 'improving';
+  else grade = 'needs-attention';
 
   return {
     score,


### PR DESCRIPTION
## Summary

- Add `.mcp/config.json` to MCP config detection across 8 source files so Claude Code's `.mcp/` directory config is discovered during shield init, mcp-audit, detect, and guard scans
- Replace letter grades (A/B/C/D/F) with descriptive labels (strong/good/moderate/improving/needs-attention) across all scoring paths to align with the project's UX policy of empowering users without shaming

## Test plan

- [x] Build passes (`npx turbo build --force`)
- [x] All 728 tests pass across 46 test files (`npx turbo test --force`)
- [x] Pre-push checks passed (sensitive file scan, build, test, lint)
- [ ] Verify `.mcp/config.json` is detected by running `opena2a init` in a project with `.mcp/config.json`
- [ ] Verify events.jsonl no longer contains "F" or "D" grades after a fresh scan