### PR TITLE
Add global --deep and --static-only flags with adapter passthrough

### DIFF
--- a/packages/cli/src/adapters/types.ts
+++ b/packages/cli/src/adapters/types.ts
@@ -27,6 +27,8 @@ export interface RunOptions {
   format?: 'text' | 'json' | 'sarif';
   contribute?: boolean;
   cwd?: string;
+  deep?: boolean;
+  staticOnly?: boolean;
 }
 
 export interface RunResult {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,6 +28,8 @@ async function main(): Promise<void> {
     .option('--verbose', 'Verbose output')
     .option('--format <type>', 'Output format: text, json, sarif', 'text')
     .option('--contribute', 'Share anonymized scan results with OpenA2A community')
+    .option('--deep', 'Enable NanoMind semantic analysis')
+    .option('--static-only', 'Static checks only (fast, no NanoMind)')
     .addHelpText('beforeAll', `
 Quick start:
   $ opena2a init                    Security assessment (30 seconds)
@@ -91,6 +93,8 @@ Learn more: https://opena2a.org/docs`);
             ci: globalOpts.ci,
             format: globalOpts.format,
             contribute: globalOpts.contribute,
+            deep: globalOpts.deep,
+            staticOnly: globalOpts.staticOnly,
           });
           process.exitCode = exitCode;
           return;
@@ -114,6 +118,8 @@ Learn more: https://opena2a.org/docs`);
           ci: globalOpts.ci,
           format: globalOpts.format,
           contribute: globalOpts.contribute,
+          deep: globalOpts.deep,
+          staticOnly: globalOpts.staticOnly,
         });
         process.exitCode = exitCode;
       });
@@ -164,6 +170,8 @@ Learn more: https://opena2a.org/docs`);
           ci: globalOpts.ci,
           format: globalOpts.format,
           contribute: globalOpts.contribute,
+          deep: globalOpts.deep,
+          staticOnly: globalOpts.staticOnly,
         });
         process.exitCode = exitCode;
       });
@@ -200,6 +208,8 @@ Learn more: https://opena2a.org/docs`);
           ci: globalOpts.ci,
           format: globalOpts.format,
           contribute: globalOpts.contribute,
+          deep: globalOpts.deep,
+          staticOnly: globalOpts.staticOnly,
         });
         process.exitCode = exitCode;
       });

--- a/packages/cli/src/router.ts
+++ b/packages/cli/src/router.ts
@@ -167,6 +167,7 @@ export async function dispatchCommand(
       format: (globalOptions.format as string) ?? 'text',
       verbose: globalOptions.verbose ?? false,
       strict: args.includes('--strict'),
+      deep: globalOptions.deep ?? false,
     });
   }
 
@@ -315,6 +316,14 @@ export async function dispatchCommand(
     const installHint = getInstallHint(adapter.config);
     process.stderr.write(`Install: ${installHint}\n`);
     return 1;
+  }
+
+  // Inject --deep / --static-only flags into adapter args so downstream tools receive them
+  if (globalOptions.deep && !adapterArgs.includes('--deep')) {
+    adapterArgs.push('--deep');
+  }
+  if (globalOptions.staticOnly && !adapterArgs.includes('--static-only')) {
+    adapterArgs.push('--static-only');
   }
 
   const result = await adapter.run({


### PR DESCRIPTION
## Summary
- Added `deep` and `staticOnly` to RunOptions interface
- Registered global `--deep` and `--static-only` Commander options
- All adapter commands now forward these flags to HMA/ai-trust
- Direct commands (scan-soul) also receive the deep flag

## Test plan
- [x] 874 tests pass
- [x] Build clean
- [x] Pre-push safety check passes