### PR TITLE
Add @opena2a/cli-ui and @opena2a/ai-classifier shared packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -900,8 +900,16 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@opena2a/ai-classifier": {
+      "resolved": "packages/ai-classifier",
+      "link": true
+    },
     "node_modules/@opena2a/aim-core": {
       "resolved": "packages/aim-core",
+      "link": true
+    },
+    "node_modules/@opena2a/cli-ui": {
+      "resolved": "packages/cli-ui",
       "link": true
     },
     "node_modules/@opena2a/contribute": {
@@ -3778,6 +3786,26 @@
         "zod": "^3.25.28 || ^4"
       }
     },
+    "packages/ai-classifier": {
+      "name": "@opena2a/ai-classifier",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "packages/ai-classifier/node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "packages/aim-core": {
       "name": "@opena2a/aim-core",
       "version": "0.2.0",
@@ -3832,6 +3860,29 @@
       },
       "optionalDependencies": {
         "@opena2a/aim-core": "*"
+      }
+    },
+    "packages/cli-ui": {
+      "name": "@opena2a/cli-ui",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "packages/cli-ui/node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "packages/cli/node_modules/@opena2a/contribute": {

--- a/packages/ai-classifier/README.md
+++ b/packages/ai-classifier/README.md
@@ -1,0 +1,37 @@
+# @opena2a/ai-classifier
+
+Decides whether a package is AI-native, AI-adjacent, or unrelated so `ai-trust`, `hackmyagent`, and `opena2a` can route it correctly.
+
+## Why it exists
+
+`ai-trust` is for AI packages. Scanning `lodash` with it produces confusing scores and wastes the user's time. This package is the shared rulebook that every OpenA2A CLI uses to answer one question: **does AI trust apply to this package?**
+
+## Tiers (v0.1)
+
+| Tier | Meaning | Example | ai-trust behavior |
+|---|---|---|---|
+| **native** | AI-specific (MCP server, A2A agent, skill, AI tool, LLM) | `@modelcontextprotocol/server-filesystem` | Full trust verification |
+| **adjacent** | General-purpose but in the AI trust boundary | `openai`, `dotenv` | *Stubbed in v0.3 → v0.4* |
+| **unrelated** | General-purpose library, no AI surface | `express`, `chalk`, `typescript` | Defer to HMA |
+| **unknown** | Can't classify confidently | novel or unnamed packages | Surface uncertainty, let user decide |
+
+## Usage
+
+```ts
+import { classify, isAiTrustScope } from "@opena2a/ai-classifier";
+
+const result = classify({ name: "express", packageType: "library" });
+// { tier: "unrelated", reasons: [], reasoning: "Registered as a general-purpose library" }
+
+if (isAiTrustScope(result)) {
+  // run ai-trust verification
+} else {
+  // route to HMA
+}
+```
+
+## Design rules
+
+- **Registry `package_type` is the strongest signal.** We trust the registry's classification first.
+- **Name-based fallback is conservative.** We only call a package "unrelated" by name when it's on a curated allowlist of well-known libraries (`chalk`, `typescript`, `@types/*`, etc.).
+- **Never false-classify as unrelated.** Ambiguous packages return `unknown`, not `unrelated`. False rejections (dropping an AI package from an audit) are worse than uncertainty.

--- a/packages/ai-classifier/package.json
+++ b/packages/ai-classifier/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@opena2a/ai-classifier",
+  "version": "0.1.0",
+  "description": "Tier-based AI package classification (native / adjacent / unrelated) for OpenA2A trust tooling",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run --passWithNoTests",
+    "lint": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opena2a-org/opena2a.git",
+    "directory": "packages/ai-classifier"
+  },
+  "homepage": "https://github.com/opena2a-org/opena2a/tree/main/packages/ai-classifier",
+  "license": "Apache-2.0"
+}

