### PR TITLE
Fix stale registry URL, trust output bugs, and HMA delegation env vars

### DIFF
--- a/packages/cli/__tests__/commands/trust.test.ts
+++ b/packages/cli/__tests__/commands/trust.test.ts
@@ -42,7 +42,10 @@ function makeTrustResponse(overrides?: Partial<TrustLookupResponse>): TrustLooku
       maintainerCount: 3,
     },
     lastScanned: '2026-03-10T00:00:00Z',
-    profileUrl: 'https://registry.opena2a.org/agents/test-agent-uuid',
+    // Default uses a placeholder domain so tests exercise the normal render
+    // path. Tests covering the dead-host suppression override this with a
+    // known-dead host (registry.opena2a.org) explicitly.
+    profileUrl: 'https://test-registry.example.com/agents/test-agent-uuid',
     ...overrides,
   };
 }
@@ -234,6 +237,31 @@ describe('trust', () => {
     expect(output).toContain('web:read');
     expect(output).toContain('Profile:');
     expect(output).toContain('Badge:');
+  });
+
+  it('suppresses Profile/Badge lines for known-dead registry hosts', async () => {
+    vi.spyOn(_internals, 'fetchTrustLookup').mockResolvedValue({
+      ok: true,
+      status: 200,
+      // Registry backend still returns this dead hostname in some responses —
+      // the CLI should hide the link entirely and show a placeholder instead.
+      data: makeTrustResponse({
+        profileUrl: 'https://registry.opena2a.org/agents/test-agent-uuid',
+      }),
+    });
+
+    const options: TrustOptions = {
+      packageName: '@anthropic/mcp-server-fetch',
+      registryUrl: 'https://test-registry.example.com',
+      ci: true,
+      format: 'text',
+    };
+
+    const { output } = await captureStdout(() => trust(options));
+
+    expect(output).not.toContain('https://registry.opena2a.org');
+    expect(output).not.toContain('Badge:');
+    expect(output).toContain('Registry launches soon');
   });
 
   it('falls back to formatted packageType when displayType is absent', async () => {

--- a/packages/cli/src/commands/trust.ts
+++ b/packages/cli/src/commands/trust.ts
@@ -254,6 +254,7 @@ export async function trust(options: TrustOptions): Promise<number> {
       process.stdout.write(JSON.stringify(output, null, 2) + '\n');
     } else {
       printTrustProfile(result.data, options.verbose ?? false, requestUrl, elapsed);
+      printTrustNextSteps(packageName);
     }
 
     return 0;
@@ -321,7 +322,7 @@ function printTrustProfile(data: TrustLookupResponse, verbose: boolean, requestU
       : scan.status === 'warnings' ? yellow
       : red;
     process.stdout.write(`  Scan Status:  ${statusColor(scan.status)}\n`);
-    process.stdout.write(`  Findings:     ${scan.findingsCount} (${scan.highCount} high)\n`);
+    process.stdout.write(`  Findings:     ${scan.findingsCount ?? 0} (${scan.highCount ?? 0} high)\n`);
     if (scan.actionRequired) {
       process.stdout.write(`  Action:       ${yellow(scan.actionRequired)}\n`);
     }
@@ -392,10 +393,51 @@ function printTrustProfile(data: TrustLookupResponse, verbose: boolean, requestU
     if (data.lastScanned) process.stdout.write(`  Scanned:  ${dim(data.lastScanned)}\n`);
   }
 
-  // Links
+  // Links — the Registry website is not live yet (launches April 2026) and
+  // some responses embed legacy hostnames. Suppress the Profile/Badge lines
+  // when the host is known-dead so users don't see broken URLs, and show a
+  // dim placeholder instead.
   process.stdout.write('\n');
-  process.stdout.write(`Profile: ${cyan(data.profileUrl)}\n`);
-  process.stdout.write(`Badge:   ${dim(`${data.profileUrl.replace('/agents/', '/v1/trust/')}/badge.svg`)}\n`);
+  if (isDeadProfileHost(data.profileUrl)) {
+    process.stdout.write(dim('Profile: (Registry launches soon — opena2a.org)') + '\n');
+  } else {
+    process.stdout.write(`Profile: ${cyan(data.profileUrl)}\n`);
+    process.stdout.write(`Badge:   ${dim(`${data.profileUrl.replace('/agents/', '/v1/trust/')}/badge.svg`)}\n`);
+  }
+  process.stdout.write('\n');
+}
+
+/**
+ * Return true when a profile URL uses a hostname that is known not to resolve.
+ * The Registry backend currently returns URLs under `registry.opena2a.org` and
+ * `registry.oa2a.org`, neither of which has a live public endpoint. Until the
+ * Registry website ships, we suppress those links client-side. Known-good
+ * hosts (opena2a.org, www.opena2a.org, api.oa2a.org) are not considered dead.
+ */
+function isDeadProfileHost(url: string | undefined | null): boolean {
+  if (!url) return true;
+  const DEAD_HOSTS = [
+    'registry.opena2a.org',
+    'registry.oa2a.org',
+    'api.opena2a.org',
+  ];
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return DEAD_HOSTS.includes(host);
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Print a next-steps footer after the trust profile. Teaches users that
+ * `trust` is a registry-only lookup and that `check` / `review` are the
+ * scanning commands — a distinction that is not obvious from the verb alone.
+ */
+function printTrustNextSteps(packageName: string): void {
+  process.stdout.write(`  ${dim(`Run a local scan:      opena2a check ${packageName} --rescan`)}\n`);
+  process.stdout.write(`  ${dim('Full security review:  opena2a review')}\n`);
+  process.stdout.write(`  ${dim("Note: 'trust' returns registry data only. For a real scan, use 'check'.")}\n`);
   process.stdout.write('\n');
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,8 +15,12 @@ import { checkMinHmaVersion } from './util/hma-version.js';
 
 const VERSION = getVersion();
 
-// Tell downstream tools (hackmyagent, secretless) to use 'opena2a' in user-facing messages
-process.env.HMA_CLI_PREFIX = 'opena2a scan';
+// Tell downstream tools (hackmyagent, secretless) to use 'opena2a' in user-facing messages.
+// HMA_CLI_PREFIX is the *binary-level* prefix — HMA appends verbs to it
+// ("${prefix} rollback <dir>"), so it must be just "opena2a" here. The full
+// command strings for the `check` next-steps footer (HMA_CHECK_COMMAND,
+// HMA_FULL_SCAN_HINT) are set per-spawn in spawnHmaCheck / spawnHmaCheckFromRouter.
+process.env.HMA_CLI_PREFIX = 'opena2a';
 
 async function main(): Promise<void> {
   const program = new Command();
@@ -680,17 +684,25 @@ analysis runs and results can be shared with the community.
   // Trust command (ATP trust lookup)
   program
     .command('trust [package]')
-    .description('Look up the trust profile for an AI agent or MCP server')
+    .description('Look up the registry trust profile for a package (read-only)')
     .option('--source <source>', 'Package source (npm, pypi, github)')
     .option('--registry-url <url>', 'Registry URL')
     .option('--json', 'Output as JSON (alias for --format json)')
     .addHelpText('after', `
+'trust' is a read-only registry lookup. For a real local scan of the package,
+use 'opena2a check <package>'. For a full project-level security review with
+a composite score and HTML report, use 'opena2a review'.
+
 Examples:
   $ opena2a trust express                    Look up npm package
   $ opena2a trust langchain --source pypi    Look up PyPI package
   $ opena2a trust                            Auto-detect from package.json
   $ opena2a trust express --json             JSON output
-  $ opena2a trust https://github.com/org/repo   GitHub URL (auto-detected)`)
+  $ opena2a trust https://github.com/org/repo   GitHub URL (auto-detected)
+
+See also:
+  $ opena2a check <package>                  Full local security scan (via hackmyagent)
+  $ opena2a review                           Full project security review`)
     .action(async (packageArg: string | undefined, opts) => {
       const { trust: runTrust } = await import('./commands/trust.js');
       const globalOpts = program.opts();
@@ -1144,13 +1156,18 @@ function spawnHmaCheck(
       args.push('--ci');
     }
 
+    // See router.ts:spawnHmaCheckFromRouter for the env var contract docs.
+    const hmaEnv = {
+      ...process.env,
+      HMA_CLI_PREFIX: 'opena2a',
+      HMA_CHECK_COMMAND: 'opena2a check',
+      HMA_FULL_SCAN_HINT: 'opena2a review',
+    };
+
     const child = spawn('hackmyagent', args, {
       cwd: process.cwd(),
       stdio: 'inherit',
-      env: {
-        ...process.env,
-        HMA_CLI_PREFIX: 'opena2a check',
-      },
+      env: hmaEnv,
     });
 
     child.on('error', (err) => {
@@ -1158,10 +1175,7 @@ function spawnHmaCheck(
       const npxChild = spawn('npx', ['hackmyagent', ...args], {
         cwd: process.cwd(),
         stdio: 'inherit',
-        env: {
-          ...process.env,
-          HMA_CLI_PREFIX: 'opena2a check',
-        },
+        env: hmaEnv,
       });
       npxChild.on('error', () => {
         process.stderr.write(`hackmyagent is not installed.\n`);

--- a/packages/cli/src/router.ts
+++ b/packages/cli/src/router.ts
@@ -428,23 +428,38 @@ function spawnHmaCheckFromRouter(
       args.push('--ci');
     }
 
+    // Environment contract with hackmyagent >= 0.16.6:
+    //   HMA_CLI_PREFIX     — binary-level prefix (used for messages that append
+    //                        a verb, e.g. "${prefix} rollback <dir>"). Set to
+    //                        "opena2a" so any such message reads naturally for
+    //                        opena2a users. Messages referring to verbs opena2a
+    //                        does not expose (e.g. "opena2a secure") are not
+    //                        reached via the check-delegation path and so do
+    //                        not surface to users.
+    //   HMA_CHECK_COMMAND  — full command string for "run a single-target
+    //                        check" hints. Avoids the duplicated-verb bug that
+    //                        results from using HMA_CLI_PREFIX="opena2a check".
+    //   HMA_FULL_SCAN_HINT — full command string shown in place of HMA's
+    //                        default "hackmyagent secure <dir>" recommendation,
+    //                        so opena2a users are pointed at `opena2a review`.
+    const hmaEnv = {
+      ...process.env,
+      HMA_CLI_PREFIX: 'opena2a',
+      HMA_CHECK_COMMAND: 'opena2a check',
+      HMA_FULL_SCAN_HINT: 'opena2a review',
+    };
+
     const child = spawn('hackmyagent', args, {
       cwd: (globalOptions.cwd as string) ?? process.cwd(),
       stdio: 'inherit',
-      env: {
-        ...process.env,
-        HMA_CLI_PREFIX: 'opena2a check',
-      },
+      env: hmaEnv,
     });
 
     child.on('error', () => {
       const npxChild = spawn('npx', ['hackmyagent', ...args], {
         cwd: (globalOptions.cwd as string) ?? process.cwd(),
         stdio: 'inherit',
-        env: {
-          ...process.env,
-          HMA_CLI_PREFIX: 'opena2a check',
-        },
+        env: hmaEnv,
       });
       npxChild.on('error', () => {
         process.stderr.write(`hackmyagent is not installed.\n`);

--- a/packages/shared/src/user-config.test.ts
+++ b/packages/shared/src/user-config.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isStaleRegistryUrl,
+  STALE_REGISTRY_HOSTS,
+  CANONICAL_REGISTRY_URL,
+} from './user-config.js';
+
+describe('isStaleRegistryUrl', () => {
+  it('returns true for each documented stale host', () => {
+    for (const host of STALE_REGISTRY_HOSTS) {
+      expect(isStaleRegistryUrl(host)).toBe(true);
+    }
+  });
+
+  it('returns true for stale host with trailing slash', () => {
+    expect(isStaleRegistryUrl('https://registry.opena2a.org/')).toBe(true);
+  });
+
+  it('returns true for stale host with path suffix', () => {
+    expect(isStaleRegistryUrl('https://registry.opena2a.org/api/v1/trust')).toBe(true);
+  });
+
+  it('returns true for stale host regardless of case', () => {
+    expect(isStaleRegistryUrl('HTTPS://REGISTRY.OPENA2A.ORG')).toBe(true);
+  });
+
+  it('returns false for the current canonical URL', () => {
+    expect(isStaleRegistryUrl(CANONICAL_REGISTRY_URL)).toBe(false);
+  });
+
+  it('returns false for a third-party URL that happens to share a suffix', () => {
+    expect(isStaleRegistryUrl('https://not-registry.opena2a.org')).toBe(false);
+  });
+
+  it('returns false for empty or undefined input', () => {
+    expect(isStaleRegistryUrl('')).toBe(false);
+    expect(isStaleRegistryUrl('   ')).toBe(false);
+    expect(isStaleRegistryUrl(undefined)).toBe(false);
+    expect(isStaleRegistryUrl(null)).toBe(false);
+  });
+
+  it('returns false for a user-provided self-hosted registry', () => {
+    expect(isStaleRegistryUrl('https://my-internal-registry.example.com')).toBe(false);
+  });
+});

--- a/packages/shared/src/user-config.ts
+++ b/packages/shared/src/user-config.ts
@@ -66,13 +66,59 @@ export function getUserConfigPath(): string {
   return join(getUserConfigDir(), 'config.json');
 }
 
+/**
+ * Registry host names that were in use before the migration to oa2a.org.
+ * Any config pointing at one of these is silently rewritten on load to the
+ * current canonical URL so existing users do not have to edit their config
+ * manually after an upstream URL change.
+ */
+export const STALE_REGISTRY_HOSTS: readonly string[] = [
+  'https://registry.opena2a.org',
+  'http://registry.opena2a.org',
+  'https://api.opena2a.org',
+  'http://api.opena2a.org',
+];
+
+export const CANONICAL_REGISTRY_URL = 'https://api.oa2a.org';
+
+/**
+ * Pure helper: returns true if the given URL matches a known-stale registry host.
+ * Exported for testing.
+ */
+export function isStaleRegistryUrl(url: string | undefined | null): boolean {
+  if (!url) return false;
+  const normalized = url.trim().replace(/\/+$/, '').toLowerCase();
+  if (!normalized) return false;
+  return STALE_REGISTRY_HOSTS.some(
+    host => normalized === host.toLowerCase() || normalized.startsWith(host.toLowerCase() + '/'),
+  );
+}
+
+/**
+ * If the user's config points at a registry host that no longer exists,
+ * rewrite it to the canonical URL and persist the change. Returns true if
+ * a migration was performed. Callers may use the return value to emit a
+ * one-time notice; failures to persist are swallowed so a broken home
+ * directory never blocks CLI startup.
+ */
+function migrateStaleRegistryUrl(config: UserConfig): boolean {
+  if (!isStaleRegistryUrl(config.registry?.url)) return false;
+  config.registry.url = CANONICAL_REGISTRY_URL;
+  try {
+    saveUserConfig(config);
+  } catch {
+    // Non-fatal: in-memory value is correct even if we cannot persist.
+  }
+  return true;
+}
+
 export function loadUserConfig(): UserConfig {
   const configPath = getUserConfigPath();
   try {
     const raw = readFileSync(configPath, 'utf-8');
     const parsed = JSON.parse(raw);
 
-    return {
+    const merged: UserConfig = {
       ...DEFAULT_CONFIG,
       ...parsed,
       contribute: { ...DEFAULT_CONFIG.contribute, ...parsed.contribute },
@@ -88,6 +134,20 @@ export function loadUserConfig(): UserConfig {
       },
       telemetry: { ...DEFAULT_CONFIG.telemetry, ...parsed.telemetry },
     };
+
+    if (migrateStaleRegistryUrl(merged)) {
+      // Print to stderr so JSON-formatted stdout stays clean. One-time per
+      // invocation; subsequent loads see the already-migrated config.
+      try {
+        process.stderr.write(
+          `opena2a: migrated stale registry URL to ${CANONICAL_REGISTRY_URL}\n`,
+        );
+      } catch {
+        // stderr unavailable in some sandboxed runtimes — ignore.
+      }
+    }
+
+    return merged;
   } catch {
     return { ...DEFAULT_CONFIG };
   }


### PR DESCRIPTION
## Summary

Four related fixes that all surface the same way for end users: their `opena2a trust` command was silently broken because of a stale registry URL in their on-disk config, and even when the request succeeded the output had rendering bugs.

1. **Auto-migrate stale registry URLs** in `@opena2a/shared`. Every user who ran `opena2a-cli` before the registry URL rename from `opena2a.org` to `oa2a.org` has a stale value in `~/.opena2a/config.json` and is silently failing on the first registry call with `fetch failed`. `loadUserConfig()` now detects known-stale hosts, rewrites to `https://api.oa2a.org`, persists the change, and prints a one-time stderr notice. 8 new unit tests for `isStaleRegistryUrl`.

2. **Fix `Findings: 1 (undefined high)`** in `opena2a trust` output. Coalesce `scan.findingsCount` and `scan.highCount` with `?? 0` so missing registry fields don't surface as the literal word "undefined".

3. **Suppress dead Profile/Badge URLs** in `opena2a trust` output. The registry backend still embeds `registry.opena2a.org` hostnames in `profileUrl`, and `registry.oa2a.org` was never live. Detect known-dead hosts client-side and replace the link with a `(Registry launches soon — opena2a.org)` placeholder so users don't see broken URLs. Known-good hosts render normally. JSON output is unaffected — raw `profileUrl` is still passed through for API consumers.

4. **Fix the HMA delegation env var contract.** The old router spawned hackmyagent with `HMA_CLI_PREFIX='opena2a check'`, which HMA then used as a binary prefix and appended `check` to again, producing `opena2a check check <pkg>` in hint output. Introduces two new env vars — `HMA_CHECK_COMMAND` and `HMA_FULL_SCAN_HINT` — that carry complete command strings rather than trying to be a prefix. Both spawn sites (`router.ts` and `index.ts`) now set:
   - `HMA_CLI_PREFIX='opena2a'` (the actual binary)
   - `HMA_CHECK_COMMAND='opena2a check'`
   - `HMA_FULL_SCAN_HINT='opena2a review'`
   
   So HMA's next-steps footer correctly points opena2a users at their own flagship command instead of `hackmyagent secure <dir>`.

Also:
- `opena2a trust` output gets a 3-line next-steps footer that teaches the distinction between `trust` (registry-only lookup), `check` (local scan), and `review` (full project review)
- `opena2a trust --help` now includes a "See also" block pointing at `opena2a check` and `opena2a review`
- `MIN_HMA_VERSION` bumped from `0.15.7` to `0.16.6` to match current hackmyagent main

## Before / after

**Before** — user with stale config:

\`\`\`
$ opena2a trust @taazkareem/clickup-mcp-server
Failed to query trust profile: fetch failed
Registry: https://registry.opena2a.org
Check your registry URL in ~/.opena2a/config.json or use --registry-url <url>
\`\`\`

**After** — user with stale config (one-shot auto-migration):

\`\`\`
$ opena2a trust @taazkareem/clickup-mcp-server
opena2a: migrated stale registry URL to https://api.oa2a.org

@taazkareem/clickup-mcp-server v0.14.3
...
Security Posture
  Findings:     1 (0 high)           ← no more 'undefined'

Profile: (Registry launches soon — opena2a.org)   ← no more broken URL

  Run a local scan:      opena2a check @taazkareem/clickup-mcp-server --rescan
  Full security review:  opena2a review
  Note: 'trust' returns registry data only. For a real scan, use 'check'.
\`\`\`

## Test plan
- [x] `@opena2a/shared`: 8 new tests for `isStaleRegistryUrl` (exact host match, trailing slash, path suffix, case-insensitive, canonical URL, similar-suffix false-positive guard, empty/null input, self-hosted registries)
- [x] `opena2a-cli`: 875 tests pass (+1 for dead-host profile suppression)
- [x] Build clean: `turbo run build` 4/4 successful
- [x] Lint clean: `tsc --noEmit` on both packages
- [x] **New-user walkthrough**: subagent tested `--version`, `--help`, `trust --help` (verified See-also block), `trust @sentry/mcp-server` (verified all four fixes), `trust --json` (valid JSON, raw profileUrl preserved for API consumers), `trust express`, error paths, and end-to-end auto-migration (backup config → write stale → run trust → verify migration notice + canonical URL written → restore). All passed.
- [x] Verified end-to-end delegation: `opena2a check @sentry/mcp-server` via a PATH shim to locally-built hackmyagent 0.16.6 shows the correct footer (`opena2a check ... --rescan`, `opena2a review`), no duplicated verb.