### PR TITLE
Bump MIN_HMA_VERSION to 0.16.7

### DIFF
--- a/packages/cli/src/util/hma-version.ts
+++ b/packages/cli/src/util/hma-version.ts
@@ -1,6 +1,9 @@
 import { execFileSync } from 'node:child_process';
 
-export const MIN_HMA_VERSION = '0.15.7';
+// 0.16.7 ships the HMA_CHECK_COMMAND / HMA_FULL_SCAN_HINT env var contract
+// that opena2a-cli's router sets when spawning HMA for the check footer.
+// 0.16.6 was never published to npm (batched with 0.16.7).
+export const MIN_HMA_VERSION = '0.16.7';
 
 let versionChecked = false;
 


### PR DESCRIPTION
## Summary

Bumps `MIN_HMA_VERSION` from `0.15.7` to `0.16.7` in `packages/cli/src/util/hma-version.ts`.

`0.16.7` is the first npm-published version that includes the `HMA_CHECK_COMMAND` / `HMA_FULL_SCAN_HINT` env var contract which opena2a-cli's router sets when spawning HMA for the check footer. `0.16.6` was never published to npm (batched with `0.16.7`). Users on older HMA will continue to see a functional but slightly-degraded footer until they upgrade.

Rebased onto `main` (was previously stacked on #72 which has CI failures).

## Test plan
- [x] `npm run build` clean
- [x] `npm test` passes (874 tests)