--- a/packages/ai-classifier/src/classify.test.ts
+++ b/packages/ai-classifier/src/classify.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import {
+  classify,
+  isAiTrustScope,
+  isHmaRoute,
+  tierLabel,
+  isNativeType,
+  isKnownUnrelatedName,
+} from "./index.js";
+
+describe("classify — registry package_type drives the decision", () => {
+  it("mcp_server -> native", () => {
+    const r = classify({ name: "@modelcontextprotocol/server-filesystem", packageType: "mcp_server" });
+    expect(r.tier).toBe("native");
+    expect(r.reasons).toEqual([]);
+  });
+
+  it("a2a_agent -> native", () => {
+    const r = classify({ name: "@opena2a/aim-core", packageType: "a2a_agent" });
+    expect(r.tier).toBe("native");
+  });
+
+  it("skill -> native", () => {
+    const r = classify({ name: "example-skill", packageType: "skill" });
+    expect(r.tier).toBe("native");
+  });
+
+  it("ai_tool -> native", () => {
+    const r = classify({ name: "some-tool", packageType: "ai_tool" });
+    expect(r.tier).toBe("native");
+  });
+
+  it("llm -> native", () => {
+    const r = classify({ name: "some-model", packageType: "llm" });
+    expect(r.tier).toBe("native");
+  });
+
+  it("library -> unrelated", () => {
+    const r = classify({ name: "express", packageType: "library" });
+    expect(r.tier).toBe("unrelated");
+  });
+});
+
+describe("classify — name-based fallback when no registry type", () => {
+  it("known unrelated name -> unrelated", () => {
+    expect(classify({ name: "chalk" }).tier).toBe("unrelated");
+    expect(classify({ name: "typescript" }).tier).toBe("unrelated");
+    expect(classify({ name: "vitest" }).tier).toBe("unrelated");
+    expect(classify({ name: "commander" }).tier).toBe("unrelated");
+  });
+
+  it("@types/* -> unrelated", () => {
+    expect(classify({ name: "@types/node" }).tier).toBe("unrelated");
+    expect(classify({ name: "@types/js-yaml" }).tier).toBe("unrelated");
+  });
+
+  it("unknown name with no type -> unknown", () => {
+    const r = classify({ name: "some-random-pkg-xyz-999" });
+    expect(r.tier).toBe("unknown");
+  });
+});
+
+describe("classify — never false-classify an AI package as unrelated", () => {
+  // The critical invariant: if we're unsure, return "unknown", not "unrelated".
+  // A user auditing an AI project doesn't want their MCP server silently dropped.
+  it("ambiguous packages return unknown, not unrelated", () => {
+    const r = classify({ name: "custom-agent-runtime" });
+    expect(r.tier).toBe("unknown");
+    expect(r.tier).not.toBe("unrelated");
+  });
+
+  it("packageType takes precedence over name allowlist", () => {
+    // If somehow a package named like a library is registered as mcp_server,
+    // we trust the registry classification.
+    const r = classify({ name: "lodash", packageType: "mcp_server" });
+    expect(r.tier).toBe("native");
+  });
+});
+
+describe("helpers", () => {
+  it("isNativeType", () => {
+    expect(isNativeType("mcp_server")).toBe(true);
+    expect(isNativeType("library")).toBe(false);
+    expect(isNativeType(undefined)).toBe(false);
+  });
+
+  it("isKnownUnrelatedName", () => {
+    expect(isKnownUnrelatedName("chalk")).toBe(true);
+    expect(isKnownUnrelatedName("@types/node")).toBe(true);
+    expect(isKnownUnrelatedName("@modelcontextprotocol/sdk")).toBe(false);
+  });
+
+  it("isAiTrustScope only true for native", () => {
+    expect(isAiTrustScope(classify({ name: "x", packageType: "mcp_server" }))).toBe(true);
+    expect(isAiTrustScope(classify({ name: "chalk" }))).toBe(false);
+    expect(isAiTrustScope(classify({ name: "unknown-pkg" }))).toBe(false);
+  });
+
+  it("isHmaRoute only true for unrelated", () => {
+    expect(isHmaRoute(classify({ name: "chalk" }))).toBe(true);
+    expect(isHmaRoute(classify({ name: "x", packageType: "mcp_server" }))).toBe(false);
+    expect(isHmaRoute(classify({ name: "unknown-pkg" }))).toBe(false);
+  });
+
+  it("tierLabel", () => {
+    expect(tierLabel("native")).toBe("AI package");
+    expect(tierLabel("unrelated")).toBe("library");
+    expect(tierLabel("unknown")).toBe("unknown");
+  });
+});

