### PR TITLE
fix(cli): remove redundant .gitignore score deduction (0.8.24)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,14 @@
 - `guard harden` subcommand: scan skills for security issues via HackMyAgent, with `--fix` and `--dry-run` flags
 - Docker adapter configurable port mapping for `train` command (full DVAA port range)
 
+## 0.8.24
+
+### Bug Fixes
+- Scoring: removed redundant 8-point deduction for missing `.gitignore` in the configuration category. HackMyAgent already covers this at LOW severity; the overlay was double-counting and caused `opena2a scan` to disagree with `hackmyagent secure` on the same target (95 MEDIUM vs 98 LOW). Users will see the same score climb from 95 to 98 on the reference fixture. The `.gitignore` hygiene check itself still reports `warn` when missing, so the item remains visible in the checks list.
+
+### Notes
+- First opena2a-cli release published via tag-triggered GitHub Actions workflow with npm provenance attestations (SLSA). Verify: `npm view opena2a-cli dist.attestations --json`.
+
 ## 0.8.23
 
 ### Bug Fixes

--- a/packages/cli/__tests__/commands/security-score.test.ts
+++ b/packages/cli/__tests__/commands/security-score.test.ts
@@ -95,14 +95,33 @@ describe('calculateSecurityScore', () => {
       [
         { label: '.gitignore', status: 'warn' as const, detail: 'missing' },
         { label: '.env protection', status: 'warn' as const, detail: 'NOT in .gitignore' },
-        { label: 'Lock file', status: 'pass' as const, detail: 'package-lock.json' },
+        { label: 'Lock file', status: 'warn' as const, detail: 'none found' },
         { label: 'Security config', status: 'info' as const, detail: 'none' },
       ],
     );
     expect(breakdown.credentials.detail).toContain('critical');
     expect(breakdown.credentials.detail).toContain('high');
     expect(breakdown.environment.detail).toContain('.env unprotected');
-    expect(breakdown.configuration.detail).toContain('no .gitignore');
+    expect(breakdown.configuration.detail).toContain('no lock file');
+  });
+
+  it('missing .gitignore does not deduct (HMA covers this at LOW, 0.8.24)', () => {
+    const withGitignore = [
+      { label: 'Credential scan', status: 'pass' as const, detail: 'no findings' },
+      { label: '.gitignore', status: 'pass' as const, detail: 'present' },
+      { label: '.env protection', status: 'pass' as const, detail: 'in .gitignore' },
+      { label: 'Lock file', status: 'pass' as const, detail: 'package-lock.json' },
+      { label: 'Security config', status: 'pass' as const, detail: '.opena2a.yaml' },
+    ];
+    const withoutGitignore = [
+      ...withGitignore.filter(c => c.label !== '.gitignore' && c.label !== '.env protection'),
+      { label: '.gitignore', status: 'warn' as const, detail: 'missing' },
+      { label: '.env protection', status: 'pass' as const, detail: 'in .gitignore' },
+    ];
+    const a = calculateSecurityScore({}, withGitignore);
+    const b = calculateSecurityScore({}, withoutGitignore);
+    expect(b.breakdown.configuration.deduction).toBe(a.breakdown.configuration.deduction);
+    expect(b.breakdown.configuration.detail).not.toContain('.gitignore');
   });
 
   it('includes MCP high-risk tools in environment deduction (+5)', () => {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opena2a-cli",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "Unified CLI for the OpenA2A security platform",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/src/util/scoring.ts
+++ b/packages/cli/src/util/scoring.ts
@@ -89,9 +89,10 @@ export function calculateSecurityScore(
   const envDetail = envDetails.length > 0 ? envDetails.join(', ') : 'clean';
 
   // --- Configuration category (cap at -15, bonus up to +5) ---
+  // .gitignore deduction removed in 0.8.24: HMA already covers this at LOW
+  // severity. Double-counting caused opena2a scan to disagree with hackmyagent
+  // secure (98 LOW vs 95 MEDIUM) on the same target.
   let configDeduction = 0;
-  const gitignoreCheck = checks.find(c => c.label === '.gitignore');
-  if (gitignoreCheck?.status !== 'pass') configDeduction += 8;
 
   const lockCheck = checks.find(c => c.label === 'Lock file');
   if (lockCheck?.status !== 'pass') configDeduction += 4;
@@ -106,7 +107,6 @@ export function calculateSecurityScore(
   configDeduction = Math.min(configDeduction, 15); // category cap
 
   const configDetails: string[] = [];
-  if (gitignoreCheck?.status !== 'pass') configDetails.push('no .gitignore');
   if (lockCheck?.status !== 'pass') configDetails.push('no lock file');
   if (secConfig?.status !== 'pass') configDetails.push('no security config');
   if (configBonus > 0) configDetails.push('security config present');


### PR DESCRIPTION
## Summary

- Removes the 8-point `.gitignore` deduction in `packages/cli/src/util/scoring.ts`. HackMyAgent already reports missing `.gitignore` at LOW severity; the overlay was double-counting.
- Closes the user-visible divergence: `opena2a init/protect/review` vs `hackmyagent secure` on the same target (95 MEDIUM vs 98 LOW on the ibm-mcp fixture) now agree.
- The `.gitignore` hygiene check still reports `warn` when missing, so the item remains visible in the hygiene list — only the double-counted score penalty is gone.
- Bumps \`opena2a-cli\` to \`0.8.24\`. First release intended to publish via the new tag-triggered workflow with npm provenance attestations (step 1 of the CLI consolidation plan).

## Test plan

- [x] \`npm run build\` green across all 6 workspaces
- [x] \`npm test\` — 876 tests pass (875 existing + 1 new regression test codifying the fix)
- [x] New regression test: \`calculateSecurityScore produces the same configuration deduction whether .gitignore is present or missing\`
- [x] Updated existing \`returns breakdown with detail strings\` test to assert on \`no lock file\` instead of the removed \`no .gitignore\` detail
- [ ] Tag-trigger publish path verified end-to-end (post-merge step)
- [ ] \`npm view opena2a-cli dist.attestations --json\` returns non-empty SLSA provenance after publish (post-merge step)

## Refs

- Plan: \`opena2a-org/briefs/cli-consolidation.md\` step 1
- Depends on: PR #80 (tag-triggered workflow with provenance) merged to main for the attestations to attach
- Depends on: PR #81 (npm audit fix — hono/picomatch/vite) merged to main for CI dependency-audit to pass