### PR TITLE
release: opena2a-cli 0.8.24 + @opena2a/shared 0.1.2 via OIDC Trusted Publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3836,7 +3836,7 @@
     },
     "packages/cli": {
       "name": "opena2a-cli",
-      "version": "0.8.23",
+      "version": "0.8.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opena2a-cli",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "Unified CLI for the OpenA2A security platform",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Re-bumps \`opena2a-cli\` from 0.8.23 to 0.8.24 (restoring what PR #82 shipped and PR #84 temporarily reverted for canary isolation). With Trusted Publishers now configured for all 6 Stage 1 packages on npmjs.com, a single \`v0.8.24\` tag will complete **step 0d** (provenance canary) and **step 1** (0.8.24 user-visible hotfix) in one event.

## Workflow behavior on the v0.8.24 tag

| Package | Local | npm | Action |
|---|---|---|---|
| opena2a-cli | 0.8.24 | 0.8.23 | **Published via OIDC** |
| @opena2a/shared | 0.1.2 | 0.1.1 | **Published via OIDC** |
| @opena2a/cli-ui | 0.1.0 | 0.1.0 | Skipped |
| @opena2a/contribute | 0.1.1 | 0.1.1 | Skipped |

Verify step polls \`@opena2a/shared\` and \`opena2a-cli\` for SLSA attestations with a 5-minute deadline per package. Neither package has ever successfully published via the new tag-triggered workflow, so this is the end-to-end proof for both TPs.

## Why two packages at once

- Each TP config is an independent binding. Both need testing.
- \`@opena2a/shared@0.1.2\` is already in \`main\` from PR #84 and has never been published — it needs to go.
- cli@0.8.24 is the hotfix the CLI consolidation plan has been aiming at since session start.
- Publishing both together is equal risk to publishing them separately, but saves a tag cycle.

## If OIDC fails on either package

The idempotent workflow records per-package success/skip/fail. A partial failure (e.g. cli succeeds, shared fails) would still:
- Attach attestations to whatever published
- Fail the workflow cleanly at the first error
- Leave the unpublished package at its current on-npm version (nothing corrupted)

We'd then fix the misconfigured TP and re-tag \`v0.8.24-retry\` — the idempotent workflow would skip the already-published package and retry the failing one.

## Test plan

- [x] Build green across all 6 workspaces
- [x] 876/876 tests pass
- [x] \`npm audit --audit-level=high\` — 0 vulnerabilities
- [ ] CI green on PR
- [ ] Merge + tag \`v0.8.24\`
- [ ] Workflow publishes both packages via OIDC (no NPM_TOKEN in env)
- [ ] \`npm view opena2a-cli dist.attestations --json\` returns SLSA provenance
- [ ] \`npm view @opena2a/shared dist.attestations --json\` returns SLSA provenance
- [ ] Follow-up: homebrew-tap formula bump for opena2a-cli 0.8.24

## Refs

- Plan: \`opena2a-org/briefs/cli-consolidation.md\` step 0d / step 1
- Related merged PRs: #27, #28, #80, #81, #82, #83, #84, #85, #106, #107