--- a/packages/ai-classifier/src/classify.ts
+++ b/packages/ai-classifier/src/classify.ts
@@ -1,0 +1,89 @@
+import type { ClassificationResult, ClassifyInput, Tier } from "./types.js";
+import { isLibraryType, isNativeType } from "./native-types.js";
+import { isKnownUnrelatedName } from "./unrelated-names.js";
+
+/**
+ * Classify a package by tier.
+ *
+ * Decision order:
+ *   1. Registry-supplied `packageType` is the strongest signal (it comes from
+ *      the Registry's own classification pipeline).
+ *   2. If no type is given, fall back to the name-based unrelated allowlist
+ *      to catch common libraries (chalk, typescript, @types/*).
+ *   3. Otherwise, return `unknown` so callers can surface uncertainty rather
+ *      than risk mislabeling an AI package as unrelated.
+ *
+ * Tier 2 (adjacent) is stubbed for v0.3. It returns `unknown` today. Once the
+ * curated adjacent allowlist lands in v0.4, this function will route matches
+ * into Tier 2 with the appropriate reason tags.
+ */
+export function classify(input: ClassifyInput): ClassificationResult {
+  const { name, packageType } = input;
+
+  // 1. Strongest signal: registry package_type.
+  if (isNativeType(packageType)) {
+    return {
+      tier: "native",
+      reasons: [],
+      reasoning: `Registered as ${packageType} in the OpenA2A Registry`,
+    };
+  }
+
+  if (isLibraryType(packageType)) {
+    return {
+      tier: "unrelated",
+      reasons: [],
+      reasoning: "Registered as a general-purpose library",
+    };
+  }
+
+  // 2. No registry type: fall back to name-based allowlist for well-known
+  //    general-purpose libraries.
+  if (isKnownUnrelatedName(name)) {
+    return {
+      tier: "unrelated",
+      reasons: [],
+      reasoning: `Recognized as a general-purpose library (${name})`,
+    };
+  }
+
+  // 3. Can't classify confidently. Return unknown so callers can ask the
+  //    user, skip, or defer to a fresh registry lookup.
+  return {
+    tier: "unknown",
+    reasons: [],
+    reasoning: "No registry classification or allowlist match",
+  };
+}
+
+/**
+ * Quick boolean: is this package worth scanning with ai-trust, or should we
+ * defer to HMA? True for tier === "native". Returns false for unrelated,
+ * unknown, and (in a future release) adjacent.
+ */
+export function isAiTrustScope(result: ClassificationResult): boolean {
+  return result.tier === "native";
+}
+
+/**
+ * Quick boolean: is this package a non-AI library that should be routed to HMA?
+ */
+export function isHmaRoute(result: ClassificationResult): boolean {
+  return result.tier === "unrelated";
+}
+
+/**
+ * Map a tier to a short label for CLI output ("AI package", "library", etc.).
+ */
+export function tierLabel(tier: Tier): string {
+  switch (tier) {
+    case "native":
+      return "AI package";
+    case "adjacent":
+      return "AI-adjacent";
+    case "unrelated":
+      return "library";
+    case "unknown":
+      return "unknown";
+  }
+}

--- a/packages/ai-classifier/src/index.ts
+++ b/packages/ai-classifier/src/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @opena2a/ai-classifier
+ *
+ * Decide whether a package is AI-native, AI-adjacent, or unrelated so
+ * ai-trust, HMA, and opena2a-cli can route it correctly.
+ *
+ * v0.1: Tier 1 (native) + Tier 3 (unrelated) only. Tier 2 (adjacent) is
+ * stubbed for v0.4 when the curated adjacent allowlist lands.
+ */
+
+export type {
+  Tier,
+  ReasonTag,
+  ClassificationResult,
+  ClassifyInput,
+} from "./types.js";
+
+export {
+  classify,
+  isAiTrustScope,
+  isHmaRoute,
+  tierLabel,
+} from "./classify.js";
+
+export {
+  AI_NATIVE_PACKAGE_TYPES,
+  LIBRARY_PACKAGE_TYPE,
+  isNativeType,
+  isLibraryType,
+} from "./native-types.js";
+
+export {
+  UNRELATED_PACKAGE_NAMES,
+  UNRELATED_SCOPE_PREFIXES,
+  isKnownUnrelatedName,
+} from "./unrelated-names.js";

--- a/packages/ai-classifier/src/native-types.ts
+++ b/packages/ai-classifier/src/native-types.ts
@@ -1,0 +1,38 @@
+/**
+ * AI-native package types. A package with one of these registry package_type
+ * values is in Tier 1 (native) regardless of its name.
+ *
+ * This list mirrors the registry's `scannableTypes` (mcp_server, a2a_agent,
+ * skill, ai_tool) plus `llm`. LLMs aren't auto-scanned by HMA (model weights
+ * don't benefit from code scanning), but they are AI-native and belong in the
+ * trust-verification flow.
+ */
+export const AI_NATIVE_PACKAGE_TYPES: ReadonlySet<string> = new Set([
+  "mcp_server",
+  "a2a_agent",
+  "skill",
+  "ai_tool",
+  "llm",
+]);
+
+/**
+ * Registry package_type value for general-purpose libraries. Packages with
+ * this type are explicitly out of scope for ai-trust and get routed to HMA.
+ */
+export const LIBRARY_PACKAGE_TYPE = "library";
+
+/**
+ * Returns true for any package_type value that represents an AI-native package.
+ */
+export function isNativeType(packageType?: string): boolean {
+  if (!packageType) return false;
+  return AI_NATIVE_PACKAGE_TYPES.has(packageType);
+}
+
+/**
+ * Returns true when the registry explicitly marks this as a general-purpose
+ * library.
+ */
+export function isLibraryType(packageType?: string): boolean {
+  return packageType === LIBRARY_PACKAGE_TYPE;
+}

