### PR TITLE
chore: bump ai-trust to ^0.2.6

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
     "@inquirer/prompts": "^7.0.0",
     "@opena2a/contribute": "0.1.0",
     "@opena2a/shared": "0.1.0",
-    "ai-trust": "^0.1.1",
+    "ai-trust": "^0.2.6",
     "commander": "^13.1.0",
     "hackmyagent": "^0.9.8",
     "secretless-ai": "^0.11.4"


### PR DESCRIPTION
## Summary
Bump ai-trust from ^0.1.1 to ^0.2.6 in opena2a-cli for accuracy improvements.

## Test plan
- [x] Dependency version bump only