### PR TITLE
deps: npm audit fix — bump hono, picomatch, vite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2411,9 +2411,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2804,9 +2804,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3534,9 +3534,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Clean patch-level dep bumps via `npm audit fix` to resolve 3 pre-existing vulnerabilities flagged by the `dependency-audit` CI gate.
- Unblocks the gate on `main` and on PR #80 (workflow hardening) after rebase.
- No API surface changes; full monorepo build + 875 tests pass.

## Vulnerabilities fixed

| Package | Before | After | Severity | Advisory |
|---|---|---|---|---|
| hono | 4.12.12 | 4.12.14 | moderate | [GHSA-458j-xx4x-4375](https://github.com/advisories/GHSA-458j-xx4x-4375) — JSX SSR HTML injection |
| picomatch | 4.0.3 | 4.0.4 | high | [GHSA-3v7f-55p6-f55p](https://github.com/advisories/GHSA-3v7f-55p6-f55p), [GHSA-c2c7-rcm5-vvqj](https://github.com/advisories/GHSA-c2c7-rcm5-vvqj) — method injection + ReDoS |
| vite | 7.3.1 | 7.3.2 | high | [GHSA-4w7w-66w2-5vf9](https://github.com/advisories/GHSA-4w7w-66w2-5vf9), [GHSA-v2wj-q39q-566r](https://github.com/advisories/GHSA-v2wj-q39q-566r), [GHSA-p9ff-h696-f583](https://github.com/advisories/GHSA-p9ff-h696-f583) — path traversal / fs.deny bypass / arbitrary file read |

After: `npm audit --audit-level=high` reports **0 vulnerabilities**.

## Test plan

- [x] `npm audit fix` applies cleanly (patch bumps only, no major)
- [x] `npm run build` green (all 6 workspaces)
- [x] `npm test` green (875/875 tests)
- [x] `npm audit --audit-level=high` reports 0 vulnerabilities
- [ ] CI dependency-audit passes
- [ ] CI sast + license-check + Claude PR Review pass

## Rebase note

Once this merges, PR #80 (`ci/publish-cli-ui-contribute-with-provenance`) should rebase on main to pick up the lockfile update.