### PR TITLE
test(baselines): isolate from real user config

### DIFF
--- a/packages/cli/__tests__/commands/baselines.test.ts
+++ b/packages/cli/__tests__/commands/baselines.test.ts
@@ -2,6 +2,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { baselines } from '../../src/commands/baselines.js';
 import type { BaselinesOptions } from '../../src/commands/baselines.js';
 
+// Isolate from the developer's real ~/.opena2a/config.json. checkOptIn does
+// `await import('@opena2a/shared')` and reads loadUserConfig().contribute.enabled
+// — without this mock the suite passes only on machines where contribute is off.
+// Default to enabled=false so the "not enabled" test path runs deterministically.
+// The other tests in this file tolerate either exit code, so a single shared
+// default is enough.
+vi.mock('@opena2a/shared', () => ({
+  default: {
+    loadUserConfig: () => ({
+      contribute: { enabled: false },
+      registry: { url: 'https://test-registry.example.com' },
+    }),
+  },
+  loadUserConfig: () => ({
+    contribute: { enabled: false },
+    registry: { url: 'https://test-registry.example.com' },
+  }),
+}));
+
 // Mock global fetch
 const mockFetch = vi.fn();
 
@@ -55,8 +74,6 @@ function captureStderr(fn: () => Promise<number>): Promise<{ exitCode: number; s
 
 describe('baselines', () => {
   it('returns 1 when contribute is not enabled', async () => {
-    // By default, @opena2a/shared will either not be loadable or return disabled
-    // The dynamic import of @opena2a/shared may fail, which means checkOptIn returns false
     const options: BaselinesOptions = {
       packageName: 'hackmyagent',
       ci: true,


### PR DESCRIPTION
## Summary

`baselines.test.ts` was reading the developer's real `~/.opena2a/config.json` via `await import('@opena2a/shared')`. On machines where the developer had opted into community contributions, the "returns 1 when contribute is not enabled" assertion failed (exitCode 0 instead of 1) because the real config returned `enabled: true`.

This blocked every push to the opena2a monorepo for opted-in developers.

## Fix

Add a `vi.mock('@opena2a/shared', ...)` at module scope returning `contribute.enabled = false`. The two later tests in this file already tolerate either exit code (assertions are gated on `exitCode === 0` or only check JSON validity), so a single shared mock at module scope is sufficient.

## Notes

The pre-existing `Function('return import(...)')` interception in tests 2 and 3 was dead code — `await import(...)` is a real ESM dynamic import, not wrapped in a Function constructor at runtime. Left in place to keep this PR scope narrow.

## Test plan

- [x] `npx vitest run __tests__/commands/baselines.test.ts` — 3/3 pass
- [x] `npm test` (opena2a-cli) — 875/875 pass