--- a/packages/ai-classifier/src/types.ts
+++ b/packages/ai-classifier/src/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Trust-relevance tier for a package.
+ *
+ * - `native`: AI-specific package (MCP server, A2A agent, skill, AI tool, LLM).
+ *             Full trust verification applies. Registry data is authoritative.
+ * - `adjacent`: General-purpose package that lives inside an AI agent's trust
+ *               boundary (LLM client, credential handler, prompt parser, etc.).
+ *               Stubbed in v0.3; reserved for v0.4 Tier 2 work.
+ * - `unrelated`: General-purpose library with no AI-specific surface. Out of
+ *                scope for ai-trust; deferred to HackMyAgent for security scanning.
+ * - `unknown`: Cannot confidently classify. Treated as unrelated for audit
+ *              output but flagged so callers can surface uncertainty.
+ */
+export type Tier = "native" | "adjacent" | "unrelated" | "unknown";
+
+/**
+ * Why a package is in its tier. Used by CLIs to render "reason" chips and
+ * drive AI-specific interpretation (e.g. "credential_handler" means a finding
+ * in this package affects your LLM API key).
+ *
+ * The set is deliberately small and curated. It is NOT a free-form tag.
+ */
+export type ReasonTag =
+  | "llm_client"            // openai, @anthropic-ai/sdk, etc.
+  | "mcp_transport"         // @modelcontextprotocol/sdk, jsonrpc libs
+  | "credential_handler"    // dotenv, keytar, AWS secrets manager
+  | "crypto_primitive"      // @noble/*, tweetnacl — used for agent identity
+  | "prompt_loader"         // js-yaml, gray-matter — used to load skills/prompts
+  | "ai_framework"          // langchain, llamaindex
+  | "agent_runtime";        // temporal, bullmq, vercel/ai — runs the agent loop
+
+export interface ClassificationResult {
+  /** The tier the package falls into. */
+  tier: Tier;
+  /**
+   * Reason tags explaining why a non-native package is AI-adjacent. Empty for
+   * native / unrelated / unknown tiers.
+   */
+  reasons: ReasonTag[];
+  /**
+   * Short human-readable explanation. Useful for CLI output; not machine-parseable.
+   */
+  reasoning: string;
+}
+
+/**
+ * Input to the classifier. `packageType` is the registry's stored package_type
+ * value if known. When passed, it is the strongest signal and overrides name-
+ * based heuristics.
+ */
+export interface ClassifyInput {
+  /** Package name (e.g. "@modelcontextprotocol/server-filesystem"). */
+  name: string;
+  /** Registry package_type, if known. e.g. "mcp_server" | "a2a_agent" | "library". */
+  packageType?: string;
+}

--- a/packages/ai-classifier/src/unrelated-names.ts
+++ b/packages/ai-classifier/src/unrelated-names.ts
@@ -1,0 +1,148 @@
+/**
+ * Allowlist of well-known general-purpose libraries that we can confidently
+ * reject as unrelated to AI trust, even if the registry lacks a `package_type`
+ * for them. This covers the long tail of utility packages that show up in
+ * every Node/Python project.
+ *
+ * Kept intentionally small and conservative. When in doubt, return "unknown"
+ * instead of adding to this list — false rejections (treating an AI package
+ * as unrelated) are worse than a graceful "we can't classify this yet."
+ *
+ * For v0.4 this will be supplemented by an allowlist of AI-ADJACENT names
+ * (Tier 2) in a separate file.
+ */
+
+const JS_UTILITIES = [
+  "lodash",
+  "underscore",
+  "chalk",
+  "colors",
+  "ansi-colors",
+  "kleur",
+  "cli-color",
+  "picocolors",
+  "debug",
+  "minimist",
+  "commander",
+  "yargs",
+  "ora",
+  "prompts",
+  "inquirer",
+  "execa",
+  "glob",
+  "rimraf",
+  "mkdirp",
+  "uuid",
+  "nanoid",
+  "semver",
+  "ms",
+  "pretty-ms",
+  "dayjs",
+  "date-fns",
+  "moment",
+  "cross-env",
+  "dotenv-cli",
+];
+
+const JS_FRAMEWORKS = [
+  "express",
+  "fastify",
+  "koa",
+  "hapi",
+  "nestjs",
+  "@nestjs/core",
+  "next",
+  "nuxt",
+  "gatsby",
+  "svelte",
+  "remix",
+  "astro",
+];
+
+const JS_BUILD_TOOLING = [
+  "typescript",
+  "tsx",
+  "ts-node",
+  "esbuild",
+  "tsup",
+  "vite",
+  "rollup",
+  "webpack",
+  "parcel",
+  "swc",
+  "@swc/core",
+  "turbo",
+  "nx",
+  "lerna",
+];
+
+const JS_TEST_TOOLING = [
+  "vitest",
+  "jest",
+  "mocha",
+  "chai",
+  "sinon",
+  "playwright",
+  "cypress",
+  "@playwright/test",
+];
+
+const JS_LINT_TOOLING = [
+  "eslint",
+  "prettier",
+  "husky",
+  "lint-staged",
+  "commitlint",
+];
+
+const PY_UTILITIES = [
+  "requests",
+  "urllib3",
+  "click",
+  "rich",
+  "typer",
+  "pydantic",
+  "python-dateutil",
+  "setuptools",
+  "pip",
+  "wheel",
+  "pytest",
+  "black",
+  "ruff",
+  "mypy",
+  "flake8",
+  "isort",
+];
+
+/**
+ * Known general-purpose libraries across npm and PyPI. Matched by exact name.
+ */
+export const UNRELATED_PACKAGE_NAMES: ReadonlySet<string> = new Set([
+  ...JS_UTILITIES,
+  ...JS_FRAMEWORKS,
+  ...JS_BUILD_TOOLING,
+  ...JS_TEST_TOOLING,
+  ...JS_LINT_TOOLING,
+  ...PY_UTILITIES,
+]);
+
+/**
+ * Prefixes for scoped packages that are always general-purpose.
+ * e.g. @types/* are TypeScript type definitions — never AI-specific.
+ */
+export const UNRELATED_SCOPE_PREFIXES: readonly string[] = [
+  "@types/",
+  "@typescript-eslint/",
+  "@babel/",
+  "@rollup/",
+  "@vitejs/",
+  "@webpack/",
+];
+
+export function isKnownUnrelatedName(name: string): boolean {
+  if (UNRELATED_PACKAGE_NAMES.has(name)) return true;
+  for (const prefix of UNRELATED_SCOPE_PREFIXES) {
+    if (name.startsWith(prefix)) return true;
+  }
+  return false;
+}

