### PR TITLE
ci(release): publish cli-ui and contribute with provenance, verify attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,14 +56,24 @@ jobs:
 
       - name: Verify provenance attached
         run: |
-          sleep 15
+          verify_attestations() {
+            local pkg="$1"
+            local deadline=$((SECONDS + 300))
+            local attestations=""
+            while [ $SECONDS -lt $deadline ]; do
+              attestations=$(npm view "$pkg" dist.attestations --json 2>&1 || true)
+              if [ -n "$attestations" ] && [ "$attestations" != "null" ] && [ "$attestations" != "{}" ]; then
+                echo "Provenance verified for $pkg"
+                return 0
+              fi
+              echo "Attestations for $pkg not yet visible, retrying in 15s... (elapsed ${SECONDS}s)"
+              sleep 15
+            done
+            echo "::error::Provenance attestations missing from npm for $pkg after 5 minutes"
+            return 1
+          }
           for pkg in opena2a-cli @opena2a/shared @opena2a/cli-ui @opena2a/contribute; do
-            attestations=$(npm view "$pkg" dist.attestations --json 2>/dev/null || echo "")
-            if [ -z "$attestations" ] || [ "$attestations" = "null" ]; then
-              echo "::error::Provenance attestations missing from npm for $pkg"
-              exit 1
-            fi
-            echo "Provenance verified for $pkg"
+            verify_attestations "$pkg" || exit 1
           done
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,28 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Publish cli-ui package
+        run: npm publish --workspace=packages/cli-ui --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish contribute package
+        run: npm publish --workspace=packages/contribute --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Verify provenance attached
+        run: |
+          sleep 15
+          for pkg in opena2a-cli @opena2a/shared @opena2a/cli-ui @opena2a/contribute; do
+            attestations=$(npm view "$pkg" dist.attestations --json 2>/dev/null || echo "")
+            if [ -z "$attestations" ] || [ "$attestations" = "null" ]; then
+              echo "::error::Provenance attestations missing from npm for $pkg"
+              exit 1
+            fi
+            echo "Provenance verified for $pkg"
+          done
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary
- Extends `.github/workflows/release.yml` to publish `@opena2a/cli-ui` and `@opena2a/contribute` alongside `opena2a-cli` and `@opena2a/shared`, all with `--provenance --access public`
- Adds a post-publish verification step that calls `npm view <pkg> dist.attestations` for each of the four packages and fails the run if any is empty
- Part of the cross-CLI consolidation supply-chain posture: exact version pins + npm provenance + no auto-merge on dep bumps

## Context
Recent audit showed zero of six org packages currently have SLSA attestations on npm, including `cli-ui` and `contribute`, which were previously published manually (outside any workflow). Manual `npm publish` is forbidden starting 2026-04-21.

## Test plan
- [ ] Merge this PR
- [ ] Tag `v0.9.0-provenance-test` (or similar) and push to trigger the workflow — this is step 0d of the CLI consolidation plan
- [ ] Watch the workflow: `gh run watch`
- [ ] After completion, verify all four packages: `for p in opena2a-cli @opena2a/shared @opena2a/cli-ui @opena2a/contribute; do npm view "$p" dist.attestations --json | head -c 200; done`
- [ ] Each must return non-empty with SLSA predicateType
- [ ] If any fail, debug before the next real release — likely causes: `NPM_TOKEN` scope missing cli-ui or contribute, or npm-account OIDC trust not configured for those packages