### PR TITLE
ci(release): per-package tag triggers + wire @opena2a/ai-classifier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+      - 'cli-v*'
+      - 'shared-v*'
+      - 'cli-ui-v*'
+      - 'contribute-v*'
+      - 'aim-core-v*'
+      - 'ai-classifier-v*'
 
 permissions:
   contents: write
@@ -58,6 +64,12 @@ jobs:
           publish_if_new packages/shared @opena2a/shared
           publish_if_new packages/cli-ui @opena2a/cli-ui
           publish_if_new packages/contribute @opena2a/contribute
+          publish_if_new packages/ai-classifier @opena2a/ai-classifier
+          # TODO(trusted-publishing-stage2): uncomment once @opena2a/aim-core
+          # has a Trusted Publisher configured on npmjs.com and the 0.1.2 -> 0.2.0
+          # migration from hackmyagent is signed off. Leaving commented prevents
+          # aim-core 0.2.0 from auto-publishing (and failing) on the next v* tag.
+          # publish_if_new packages/aim-core @opena2a/aim-core
           echo "=== Published this run ==="
           cat /tmp/published.txt
           echo "=== Skipped (version already on npm) ==="


### PR DESCRIPTION
## Summary
- Expand release.yml tag triggers to include `cli-v*`, `shared-v*`, `cli-ui-v*`, `contribute-v*`, `aim-core-v*`, `ai-classifier-v*` so the per-package convention is no longer blocked by the `v0.1.2` collision hit on 2026-04-21 (workaround `v0.1.2-shared-canary`).
- Add `@opena2a/ai-classifier` to `publish_if_new`. Already at 0.1.0 on npm so this line no-ops until the next real bump.
- Leave `@opena2a/aim-core` commented with a TODO: local is 0.2.0 vs npm 0.1.2, and TP config needs to land on npmjs.com first, and the 0.2.0 bump from hackmyagent needs explicit sign-off.

## Test plan
- [ ] Merge with no tag pushed — no release runs
- [ ] Push `ai-classifier-v0.1.0-test` to confirm `publish_if_new` skips the already-published version
- [ ] Watch workflow logs for "already on npm — skipping publish" on 5 of 5 packages