--- a/packages/ai-classifier/tsconfig.json
+++ b/packages/ai-classifier/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/cli-ui/README.md
+++ b/packages/cli-ui/README.md
@@ -1,0 +1,30 @@
+# @opena2a/cli-ui
+
+Shared terminal UI primitives for OpenA2A CLIs (`ai-trust`, `hackmyagent`, `opena2a`).
+
+One place to update score meters, dividers, trust level legends, and verdict colors so the three CLIs stay visually consistent.
+
+## What's in the box
+
+- `scoreMeter(value, max?)` — full-width colored bar: `━━━━━━━━━━━━━━━━━━━━ 87/100`
+- `miniMeter(value, max?)` — compact 8-cell bar for table cells
+- `divider(label?)` — section divider, optionally labeled
+- `verdictColor(verdict)` / `normalizeVerdict(verdict)` — collapse registry verdict variants and get a chalk color
+- `trustLevelLabel(0-4)` / `trustLevelColor(0-4)` / `trustLevelLegend(current)` — render the 5-level trust ladder
+- `formatScanAge(timestamp)` — "3 days ago" or "120 days ago (stale)"
+
+## Usage
+
+```ts
+import { scoreMeter, divider, trustLevelLegend, verdictColor } from "@opena2a/cli-ui";
+
+console.log(`  Trust     ${scoreMeter(87)}`);
+console.log(divider("Findings"));
+console.log(`  ${trustLevelLegend(3)}`);
+```
+
+## Color rules
+
+- Score / meter: green ≥ 70, yellow ≥ 40, red below.
+- Trust level: green (3, 4), yellow (1, 2), red (0).
+- Verdict: safe → green, warning → yellow, blocked → red, listed → cyan.

--- a/packages/cli-ui/package.json
+++ b/packages/cli-ui/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@opena2a/cli-ui",
+  "version": "0.1.0",
+  "description": "Shared terminal UI primitives for OpenA2A CLIs (score meter, trust level legend, verdict colors)",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run --passWithNoTests",
+    "lint": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  },
+  "dependencies": {
+    "chalk": "^5.3.0"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opena2a-org/opena2a.git",
+    "directory": "packages/cli-ui"
+  },
+  "homepage": "https://github.com/opena2a-org/opena2a/tree/main/packages/cli-ui",
+  "license": "Apache-2.0"
+}

--- a/packages/cli-ui/src/divider.ts
+++ b/packages/cli-ui/src/divider.ts
@@ -1,0 +1,15 @@
+import chalk from "chalk";
+
+const DIVIDER_WIDTH = 62;
+
+/**
+ * Section divider. With a label: `── Findings ──────────────`.
+ * Without a label: a plain horizontal rule.
+ */
+export function divider(label?: string): string {
+  if (label) {
+    const pad = Math.max(1, 56 - label.length);
+    return `\n  ${chalk.dim("\u2500\u2500")} ${chalk.bold(label)} ${chalk.dim("\u2500".repeat(pad))}`;
+  }
+  return `  ${chalk.dim("\u2500".repeat(DIVIDER_WIDTH))}`;
+}

