### PR TITLE
canary: @opena2a/shared 0.1.2 — step 0d provenance validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3911,7 +3911,7 @@
     },
     "packages/shared": {
       "name": "@opena2a/shared",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.24.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opena2a-cli",
-  "version": "0.8.24",
+  "version": "0.8.23",
   "description": "Unified CLI for the OpenA2A security platform",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/shared",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Shared types, config schema, and utilities for the OpenA2A platform",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

First tag of the new idempotent release workflow (#83). Isolates \`@opena2a/shared\` as the canary package so npm provenance attachment is verified on the lowest-blast-radius package **before** shipping the user-visible \`opena2a-cli@0.8.24\` hotfix (which is already merged as code on main, just not yet tagged).

## What this PR changes

- \`packages/shared/package.json\`: \`0.1.1\` -> \`0.1.2\`
- \`packages/cli/package.json\`: \`0.8.24\` -> \`0.8.23\` *(temporary revert to isolate shared on the canary tag; a follow-up PR re-bumps to 0.8.24 after canary passes)*
- \`package-lock.json\`: version bump

## Workflow behavior on the \`v0.1.2\` tag

| Package | Local | npm | Action |
|---|---|---|---|
| opena2a-cli | 0.8.23 | 0.8.23 | Skipped |
| @opena2a/shared | 0.1.2 | 0.1.1 | **Published with \`--provenance\`** |
| @opena2a/cli-ui | 0.1.0 | 0.1.0 | Skipped |
| @opena2a/contribute | 0.1.1 | 0.1.1 | Skipped |

Verify step polls only \`@opena2a/shared\` for attestations (5 min window).

## Why path Y over path X

\`opena2a-cli\` is the most user-visible package in the monorepo. If npm org OIDC trust is misconfigured for the @opena2a scope, \`npm publish --provenance\` could either error before publishing (fail closed, good) or publish without attestations (fail open, bad). We have not verified OIDC trust is configured pre-tag, so shipping the canary on \`@opena2a/shared\` first surfaces any config gap on the low-stakes package.

## Test plan

- [x] \`npm run build\` green across 6 workspaces
- [x] \`npm test\` green (876/876)
- [x] \`npm audit --audit-level=high\`: 0 vulnerabilities
- [ ] CI green
- [ ] Merge + tag \`v0.1.2\` -> workflow publishes only \`@opena2a/shared@0.1.2\`
- [ ] \`npm view @opena2a/shared dist.attestations --json\` returns non-empty with SLSA predicateType
- [ ] Follow-up PR re-bumps \`opena2a-cli\` to 0.8.24 -> tag \`v0.8.24\` -> step 1 ships

## Refs

- Plan: \`opena2a-org/briefs/cli-consolidation.md\` step 0d
- Related: #80 (workflow baseline), #81 (deps), #82 (0.8.24 hotfix code), #83 (idempotent workflow)