### PR TITLE
Fix --server cloud to point at AIM Cloud backend (aim.oa2a.org)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3808,7 +3808,7 @@
     },
     "packages/cli": {
       "name": "opena2a-cli",
-      "version": "0.8.21",
+      "version": "0.8.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,11 @@
 - `guard harden` subcommand: scan skills for security issues via HackMyAgent, with `--fix` and `--dry-run` flags
 - Docker adapter configurable port mapping for `train` command (full DVAA port range)
 
+## 0.8.23
+
+### Bug Fixes
+- `--server cloud` now resolves to `https://aim.oa2a.org` (AIM Cloud backend). Previously pointed to `api.aim.opena2a.org`, which serves a different product (community). Bare `aim.opena2a.org` still routes to `api.aim.opena2a.org` for community users.
+
 ## 0.6.3
 
 ### Breaking Changes

--- a/packages/cli/__tests__/util/server-url.test.ts
+++ b/packages/cli/__tests__/util/server-url.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { resolveServerUrl } from '../../src/util/server-url.js';
 
 describe('resolveServerUrl', () => {
-  it('resolves "cloud" to https://api.aim.opena2a.org', () => {
-    expect(resolveServerUrl('cloud')).toBe('https://api.aim.opena2a.org');
+  it('resolves "cloud" to https://aim.oa2a.org', () => {
+    expect(resolveServerUrl('cloud')).toBe('https://aim.oa2a.org');
   });
 
-  it('resolves bare "aim.opena2a.org" to https://api.aim.opena2a.org', () => {
+  it('resolves bare "aim.opena2a.org" to the community API', () => {
     expect(resolveServerUrl('aim.opena2a.org')).toBe('https://api.aim.opena2a.org');
   });
 
@@ -14,7 +14,7 @@ describe('resolveServerUrl', () => {
     expect(resolveServerUrl('aim.opena2a.org/')).toBe('https://api.aim.opena2a.org');
   });
 
-  it('resolves "api.aim.opena2a.org" directly', () => {
+  it('resolves "api.aim.opena2a.org" literal as-is', () => {
     expect(resolveServerUrl('api.aim.opena2a.org')).toBe('https://api.aim.opena2a.org');
   });
 
@@ -51,7 +51,7 @@ describe('resolveServerUrl', () => {
   });
 
   it('trims whitespace', () => {
-    expect(resolveServerUrl('  cloud  ')).toBe('https://api.aim.opena2a.org');
+    expect(resolveServerUrl('  cloud  ')).toBe('https://aim.oa2a.org');
     expect(resolveServerUrl('  localhost:8080  ')).toBe('http://localhost:8080');
   });
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opena2a-cli",
-  "version": "0.8.21",
+  "version": "0.8.23",
   "description": "Unified CLI for the OpenA2A security platform",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -27,7 +27,7 @@ export async function login(options: LoginOptions): Promise<number> {
     if (isJson) {
       console.log(JSON.stringify({ error: 'invalid_server', message: 'Server URL is required.' }));
     } else {
-      console.error('Server URL is required. Use --server <url> or omit for aim.opena2a.org.');
+      console.error('Server URL is required. Use --server <url> or omit for aim.oa2a.org.');
     }
     return 1;
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -385,7 +385,7 @@ analysis runs and results can be shared with the community.
   program
     .command('login')
     .description('Authenticate with an AIM server via browser login')
-    .option('--server <url>', 'AIM server URL (default: cloud, i.e. aim.opena2a.org)')
+    .option('--server <url>', 'AIM server URL (default: cloud, i.e. aim.oa2a.org)')
     .option('--json', 'Output as JSON')
     .action(async (opts) => {
       const { login } = await import('./commands/login.js');

--- a/packages/cli/src/util/server-url.ts
+++ b/packages/cli/src/util/server-url.ts
@@ -2,31 +2,25 @@
  * Resolve a user-provided --server value into a full URL.
  *
  * Shortcuts:
- *   "cloud"             → https://aim.opena2a.org
- *   "aim.opena2a.org"   → https://aim.opena2a.org
- *   "localhost:8080"    → http://localhost:8080
- *   "http://..." / "https://..." → used as-is
- *   "cloud"             -> https://aim.opena2a.org
- *   "aim.opena2a.org"   -> https://aim.opena2a.org
+ *   "cloud"             -> https://aim.oa2a.org
+ *   "aim.opena2a.org"   -> https://api.aim.opena2a.org
  *   "localhost:8080"    -> http://localhost:8080
  *   "http://..." / "https://..." -> used as-is
  */
 export function resolveServerUrl(input: string): string {
   const trimmed = input.trim();
 
-  // Shorthand for the hosted AIM service (API endpoint, not the dashboard)
+  // Shorthand for AIM Cloud (Phase 7 backend)
   if (trimmed === 'cloud') {
-    return 'https://api.aim.opena2a.org';
+    return 'https://aim.oa2a.org';
   }
 
-  // Already a full URL — use as-is
   // Already a full URL -- use as-is
   if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
-    // Strip trailing slash for consistency
     return trimmed.replace(/\/+$/, '');
   }
 
-  // Bare hostname that matches the cloud service — route to API endpoint
+  // Bare community hostnames route to the community API
   if (trimmed === 'aim.opena2a.org' || trimmed.startsWith('aim.opena2a.org/')) {
     return 'https://api.aim.opena2a.org';
   }
@@ -34,13 +28,11 @@ export function resolveServerUrl(input: string): string {
     return `https://${trimmed}`.replace(/\/+$/, '');
   }
 
-  // localhost / 127.0.0.1 / [::1] → default to http
   // localhost / 127.0.0.1 / [::1] -- default to http
   if (/^(localhost|127\.0\.0\.1|\[::1\])(:\d+)?(\/|$)/.test(trimmed)) {
     return `http://${trimmed}`.replace(/\/+$/, '');
   }
 
-  // Any other hostname — default to https
   // Any other hostname -- default to https
   return `https://${trimmed}`.replace(/\/+$/, '');
 }


### PR DESCRIPTION
## Summary
- `--server cloud` now resolves to `https://aim.oa2a.org` (Phase 7 AIM Cloud backend).
- Previously pointed to `https://api.aim.opena2a.org`, which serves a different product (community).
- Bare `aim.opena2a.org` still routes to `api.aim.opena2a.org` for community users.
- Updated `--server` help text and login error message to reference the new default.
- Bumped opena2a-cli to 0.8.23.

## Why
AIM Cloud (`aim-prod-backend`, Canada Central) is a separate product from the community backend (`ca-aim-backend-prod`, EastUS2). CA-010 bound `aim.oa2a.org` to the Phase 7 deployment on 2026-04-14, so the "cloud" shorthand now has a stable, product-correct home. See `project_aim_two_products.md`.

## Test plan
- [x] `npx vitest run __tests__/util/server-url.test.ts` — 12/12 pass
- [x] Full CLI test suite — 875/875 pass
- [x] `node dist/index.js --version` → `opena2a 0.8.23`
- [x] `node dist/index.js login --server ""` → error message references `aim.oa2a.org`
- [x] `curl https://aim.oa2a.org/health` → 200
- [ ] After merge + publish: update `opena2a-website/app/docs/cli/page.tsx` version and `homebrew-tap/Formula/opena2a.rb` url+sha256