--- a/packages/cli-ui/src/index.test.ts
+++ b/packages/cli-ui/src/index.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import {
+  scoreMeter,
+  miniMeter,
+  divider,
+  normalizeVerdict,
+  trustLevelLabel,
+  trustLevelLegend,
+  formatScanAge,
+} from "./index.js";
+
+describe("scoreMeter", () => {
+  it("renders value and max", () => {
+    const out = scoreMeter(87);
+    expect(out).toContain("87");
+    expect(out).toContain("/100");
+  });
+
+  it("supports custom max", () => {
+    const out = scoreMeter(5, 10);
+    expect(out).toContain("5");
+    expect(out).toContain("/10");
+  });
+});
+
+describe("miniMeter", () => {
+  it("renders value without max suffix", () => {
+    const out = miniMeter(50);
+    expect(out).toContain("50");
+    expect(out).not.toContain("/100");
+  });
+});
+
+describe("divider", () => {
+  it("renders plain rule without label", () => {
+    const out = divider();
+    expect(out).toMatch(/─+/);
+  });
+
+  it("includes label when provided", () => {
+    const out = divider("Findings");
+    expect(out).toContain("Findings");
+  });
+});
+
+describe("normalizeVerdict", () => {
+  it("collapses scan-status variants", () => {
+    expect(normalizeVerdict("passed")).toBe("safe");
+    expect(normalizeVerdict("safe")).toBe("safe");
+    expect(normalizeVerdict("warnings")).toBe("warning");
+    expect(normalizeVerdict("warning")).toBe("warning");
+    expect(normalizeVerdict("failed")).toBe("blocked");
+    expect(normalizeVerdict("blocked")).toBe("blocked");
+    expect(normalizeVerdict("listed")).toBe("listed");
+  });
+
+  it("returns unknown verdicts unchanged", () => {
+    expect(normalizeVerdict("mystery")).toBe("mystery");
+  });
+});
+
+describe("trustLevelLabel", () => {
+  it("maps 0-4 to names", () => {
+    expect(trustLevelLabel(0)).toBe("Blocked");
+    expect(trustLevelLabel(1)).toBe("Warning");
+    expect(trustLevelLabel(2)).toBe("Listed");
+    expect(trustLevelLabel(3)).toBe("Scanned");
+    expect(trustLevelLabel(4)).toBe("Verified");
+  });
+
+  it("marks unknown levels", () => {
+    expect(trustLevelLabel(99)).toContain("Unknown");
+  });
+});
+
+describe("trustLevelLegend", () => {
+  it("includes all five levels", () => {
+    const out = trustLevelLegend(2);
+    expect(out).toContain("Blocked");
+    expect(out).toContain("Warning");
+    expect(out).toContain("Listed");
+    expect(out).toContain("Scanned");
+    expect(out).toContain("Verified");
+  });
+});
+
+describe("formatScanAge", () => {
+  it("returns null when timestamp missing", () => {
+    expect(formatScanAge()).toBeNull();
+    expect(formatScanAge(undefined)).toBeNull();
+  });
+
+  it('returns "today" for recent scans', () => {
+    const now = new Date().toISOString();
+    expect(formatScanAge(now)).toBe("today");
+  });
+
+  it('flags stale scans (>90 days)', () => {
+    const old = new Date(Date.now() - 120 * 86400 * 1000).toISOString();
+    const out = formatScanAge(old);
+    expect(out).toContain("120");
+    expect(out).toContain("stale");
+  });
+});

--- a/packages/cli-ui/src/index.ts
+++ b/packages/cli-ui/src/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @opena2a/cli-ui — Shared terminal UI primitives for OpenA2A CLIs.
+ *
+ * One source of truth for score meters, trust level legends, verdict colors,
+ * dividers, and other output components. Used by ai-trust, hackmyagent, and
+ * opena2a-cli so UX stays consistent across the platform.
+ */
+
+export { scoreMeter, miniMeter } from "./meters.js";
+export { divider } from "./divider.js";
+export {
+  normalizeVerdict,
+  verdictColor,
+  type Verdict,
+} from "./verdict.js";
+export {
+  trustLevelLabel,
+  trustLevelColor,
+  trustLevelLegend,
+  scoreColor,
+  type TrustLevel,
+} from "./trust-level.js";
+export { formatScanAge } from "./scan-age.js";

