### PR TITLE
ci: make monorepo publish workflow idempotent per-package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,27 +34,38 @@ jobs:
 
       - run: npm run test
 
-      - name: Publish CLI package
-        run: npm publish --workspace=packages/cli --provenance --access public
+      - name: Publish packages (idempotent — skips if version already on npm)
+        id: publish
+        run: |
+          set -e
+          : > /tmp/published.txt
+          : > /tmp/skipped.txt
+          publish_if_new() {
+            local ws="$1"
+            local pkg="$2"
+            local ver
+            ver=$(node -p "require('./$ws/package.json').version")
+            if npm view "$pkg@$ver" version >/dev/null 2>&1; then
+              echo "::notice::$pkg@$ver already on npm — skipping publish"
+              echo "$pkg" >> /tmp/skipped.txt
+            else
+              echo "Publishing $pkg@$ver with provenance..."
+              npm publish --workspace="$ws" --provenance --access public
+              echo "$pkg" >> /tmp/published.txt
+            fi
+          }
+          publish_if_new packages/cli opena2a-cli
+          publish_if_new packages/shared @opena2a/shared
+          publish_if_new packages/cli-ui @opena2a/cli-ui
+          publish_if_new packages/contribute @opena2a/contribute
+          echo "=== Published this run ==="
+          cat /tmp/published.txt
+          echo "=== Skipped (version already on npm) ==="
+          cat /tmp/skipped.txt
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish shared package
-        run: npm publish --workspace=packages/shared --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish cli-ui package
-        run: npm publish --workspace=packages/cli-ui --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish contribute package
-        run: npm publish --workspace=packages/contribute --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Verify provenance attached
+      - name: Verify provenance on newly-published packages
         run: |
           verify_attestations() {
             local pkg="$1"
@@ -72,9 +83,13 @@ jobs:
             echo "::error::Provenance attestations missing from npm for $pkg after 5 minutes"
             return 1
           }
-          for pkg in opena2a-cli @opena2a/shared @opena2a/cli-ui @opena2a/contribute; do
+          if [ ! -s /tmp/published.txt ]; then
+            echo "No packages published this run — nothing to verify."
+            exit 0
+          fi
+          while IFS= read -r pkg; do
             verify_attestations "$pkg" || exit 1
-          done
+          done < /tmp/published.txt
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

- The tag-triggered release workflow previously ran \`npm publish\` unconditionally on all 4 monorepo packages. If only one needed a new version (e.g. canary-tagging \`@opena2a/shared\` for step 0d of the CLI consolidation plan), the other three failed with \"cannot publish over existing version\" and stopped the workflow before provenance verification ran.
- Replaces the 4 separate publish steps with one idempotent step that checks each package's local version against npm and skips if already published. The verify step then only polls for attestations on packages this run actually pushed.

## Before / after

| Scenario | Before | After |
|---|---|---|
| First ship after all-new versions | publishes 4, verifies 4 | publishes 4, verifies 4 (same) |
| Canary: only shared bumped | publishes cli, fails on shared duplicate, never verifies | skips cli/cli-ui/contribute, publishes shared, verifies shared |
| Retry a failed run | cli publish fails on duplicate, no recovery | cli skipped, other failed packages retry |

## Test plan

- [x] YAML syntax valid (\`python3 -c \"import yaml; yaml.safe_load(open(...))\"\`)
- [x] Verify step correctly skips when \`/tmp/published.txt\` is empty (dry-logic check)
- [ ] CI \`review\`, \`sast\`, \`license-check\`, \`dependency-audit\` green
- [ ] First real tag after merge publishes only packages with a bumped version

## Why this blocks step 0d

The CLI consolidation plan's step 0d is a canary publish of \`@opena2a/shared\` (simplest package) to confirm attestations attach before shipping \`opena2a-cli@0.8.24\` on the same workflow. Without idempotency, the canary inevitably publishes opena2a-cli too — conflating the canary with the hotfix. This PR restores the canary's isolation.

## Refs

- Plan: \`opena2a-org/briefs/cli-consolidation.md\` step 0d / step 1
- Related PRs: #80 (workflow baseline, merged), #82 (0.8.24 hotfix, merged), #81 (npm audit fix, merged)