--- a/packages/cli-ui/src/meters.ts
+++ b/packages/cli-ui/src/meters.ts
@@ -1,0 +1,33 @@
+import chalk from "chalk";
+
+const METER_WIDTH = 20;
+const MINI_METER_WIDTH = 8;
+
+function meterColor(value: number) {
+  if (value >= 70) return chalk.green;
+  if (value >= 40) return chalk.yellow;
+  return chalk.red;
+}
+
+/**
+ * Full-width score meter: `━━━━━━━━━━━━━━━━━━━━ 87/100`
+ * Green >=70, yellow >=40, red below.
+ */
+export function scoreMeter(value: number, max: number = 100): string {
+  const pct = Math.round((value / max) * METER_WIDTH);
+  const color = meterColor(value);
+  const filled = "\u2501".repeat(pct);
+  const empty = "\u2501".repeat(METER_WIDTH - pct);
+  return `${color(filled)}${chalk.dim(empty)} ${color.bold(String(value))}${chalk.dim(`/${max}`)}`;
+}
+
+/**
+ * Compact meter for table cells: `━━━━━━━━ 87`
+ */
+export function miniMeter(value: number, max: number = 100): string {
+  const pct = Math.round((value / max) * MINI_METER_WIDTH);
+  const color = meterColor(value);
+  const filled = "\u2501".repeat(pct);
+  const empty = "\u2501".repeat(MINI_METER_WIDTH - pct);
+  return `${color(filled)}${chalk.dim(empty)} ${color.bold(String(value))}`;
+}

--- a/packages/cli-ui/src/scan-age.ts
+++ b/packages/cli-ui/src/scan-age.ts
@@ -1,0 +1,18 @@
+/**
+ * Format a scan timestamp as a friendly age string: "today", "1 day ago",
+ * "12 days ago", "120 days ago (stale)".
+ *
+ * Returns null when no timestamp is provided, so callers can omit the label.
+ */
+export function formatScanAge(lastScannedAt?: string): string | null {
+  if (!lastScannedAt) return null;
+  const scanned = new Date(lastScannedAt);
+  const now = new Date();
+  const days = Math.floor(
+    (now.getTime() - scanned.getTime()) / (1000 * 60 * 60 * 24)
+  );
+  if (days === 0) return "today";
+  if (days === 1) return "1 day ago";
+  if (days > 90) return `${days} days ago (stale)`;
+  return `${days} days ago`;
+}

--- a/packages/cli-ui/src/trust-level.ts
+++ b/packages/cli-ui/src/trust-level.ts
@@ -1,0 +1,43 @@
+import chalk from "chalk";
+
+export type TrustLevel = 0 | 1 | 2 | 3 | 4;
+
+const LEVEL_NAMES = ["Blocked", "Warning", "Listed", "Scanned", "Verified"] as const;
+
+/**
+ * Human name for a 0-4 trust level.
+ */
+export function trustLevelLabel(level: number): string {
+  if (level >= 0 && level < LEVEL_NAMES.length) return LEVEL_NAMES[level];
+  return `Unknown (${level})`;
+}
+
+/**
+ * Chalk color for a trust level. Green for Scanned/Verified, yellow for
+ * Warning/Listed, red for Blocked.
+ */
+export function trustLevelColor(level: number) {
+  if (level >= 3) return chalk.green;
+  if (level >= 1) return chalk.yellow;
+  return chalk.red;
+}
+
+/**
+ * `Blocked > Warning > Listed > Scanned > Verified` with the current level
+ * highlighted in its color, others dim.
+ */
+export function trustLevelLegend(currentLevel: number): string {
+  return LEVEL_NAMES.map((name, i) => {
+    if (i === currentLevel) return trustLevelColor(i).bold(name);
+    return chalk.dim(name);
+  }).join(chalk.dim(" > "));
+}
+
+/**
+ * Chalk color for a raw score value (0-100 scale).
+ */
+export function scoreColor(value: number): (text: string) => string {
+  if (value >= 70) return chalk.green;
+  if (value >= 40) return chalk.yellow;
+  return chalk.red;
+}

--- a/packages/cli-ui/src/verdict.ts
+++ b/packages/cli-ui/src/verdict.ts
@@ -1,0 +1,45 @@
+import chalk from "chalk";
+
+export type Verdict = "safe" | "warning" | "blocked" | "listed";
+
+/**
+ * Collapse the registry's verdict string variants into a normalized form.
+ * Accepts: "safe", "passed", "warning", "warnings", "blocked", "failed", "listed".
+ */
+export function normalizeVerdict(verdict: string): string {
+  switch (verdict) {
+    case "safe":
+    case "passed":
+      return "safe";
+    case "warning":
+    case "warnings":
+      return "warning";
+    case "blocked":
+    case "failed":
+      return "blocked";
+    case "listed":
+      return "listed";
+    default:
+      return verdict;
+  }
+}
+
+/**
+ * Map a verdict string (or its variants) to its chalk color function.
+ * Unknown verdicts render dim gray.
+ */
+export function verdictColor(verdict: string): (text: string) => string {
+  const normalized = normalizeVerdict(verdict);
+  switch (normalized) {
+    case "safe":
+      return chalk.green;
+    case "warning":
+      return chalk.yellow;
+    case "blocked":
+      return chalk.red;
+    case "listed":
+      return chalk.cyan;
+    default:
+      return chalk.gray;
+  }
+}

--- a/packages/cli-ui/tsconfig.json
+++ b/packages/cli-ui/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/cli/__tests__/commands/baselines.test.ts
+++ b/packages/cli/__tests__/commands/baselines.test.ts
@@ -2,6 +2,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { baselines } from '../../src/commands/baselines.js';
 import type { BaselinesOptions } from '../../src/commands/baselines.js';
 
+// Isolate from the developer's real ~/.opena2a/config.json. checkOptIn does
+// `await import('@opena2a/shared')` and reads loadUserConfig().contribute.enabled
+// — without this mock the suite passes only on machines where contribute is off.
+// Default to enabled=false so the "not enabled" test path runs deterministically.
+// The other tests in this file tolerate either exit code, so a single shared
+// default is enough.
+vi.mock('@opena2a/shared', () => ({
+  default: {
+    loadUserConfig: () => ({
+      contribute: { enabled: false },
+      registry: { url: 'https://test-registry.example.com' },
+    }),
+  },
+  loadUserConfig: () => ({
+    contribute: { enabled: false },
+    registry: { url: 'https://test-registry.example.com' },
+  }),
+}));
+
 // Mock global fetch
 const mockFetch = vi.fn();
 
@@ -55,8 +74,6 @@ function captureStderr(fn: () => Promise<number>): Promise<{ exitCode: number; s
 
 describe('baselines', () => {
   it('returns 1 when contribute is not enabled', async () => {
-    // By default, @opena2a/shared will either not be loadable or return disabled
-    // The dynamic import of @opena2a/shared may fail, which means checkOptIn returns false
     const options: BaselinesOptions = {
       packageName: 'hackmyagent',
       ci: true,

--- a/packages/cli/src/commands/mcp-audit.ts
+++ b/packages/cli/src/commands/mcp-audit.ts
@@ -248,6 +248,10 @@ async function handleAudit(options: McpCommandOptions): Promise<number> {
     for (const source of sources) {
       process.stdout.write(dim(`  ${source.filePath}`) + '\n');
     }
+    process.stdout.write('\n');
+    process.stdout.write(bold('Next Steps') + '\n');
+    process.stdout.write(`  ${cyan('Add MCP servers:')}  Edit ${dim('~/.cursor/mcp.json')} or ${dim('~/.claude/mcp.json')} to register servers\n`);
+    process.stdout.write(`  ${cyan('Full command list:')}  opena2a --help\n`);
     return 0;
   }
 


### PR DESCRIPTION
## Summary

Two new internal packages under `packages/` that the OpenA2A CLIs (`ai-trust`, `hackmyagent`, `opena2a`) consume so they share a single source of truth for terminal UX and for the question "is this an AI package?"

### `@opena2a/cli-ui@0.1.0` (13 tests)

Shared terminal UI primitives:
- `scoreMeter` / `miniMeter` — colored bars (green ≥ 70, yellow ≥ 40, red below)
- `divider` — section divider, optionally labeled
- `verdictColor` / `normalizeVerdict` — collapse registry verdict variants and color them
- `trustLevelLabel` / `trustLevelColor` / `trustLevelLegend` — render the 5-level trust ladder
- `formatScanAge` — "3 days ago" / "120 days ago (stale)"

### `@opena2a/ai-classifier@0.1.0` (16 tests)

Decides whether a package is AI-native, AI-adjacent, or unrelated so the CLIs route correctly:
- **native** (mcp_server, a2a_agent, skill, ai_tool, llm) → trust verification
- **adjacent** → stubbed for v0.4
- **unrelated** (express, chalk, typescript, @types/*, etc.) → defer to HMA
- **unknown** → surface uncertainty, don't false-classify as unrelated

Decision order: registry `package_type` first (strongest signal), then a conservative name-based allowlist for well-known general-purpose libraries, otherwise return `unknown`.

## Why

`ai-trust@0.3` narrows scope to AI packages and routes libraries to HMA. To make that routing decision in a single place — and keep the meter/verdict/trust UX consistent across all three CLIs — these primitives need to live in one shared package each.

## Notes

- Both packages are ESM (`"type": "module"`).
- One commit (`dfe860e`) is from PR #78 (baselines test isolation) — included to unblock the pre-push hook on this branch. It will deduplicate when #78 merges.
- One commit (`d6f73c4`) is from `fix/protect-credential-migration-bugs` (orthogonal work this branch was based on); it will deduplicate when that PR lands.

## Test plan

- [x] `npm test` in each package — cli-ui 13/13, ai-classifier 16/16
- [x] `npm run build` — clean tsc emit
- [x] HMA scan on each — 98/100 (one LOW each on missing .gitignore, inherited from monorepo root)
- [ ] Publish `@opena2a/cli-ui@0.1.0` and `@opena2a/ai-classifier@0.1.0` after merge (gated on user approval per session 81)
- [ ] After publish, ai-trust v0.3 PR flips its `file:` deps to `^0.1.0`