### PR TITLE
feat(cli-ui): export observations + analyst-render for shared CLI use

### DIFF
--- a/packages/cli-ui/package.json
+++ b/packages/cli-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opena2a/cli-ui",
-  "version": "0.1.0",
-  "description": "Shared terminal UI primitives for OpenA2A CLIs (score meter, trust level legend, verdict colors)",
+  "version": "0.2.0",
+  "description": "Shared terminal UI primitives for OpenA2A CLIs (score meter, trust level legend, verdict colors, observations + verdict block, analyst-render)",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli-ui/src/analyst-render.test.ts
+++ b/packages/cli-ui/src/analyst-render.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isRenderableAnalystFinding,
+  formatAnalystDescription,
+  capAnalystThreatLevel,
+  formatAnalystConfidence,
+  LOW_CONFIDENCE_CAP,
+} from './analyst-render.js';
+
+describe('isRenderableAnalystFinding', () => {
+  it('drops below-confidence entries', () => {
+    expect(isRenderableAnalystFinding({
+      confidence: 0.4,
+      taskType: 'threatAnalysis',
+      result: { threatLevel: 'CRITICAL' },
+    })).toBe(false);
+  });
+
+  it('drops threatAnalysis with NONE level (orphan-level bug)', () => {
+    expect(isRenderableAnalystFinding({
+      confidence: 0.9,
+      taskType: 'threatAnalysis',
+      result: { threatLevel: 'NONE' },
+    })).toBe(false);
+  });
+
+  it('drops threatAnalysis with LOW and INFO levels', () => {
+    for (const lvl of ['LOW', 'low', 'INFO', 'info']) {
+      expect(isRenderableAnalystFinding({
+        confidence: 0.9,
+        taskType: 'threatAnalysis',
+        result: { threatLevel: lvl },
+      })).toBe(false);
+    }
+  });
+
+  it('keeps CRITICAL, HIGH, MEDIUM threatAnalysis entries', () => {
+    for (const lvl of ['CRITICAL', 'HIGH', 'MEDIUM']) {
+      expect(isRenderableAnalystFinding({
+        confidence: 0.9,
+        taskType: 'threatAnalysis',
+        result: { threatLevel: lvl },
+      })).toBe(true);
+    }
+  });
+
+  it('keeps non-threatAnalysis task types regardless of level', () => {
+    expect(isRenderableAnalystFinding({
+      confidence: 0.6,
+      taskType: 'credentialContextClassification',
+      result: { classification: 'test' },
+    })).toBe(true);
+    expect(isRenderableAnalystFinding({
+      confidence: 0.6,
+      taskType: 'intelReport',
+      result: {},
+    })).toBe(true);
+  });
+});
+
+describe('formatAnalystDescription', () => {
+  it('drops markdown header lines entirely (not just the #)', () => {
+    const raw = '## Analysis\n\nThis artifact is a context-purpose mismatch attack.';
+    const { text } = formatAnalystDescription(raw, { verbose: false });
+    expect(text).toBe('This artifact is a context-purpose mismatch attack.');
+    expect(text).not.toContain('Analysis');
+    expect(text).not.toContain('##');
+  });
+
+  it('handles multiple header levels', () => {
+    const raw = '# Title\n## Section\n### Subsection\n\nBody text here.';
+    const { text } = formatAnalystDescription(raw, { verbose: false });
+    expect(text).toBe('Body text here.');
+  });
+
+  it('collapses blank lines to an em-dash separator', () => {
+    const raw = 'First paragraph.\n\nSecond paragraph.';
+    const { text } = formatAnalystDescription(raw, { verbose: false });
+    expect(text).toBe('First paragraph. — Second paragraph.');
+  });
+
+  it('collapses single newlines to spaces (wrapped prose)', () => {
+    const raw = 'A long sentence\nthat wraps onto\nmultiple lines.';
+    const { text } = formatAnalystDescription(raw, { verbose: false });
+    expect(text).toBe('A long sentence that wraps onto multiple lines.');
+  });
+
+  it('strips bold markers', () => {
+    const raw = 'This is **important** and **critical**.';
+    const { text } = formatAnalystDescription(raw, { verbose: false });
+    expect(text).toBe('This is important and critical.');
+  });
+
+  it('truncates at 240 chars with ellipsis when not verbose', () => {
+    const raw = 'word '.repeat(100).trim(); // 499 chars
+    const { text, truncated } = formatAnalystDescription(raw, { verbose: false });
+    expect(truncated).toBe(true);
+    expect(text.length).toBe(240);
+    expect(text.endsWith('...')).toBe(true);
+  });
+
+  it('does not truncate when verbose', () => {
+    const raw = 'word '.repeat(100).trim();
+    const { text, truncated } = formatAnalystDescription(raw, { verbose: true });
+    expect(truncated).toBe(false);
+    expect(text).toBe(raw);
+  });
+
+  it('respects custom maxLen', () => {
+    const raw = 'word '.repeat(20).trim();
+    const { text, truncated } = formatAnalystDescription(raw, { verbose: false, maxLen: 30 });
+    expect(truncated).toBe(true);
+    expect(text.length).toBe(30);
+  });
+
+  it('real-world reproducer: header + description does not produce orphan "Analysis"', () => {
+    // This is the exact shape the user hit on /tmp/hma-real-world/ibm-mcp/
+    const raw = '## Analysis\n\nThis artifact is a context-purpose mismatch attack disguised as a legitimate agent configuration. The artifact contains a hidden malicious payload that redirects tool output to an attacker-controlled endpoint.';
+    const { text, truncated } = formatAnalystDescription(raw, { verbose: false });
+    expect(text.startsWith('This artifact')).toBe(true);
+    expect(text).not.toMatch(/^Analysis/);
+    // The full prose fits under 240; confirm no truncation.
+    expect(truncated).toBe(false);
+  });
+
+  it('returns empty string when input is empty', () => {
+    const { text, truncated } = formatAnalystDescription('', { verbose: false });
+    expect(text).toBe('');
+    expect(truncated).toBe(false);
+  });
+
+  it('returns empty string when input is only headers', () => {
+    const { text } = formatAnalystDescription('## Header\n### Another\n', { verbose: false });
+    expect(text).toBe('');
+  });
+});
+
+describe('capAnalystThreatLevel', () => {
+  it('caps CRITICAL to HIGH when confidence is below the calibration threshold', () => {
+    // Real-world reproducer: NanoMind emits CRITICAL with hardcoded 60% confidence.
+    const { level, capped } = capAnalystThreatLevel('CRITICAL', 0.60);
+    expect(level).toBe('HIGH');
+    expect(capped).toBe(true);
+  });
+
+  it('preserves CRITICAL when confidence meets the threshold', () => {
+    const { level, capped } = capAnalystThreatLevel('CRITICAL', LOW_CONFIDENCE_CAP);
+    expect(level).toBe('CRITICAL');
+    expect(capped).toBe(false);
+  });
+
+  it('preserves CRITICAL when confidence is above the threshold', () => {
+    const { level, capped } = capAnalystThreatLevel('CRITICAL', 0.95);
+    expect(level).toBe('CRITICAL');
+    expect(capped).toBe(false);
+  });
+
+  it('does not cap HIGH at any confidence (only CRITICAL is capped)', () => {
+    for (const conf of [0.30, 0.60, 0.79, 0.85]) {
+      const { level, capped } = capAnalystThreatLevel('HIGH', conf);
+      expect(level).toBe('HIGH');
+      expect(capped).toBe(false);
+    }
+  });
+
+  it('does not cap MEDIUM or LOW at low confidence', () => {
+    for (const lvl of ['MEDIUM', 'LOW', 'INFO']) {
+      const { level, capped } = capAnalystThreatLevel(lvl, 0.40);
+      expect(level).toBe(lvl);
+      expect(capped).toBe(false);
+    }
+  });
+
+  it('normalizes case and treats lowercase critical the same as uppercase', () => {
+    const { level, capped } = capAnalystThreatLevel('critical', 0.60);
+    expect(level).toBe('HIGH');
+    expect(capped).toBe(true);
+  });
+
+  it('returns unknown when threatLevel is missing', () => {
+    const { level, capped } = capAnalystThreatLevel(undefined, 0.95);
+    expect(level).toBe('UNKNOWN');
+    expect(capped).toBe(false);
+  });
+});
+
+describe('formatAnalystConfidence', () => {
+  it('shows numeric % when confidence meets the threshold', () => {
+    const { label, numeric } = formatAnalystConfidence(0.85);
+    expect(label).toBe('85%');
+    expect(numeric).toBe(true);
+  });
+
+  it('shows numeric % at the threshold boundary (>= cap is numeric)', () => {
+    const { label, numeric } = formatAnalystConfidence(LOW_CONFIDENCE_CAP);
+    expect(label).toBe('80%');
+    expect(numeric).toBe(true);
+  });
+
+  it('shows qualitative label when confidence is below the threshold', () => {
+    // 60% is the hardcoded value the audit found on 14/14 findings.
+    const { label, numeric } = formatAnalystConfidence(0.60);
+    expect(label).toBe('low confidence');
+    expect(numeric).toBe(false);
+  });
+
+  it('shows qualitative label just below the threshold', () => {
+    const { label, numeric } = formatAnalystConfidence(0.79);
+    expect(label).toBe('low confidence');
+    expect(numeric).toBe(false);
+  });
+
+  it('rounds the numeric % rather than truncating', () => {
+    const { label } = formatAnalystConfidence(0.876);
+    expect(label).toBe('88%');
+  });
+});

--- a/packages/cli-ui/src/analyst-render.ts
+++ b/packages/cli-ui/src/analyst-render.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure helpers for rendering NanoMind generative findings in scan output.
+ *
+ * Shared across hackmyagent, opena2a-cli, ai-trust per [CA-030]. Zero
+ * runtime deps — callers apply colors and wrapping. Transformations
+ * stay isolated from the render pipeline so they can be unit-tested
+ * without spinning up a full scan.
+ */
+
+export interface AnalystFindingLike {
+  confidence: number;
+  taskType: string;
+  result: {
+    threatLevel?: string;
+    [key: string]: unknown;
+  };
+}
+
+/**
+ * A finding is renderable when it meets the confidence gate AND, for
+ * threatAnalysis specifically, reports a severity above the noise floor.
+ * Everything else falls through to the taskType-specific branches.
+ */
+export function isRenderableAnalystFinding(af: AnalystFindingLike): boolean {
+  if (af.confidence < 0.50) return false;
+  if (af.taskType === 'threatAnalysis') {
+    const lvl = String(af.result.threatLevel ?? 'unknown').toUpperCase();
+    if (lvl === 'LOW' || lvl === 'INFO' || lvl === 'NONE') return false;
+  }
+  return true;
+}
+
+/** Confidence threshold below which a CRITICAL claim is downgraded to HIGH. */
+export const LOW_CONFIDENCE_CAP = 0.80;
+
+/**
+ * Cap CRITICAL severity to HIGH when confidence is below the calibration
+ * threshold. The model emits CRITICAL on findings with hardcoded ~60%
+ * confidence, which is not enough evidence to scream the loudest severity.
+ */
+export function capAnalystThreatLevel(
+  rawLevel: string | undefined,
+  confidence: number,
+): { level: string; capped: boolean } {
+  const upper = String(rawLevel ?? 'unknown').toUpperCase();
+  if (confidence < LOW_CONFIDENCE_CAP && upper === 'CRITICAL') {
+    return { level: 'HIGH', capped: true };
+  }
+  return { level: upper, capped: false };
+}
+
+/**
+ * Render confidence as a number when it crosses the calibration threshold,
+ * and as a qualitative label otherwise. Avoids displaying a hardcoded value
+ * (e.g. exactly 60% on every finding) as if it were a real measurement.
+ */
+export function formatAnalystConfidence(
+  confidence: number,
+): { label: string; numeric: boolean } {
+  if (confidence >= LOW_CONFIDENCE_CAP) {
+    return { label: `${Math.round(confidence * 100)}%`, numeric: true };
+  }
+  return { label: 'low confidence', numeric: false };
+}
+
+export interface FormattedDescription {
+  text: string;
+  truncated: boolean;
+}
+
+/**
+ * Normalize an LLM-generated markdown description for terminal output.
+ *
+ * LLMs often produce "## Analysis\n\nThis artifact is..." — rendering that
+ * raw puts "Analysis" on its own orphan line and wastes vertical space. This:
+ *   - drops entire header lines (not just the # chars)
+ *   - drops bold markers
+ *   - collapses blank lines to an em-dash separator
+ *   - collapses single newlines to spaces
+ *   - caps length for non-verbose callers
+ */
+export function formatAnalystDescription(
+  raw: string,
+  opts: { verbose: boolean; maxLen?: number } = { verbose: false }
+): FormattedDescription {
+  const maxLen = opts.maxLen ?? 240;
+  const cleaned = String(raw)
+    .replace(/^#{1,6}\s+[^\n]*\n+/gm, '')
+    .replace(/\*\*/g, '')
+    .replace(/\s*\n\s*\n\s*/g, ' — ')
+    .replace(/\s*\n\s*/g, ' ')
+    .trim();
+  if (opts.verbose || cleaned.length <= maxLen) {
+    return { text: cleaned, truncated: false };
+  }
+  return { text: cleaned.slice(0, maxLen - 3) + '...', truncated: true };
+}

--- a/packages/cli-ui/src/index.ts
+++ b/packages/cli-ui/src/index.ts
@@ -21,3 +21,29 @@ export {
   type TrustLevel,
 } from "./trust-level.js";
 export { formatScanAge } from "./scan-age.js";
+export {
+  buildCategorySummaries,
+  buildVerdict,
+  classifyCategory,
+  renderObservationsBlock,
+  ALL_CATEGORY_LABELS,
+  type ArtifactLine,
+  type CategorizableFinding,
+  type CategorySummary,
+  type ChecksSummary,
+  type ObservationsInput,
+  type RenderedLine,
+  type RenderedObservations,
+  type SurfaceSummary,
+  type VerdictFinding,
+  type VerdictStatus,
+} from "./observations.js";
+export {
+  isRenderableAnalystFinding,
+  formatAnalystDescription,
+  capAnalystThreatLevel,
+  formatAnalystConfidence,
+  LOW_CONFIDENCE_CAP,
+  type AnalystFindingLike,
+  type FormattedDescription,
+} from "./analyst-render.js";

--- a/packages/cli-ui/src/observations.test.ts
+++ b/packages/cli-ui/src/observations.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildCategorySummaries,
+  buildVerdict,
+  classifyCategory,
+  renderObservationsBlock,
+  ALL_CATEGORY_LABELS,
+  type CategorizableFinding,
+} from './observations.js';
+
+function finding(over: Partial<CategorizableFinding>): CategorizableFinding {
+  return {
+    checkId: '',
+    name: '',
+    category: '',
+    severity: 'low',
+    passed: false,
+    ...over,
+  };
+}
+
+describe('classifyCategory', () => {
+  it('classifies by checkId prefix', () => {
+    expect(classifyCategory(finding({ checkId: 'CRED-001' }))).toBe('credentials');
+    expect(classifyCategory(finding({ checkId: 'MCP-003' }))).toBe('MCP');
+    expect(classifyCategory(finding({ checkId: 'NEMO-007' }))).toBe('sandbox-escape');
+    expect(classifyCategory(finding({ checkId: 'AST-GOV-004' }))).toBe('governance');
+    expect(classifyCategory(finding({ checkId: 'UNICODE-STEGO-001' }))).toBe('unicode-stego');
+  });
+
+  it('falls back to name/category keywords when checkId has no known prefix', () => {
+    expect(
+      classifyCategory(finding({ checkId: 'X', name: 'Hardcoded API key in source' })),
+    ).toBe('credentials');
+    expect(
+      classifyCategory(finding({ checkId: 'X', category: 'mcp-config' })),
+    ).toBe('MCP');
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(classifyCategory(finding({ checkId: 'UNKNOWN-XYZ', name: 'Nothing to see' }))).toBeNull();
+  });
+});
+
+describe('buildCategorySummaries', () => {
+  it('marks all categories clear for zero findings', () => {
+    const summaries = buildCategorySummaries([]);
+    expect(summaries.length).toBeGreaterThanOrEqual(ALL_CATEGORY_LABELS.length);
+    for (const s of summaries) {
+      expect(s.clear).toBe(true);
+      expect(s.counts.critical + s.counts.high + s.counts.medium + s.counts.low).toBe(0);
+    }
+  });
+
+  it('counts severity for matching findings and marks matched category dirty', () => {
+    const summaries = buildCategorySummaries([
+      finding({ checkId: 'CRED-001', severity: 'critical' }),
+      finding({ checkId: 'CRED-002', severity: 'critical' }),
+      finding({ checkId: 'MCP-003', severity: 'high' }),
+    ]);
+    const cred = summaries.find(s => s.name === 'credentials')!;
+    const mcp = summaries.find(s => s.name === 'MCP')!;
+    const network = summaries.find(s => s.name === 'network')!;
+    expect(cred.clear).toBe(false);
+    expect(cred.counts.critical).toBe(2);
+    expect(mcp.clear).toBe(false);
+    expect(mcp.counts.high).toBe(1);
+    expect(network.clear).toBe(true);
+  });
+
+  it('groups unrecognized findings into "other" bucket', () => {
+    const summaries = buildCategorySummaries([
+      finding({ checkId: 'UNKNOWN-999', severity: 'critical' }),
+    ]);
+    const other = summaries.find(s => s.name === 'other');
+    expect(other).toBeDefined();
+    expect(other!.clear).toBe(false);
+    expect(other!.counts.critical).toBe(1);
+  });
+
+  it('ignores passed findings', () => {
+    const summaries = buildCategorySummaries([
+      finding({ checkId: 'CRED-001', severity: 'critical', passed: true }),
+    ]);
+    const cred = summaries.find(s => s.name === 'credentials')!;
+    expect(cred.clear).toBe(true);
+    expect(cred.counts.critical).toBe(0);
+  });
+});
+
+describe('buildVerdict', () => {
+  it('unsafe verdict names the lead critical finding with file:line', () => {
+    const v = buildVerdict(
+      { critical: 3, high: 0, medium: 0, low: 0 },
+      { kind: 'library' },
+      [
+        { severity: 'critical', name: 'Hardcoded API key', file: '.env', line: 3 },
+        { severity: 'critical', name: 'Weak PERM', file: 'config.json' },
+        { severity: 'critical', name: 'Open Port', file: 'server.ts' },
+      ],
+    );
+    expect(v.status).toBe('unsafe');
+    expect(v.message).toContain('Hardcoded API key in .env:3');
+    expect(v.message).toContain('+ 2 more');
+    expect(v.message).toContain('production');
+  });
+
+  it('unsafe verdict on high names the lead high finding', () => {
+    const v = buildVerdict(
+      { critical: 0, high: 2, medium: 0, low: 0 },
+      { kind: 'library' },
+      [
+        { severity: 'high', name: 'Unsafe eval', file: 'deploy.skill.md', line: 4 },
+        { severity: 'high', name: 'Broad MCP scope', file: 'mcp.json' },
+      ],
+    );
+    expect(v.status).toBe('unsafe');
+    expect(v.message).toContain('Unsafe eval in deploy.skill.md:4');
+    expect(v.message).toContain('+ 1 more');
+  });
+
+  it('needs-fix verdict names the lead medium/low finding', () => {
+    const v = buildVerdict(
+      { critical: 0, high: 0, medium: 2, low: 3 },
+      { kind: 'library' },
+      [
+        { severity: 'medium', name: 'Missing audit log', file: 'app.ts' },
+        { severity: 'medium', name: 'Weak rate limit', file: 'api.ts' },
+        { severity: 'low', name: 'Missing .gitignore', file: '.gitignore' },
+        { severity: 'low', name: 'Broad perms', file: 'config.json' },
+        { severity: 'low', name: 'No audit trail', file: 'log.ts' },
+      ],
+    );
+    expect(v.status).toBe('needs-fix');
+    expect(v.message).toContain('Missing audit log in app.ts');
+    expect(v.message).toContain('+ 4 more');
+    expect(v.message).toContain('secure --fix');
+  });
+
+  it('safe verdict on zero findings', () => {
+    const v = buildVerdict({ critical: 0, high: 0, medium: 0, low: 0 }, { kind: 'library' });
+    expect(v.status).toBe('safe');
+    expect(v.message).toMatch(/safe to use/i);
+    expect(v.message).toContain('library');
+  });
+
+  it('safe verdict falls back to "project" when kind is unknown', () => {
+    const v = buildVerdict({ critical: 0, high: 0, medium: 0, low: 0 }, { kind: 'unknown' });
+    expect(v.message).toContain('project');
+  });
+
+  it('falls back to severity-count when findings array not passed', () => {
+    const v = buildVerdict({ critical: 2, high: 0, medium: 0, low: 0 }, { kind: 'library' });
+    expect(v.status).toBe('unsafe');
+    expect(v.message).toContain('2 critical');
+  });
+
+  it('falls back to checkId when finding name is empty', () => {
+    const v = buildVerdict(
+      { critical: 1, high: 0, medium: 0, low: 0 },
+      { kind: 'library' },
+      [{ severity: 'critical', checkId: 'CRED-001', file: 'secret.ts' }],
+    );
+    expect(v.message).toContain('CRED-001 in secret.ts');
+  });
+
+  it('no extra count when there is exactly one finding', () => {
+    const v = buildVerdict(
+      { critical: 1, high: 0, medium: 0, low: 0 },
+      { kind: 'library' },
+      [{ severity: 'critical', name: 'API key exposed', file: '.env', line: 2 }],
+    );
+    expect(v.message).toContain('API key exposed in .env:2');
+    expect(v.message).not.toContain('+ ');
+  });
+});
+
+describe('renderObservationsBlock with artifacts', () => {
+  const base = {
+    surfaces: { kind: 'library', filesScanned: 4, artifactsCompiled: 2 },
+    checks: { staticCount: 209, semanticCount: 2 },
+    categories: buildCategorySummaries([]),
+    verdict: buildVerdict({ critical: 0, high: 0, medium: 0, low: 0 }, { kind: 'library' }),
+  };
+
+  it('artifacts block empty when no artifacts passed', () => {
+    const out = renderObservationsBlock(base);
+    expect(out.artifactLines).toEqual([]);
+  });
+
+  it('artifacts block empty when artifacts array is empty', () => {
+    const out = renderObservationsBlock({ ...base, artifacts: [] });
+    expect(out.artifactLines).toEqual([]);
+  });
+
+  it('renders one line per artifact', () => {
+    const out = renderObservationsBlock({
+      ...base,
+      artifacts: [
+        { path: 'deploy.skill.md', type: 'skill', intent: 'benign', capabilityLabels: ['fs-write', 'net-egress'], constraintCount: 3, weakConstraintCount: 0 },
+        { path: 'mcp.json', type: 'mcp_config', intent: 'suspicious', capabilityLabels: ['shell-exec'], constraintCount: 0, weakConstraintCount: 0 },
+      ],
+    });
+    // Output order: suspicious before benign (intent-ranked).
+    expect(out.artifactLines).toHaveLength(2);
+    const joined = out.artifactLines.join('\n');
+    expect(joined).toContain('deploy.skill.md');
+    expect(joined).toContain('skill');
+    expect(joined).toContain('benign');
+    expect(joined).toContain('fs-write + net-egress');
+    expect(joined).toContain('3 constraints');
+    expect(joined).toContain('mcp.json');
+    expect(joined).toContain('shell-exec');
+    expect(joined).toContain('no declared constraints');
+    // Suspicious comes first
+    expect(out.artifactLines[0]).toContain('mcp.json');
+  });
+
+  it('sorts artifacts by intent severity (malicious first) then capability count', () => {
+    const out = renderObservationsBlock({
+      ...base,
+      artifacts: [
+        { path: 'a.skill.md', type: 'skill', intent: 'benign', capabilityLabels: [], constraintCount: 0, weakConstraintCount: 0 },
+        { path: 'b.skill.md', type: 'skill', intent: 'malicious', capabilityLabels: ['fs-write'], constraintCount: 0, weakConstraintCount: 0 },
+        { path: 'c.skill.md', type: 'skill', intent: 'suspicious', capabilityLabels: ['net-egress'], constraintCount: 0, weakConstraintCount: 0 },
+      ],
+    });
+    expect(out.artifactLines[0]).toContain('b.skill.md');        // malicious
+    expect(out.artifactLines[1]).toContain('c.skill.md');        // suspicious
+    expect(out.artifactLines[2]).toContain('a.skill.md');        // benign
+  });
+
+  it('caps at 6 lines in default mode and appends "+ N more" tail', () => {
+    const arts = Array.from({ length: 10 }, (_, i) => ({
+      path: `skill-${i}.md`,
+      type: 'skill',
+      intent: 'benign' as const,
+      capabilityLabels: ['fs-read'],
+      constraintCount: 1,
+      weakConstraintCount: 0,
+    }));
+    const out = renderObservationsBlock({ ...base, artifacts: arts });
+    expect(out.artifactLines).toHaveLength(7); // 6 artifacts + 1 tail
+    expect(out.artifactLines[6]).toContain('+ 4 more');
+    expect(out.artifactLines[6]).toContain('--verbose');
+  });
+
+  it('verbose mode shows all artifacts with no tail', () => {
+    const arts = Array.from({ length: 10 }, (_, i) => ({
+      path: `skill-${i}.md`,
+      type: 'skill',
+      intent: 'benign' as const,
+      capabilityLabels: ['fs-read'],
+      constraintCount: 1,
+      weakConstraintCount: 0,
+    }));
+    const out = renderObservationsBlock({ ...base, artifacts: arts, verbose: true });
+    expect(out.artifactLines).toHaveLength(10);
+    expect(out.artifactLines.every(l => !l.includes('+ '))).toBe(true);
+  });
+
+  it('names weak constraints when present', () => {
+    const out = renderObservationsBlock({
+      ...base,
+      artifacts: [
+        { path: 'SOUL.md', type: 'soul', intent: 'benign', capabilityLabels: [], constraintCount: 5, weakConstraintCount: 2 },
+      ],
+    });
+    expect(out.artifactLines[0]).toContain('5 constraints, 2 weak');
+  });
+});
+
+describe('renderObservationsBlock', () => {
+  const zeroFindingsInput = {
+    surfaces: { kind: 'library', filesScanned: 2, artifactsCompiled: 2 },
+    checks: { staticCount: 209, semanticCount: 2 },
+    categories: buildCategorySummaries([]),
+    verdict: buildVerdict({ critical: 0, high: 0, medium: 0, low: 0 }, { kind: 'library' }),
+  };
+
+  it('emits 4 lines in the fixed order', () => {
+    const { lines } = renderObservationsBlock(zeroFindingsInput);
+    expect(lines.map(l => l.label)).toEqual(['Surfaces', 'Checks', 'Categories', 'Verdict']);
+  });
+
+  it('zero-findings Categories line marks all clear', () => {
+    const { lines } = renderObservationsBlock(zeroFindingsInput);
+    const cat = lines.find(l => l.label === 'Categories')!;
+    expect(cat.value).toContain('all clear');
+    expect(cat.tone).toBe('good');
+  });
+
+  it('findings Categories line groups dirty buckets with severity and collapses clear count', () => {
+    const findings = [
+      finding({ checkId: 'CRED-001', severity: 'critical' }),
+      finding({ checkId: 'MCP-003', severity: 'high' }),
+    ];
+    const { lines } = renderObservationsBlock({
+      ...zeroFindingsInput,
+      categories: buildCategorySummaries(findings),
+      verdict: buildVerdict({ critical: 1, high: 1, medium: 0, low: 0 }, { kind: 'library' }),
+    });
+    const cat = lines.find(l => l.label === 'Categories')!;
+    expect(cat.value).toContain('credentials (1 critical)');
+    expect(cat.value).toContain('MCP (1 high)');
+    expect(cat.value).toMatch(/others clear/);
+    expect(cat.tone).toBe('warning');
+  });
+
+  it('Verdict tone reflects verdict status', () => {
+    const unsafe = renderObservationsBlock({
+      ...zeroFindingsInput,
+      verdict: buildVerdict({ critical: 1, high: 0, medium: 0, low: 0 }, { kind: 'library' }),
+    });
+    expect(unsafe.lines.find(l => l.label === 'Verdict')!.tone).toBe('critical');
+
+    const needsFix = renderObservationsBlock({
+      ...zeroFindingsInput,
+      verdict: buildVerdict({ critical: 0, high: 0, medium: 0, low: 1 }, { kind: 'library' }),
+    });
+    expect(needsFix.lines.find(l => l.label === 'Verdict')!.tone).toBe('warning');
+
+    const safe = renderObservationsBlock(zeroFindingsInput);
+    expect(safe.lines.find(l => l.label === 'Verdict')!.tone).toBe('good');
+  });
+
+  it('Checks line includes skipped detail when present', () => {
+    const { lines } = renderObservationsBlock({
+      ...zeroFindingsInput,
+      checks: {
+        staticCount: 209,
+        semanticCount: 2,
+        skipped: [{ category: 'ARP', reason: 'requires --deep' }],
+      },
+    });
+    const checks = lines.find(l => l.label === 'Checks')!;
+    expect(checks.value).toContain('1 skipped');
+    expect(checks.value).toContain('ARP — requires --deep');
+  });
+
+  it('verbose mode expands Categories list', () => {
+    const { lines } = renderObservationsBlock({ ...zeroFindingsInput, verbose: true });
+    const cat = lines.find(l => l.label === 'Categories')!;
+    expect(cat.value).not.toContain('+ ');
+    expect(cat.value).toContain('all clear');
+  });
+});

--- a/packages/cli-ui/src/observations.ts
+++ b/packages/cli-ui/src/observations.ts
@@ -1,0 +1,428 @@
+/**
+ * Observations + Verdict block for CLI scan output.
+ *
+ * Sits between the score meter and Findings / Next Steps. Shows the user
+ * WHAT was scanned, HOW MANY checks ran, WHICH risk categories were
+ * verified, and a plain-English verdict — so `100/100` never stands
+ * alone as a dead-end opaque signal.
+ *
+ * Shared across hackmyagent, opena2a-cli, ai-trust per [CA-030].
+ * No runtime deps (no chalk); returns tone tuples so callers apply colors.
+ */
+
+/**
+ * Minimal structural finding shape used by category classification.
+ * Any SecurityFinding (hackmyagent) or equivalent finding object with
+ * these fields satisfies this by structural typing — consumers need
+ * no adapter layer.
+ */
+export interface CategorizableFinding {
+  checkId?: string;
+  name?: string;
+  category?: string;
+  passed: boolean;
+  severity: 'critical' | 'high' | 'medium' | 'low';
+}
+
+export type VerdictStatus = 'safe' | 'needs-fix' | 'unsafe' | 'unknown';
+
+export interface SurfaceSummary {
+  /** projectType or package kind, e.g. "library", "mcp-server", "skill". */
+  kind: string;
+  /** Human-readable file count or artifact count. */
+  filesScanned?: number;
+  /** Compiled semantic artifacts (NanoMind AST). */
+  artifactsCompiled?: number;
+  /** Named artifacts detected, e.g. "MCP config", "SOUL.md". */
+  detected?: string[];
+}
+
+/** Per-artifact summary displayed in the Artifacts block.
+ *  Shape matches the one produced by the NanoMind scanner-bridge
+ *  `ArtifactSummary` — kept structurally compatible but defined here
+ *  so observations.ts has no import dependency on nanomind-core. */
+export interface ArtifactLine {
+  path: string;
+  type: string;
+  intent: 'benign' | 'suspicious' | 'malicious' | 'unknown';
+  capabilityLabels: string[];
+  constraintCount: number;
+  weakConstraintCount: number;
+}
+
+export interface ChecksSummary {
+  /** Total static checks executed. */
+  staticCount: number;
+  /** Total NanoMind semantic checks executed. */
+  semanticCount: number;
+  /** Check categories deliberately skipped, e.g. `{category: 'ARP', reason: 'requires --deep'}`. */
+  skipped?: Array<{ category: string; reason: string }>;
+}
+
+export interface CategorySummary {
+  /** Top-level category name (credentials, MCP, governance, ...). */
+  name: string;
+  /** Severity counts if findings fired in this category. */
+  counts: {
+    critical: number;
+    high: number;
+    medium: number;
+    low: number;
+  };
+  /** True when zero findings fired on this category. */
+  clear: boolean;
+}
+
+export interface ObservationsInput {
+  surfaces: SurfaceSummary;
+  checks: ChecksSummary;
+  categories: CategorySummary[];
+  verdict: { status: VerdictStatus; message: string };
+  /** Per-artifact summaries from NanoMind AST compiler. Empty array and
+   *  the Artifacts block is skipped — scans without agent artifacts
+   *  don't need a dedicated "what did we compile" block. */
+  artifacts?: ArtifactLine[];
+  verbose?: boolean;
+  /** Terminal width for wrapping (default 65). */
+  width?: number;
+}
+
+export interface RenderedLine {
+  text: string;
+  /** Visual priority — higher = more prominent. Used by CLI to pick color. */
+  tone: 'default' | 'good' | 'warning' | 'critical' | 'dim';
+}
+
+/**
+ * Group findings by top-level category bucket.
+ *
+ * HMA has 35+ check-ID prefixes (CRED, MCP, CLAUDE, NET, PROMPT, INJ, ...).
+ * The Observations block groups them into user-facing categories so the
+ * line "credentials (1 critical) · MCP (2 high) · rest clear" is
+ * readable without the user knowing HMA's internal check-ID schema.
+ */
+const CATEGORY_MAP: Array<{ label: string; prefixes: string[]; keywords?: string[] }> = [
+  { label: 'credentials', prefixes: ['CRED', 'AST-CRED', 'WEBCRED', 'SEM-CRED', 'AGENT-CRED', 'ENVLEAK', 'CLIPASS'], keywords: ['credential', 'api key', 'token', 'password', 'secret'] },
+  { label: 'MCP', prefixes: ['MCP', 'AST-MCP', 'SEM-MCP'], keywords: ['mcp'] },
+  { label: 'network', prefixes: ['NET', 'GATEWAY', 'WEBEXPOSE'] },
+  { label: 'injection', prefixes: ['INJ', 'IO', 'CODEINJ', 'DOCKERINJ'] },
+  { label: 'prompt', prefixes: ['PROMPT', 'AST-PROMPT', 'SEM-INST'] },
+  { label: 'encryption', prefixes: ['ENCRYPT'] },
+  { label: 'session', prefixes: ['SESSION'] },
+  { label: 'sandbox', prefixes: ['SANDBOX', 'PROC', 'PERM', 'SEM-PERM', 'TMPPATH', 'TOCTOU', 'AST-CODE'] },
+  { label: 'capabilities', prefixes: ['AST-CAP', 'AST-SCOPE'] },
+  { label: 'supply-chain', prefixes: ['SUPPLY', 'DEP', 'INSTALL', 'INTEGRITY'] },
+  { label: 'governance', prefixes: ['AST-GOV', 'AST-GOVERN', 'SOUL', 'GOV', 'SOUL-OVERRIDE'] },
+  { label: 'skill', prefixes: ['SKILL', 'SKILL-MEM'] },
+  { label: 'unicode-stego', prefixes: ['UNICODE-STEGO', 'STEGO'] },
+  { label: 'memory', prefixes: ['MEM', 'RAG'] },
+  { label: 'identity', prefixes: ['AIM', 'AST-AIM', 'DNA'] },
+  { label: 'sandbox-escape', prefixes: ['NEMO'] },
+  { label: 'CVE', prefixes: ['CVE'] },
+  { label: 'A2A', prefixes: ['A2A'] },
+  { label: 'lifecycle', prefixes: ['LIFECYCLE'] },
+  { label: 'LLM risk', prefixes: ['LLM'] },
+  { label: 'heartbeat', prefixes: ['HEARTBEAT', 'AST-HEARTBEAT'] },
+  { label: 'config', prefixes: ['CONFIG', 'ENV', 'VSCODE', 'CURSOR', 'CLAUDE', 'SEC'] },
+  { label: 'audit', prefixes: ['AUDIT', 'LOG', 'RATE', 'SCAN', 'CHK', 'CHK-FAIL'] },
+  { label: 'auth', prefixes: ['AUTH', 'TOOL', 'API', 'AITOOL'] },
+  { label: 'git hygiene', prefixes: ['GIT'] },
+];
+
+/** All top-level category labels, ordered. Used to render "all clear" lists. */
+export const ALL_CATEGORY_LABELS = CATEGORY_MAP.map(c => c.label);
+
+/**
+ * Classify a single finding into its top-level category label.
+ * Returns null if nothing matches — caller decides whether to bucket
+ * as "Other" or drop.
+ */
+export function classifyCategory(finding: CategorizableFinding): string | null {
+  const checkId = (finding.checkId || '').toUpperCase();
+  const name = (finding.name || '').toLowerCase();
+  const categoryField = (finding.category || '').toLowerCase();
+
+  for (const bucket of CATEGORY_MAP) {
+    for (const prefix of bucket.prefixes) {
+      if (checkId.startsWith(prefix + '-') || checkId === prefix) return bucket.label;
+    }
+    if (bucket.keywords) {
+      for (const kw of bucket.keywords) {
+        if (name.includes(kw) || categoryField.includes(kw)) return bucket.label;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Build a CategorySummary[] from raw findings. Unmatched findings go
+ * into an "other" bucket; categories with zero findings are marked
+ * `clear: true` so the renderer can list them under "rest clear".
+ */
+export function buildCategorySummaries(findings: CategorizableFinding[]): CategorySummary[] {
+  const byLabel = new Map<string, CategorySummary>();
+  for (const label of ALL_CATEGORY_LABELS) {
+    byLabel.set(label, { name: label, counts: { critical: 0, high: 0, medium: 0, low: 0 }, clear: true });
+  }
+
+  for (const f of findings) {
+    if (f.passed) continue;
+    const label = classifyCategory(f) ?? 'other';
+    if (!byLabel.has(label)) {
+      byLabel.set(label, { name: label, counts: { critical: 0, high: 0, medium: 0, low: 0 }, clear: true });
+    }
+    const bucket = byLabel.get(label)!;
+    bucket.clear = false;
+    const sev = f.severity as 'critical' | 'high' | 'medium' | 'low';
+    if (sev in bucket.counts) bucket.counts[sev]++;
+  }
+
+  return Array.from(byLabel.values());
+}
+
+/** Minimal finding shape the verdict builder consumes — a subset of SecurityFinding
+ *  so callers don't have to pass the whole object. Must include the fields
+ *  buildVerdict uses to name the lead finding. */
+export interface VerdictFinding {
+  severity: 'critical' | 'high' | 'medium' | 'low';
+  name?: string;
+  checkId?: string;
+  file?: string;
+  line?: number;
+}
+
+/**
+ * Build a plain-English verdict from the actual failed findings.
+ *
+ * Old version counted severities and produced grammar like "1 low finding to
+ * address" — which told the reader nothing they couldn't count themselves.
+ * This version names the lead finding (worst severity, first by check-ID)
+ * so the Verdict line is action-oriented: the user learns WHAT to fix, not
+ * just HOW MANY exist.
+ *
+ * Never uses letter grades. Anchors to an action per CISO philosophy rule
+ * #10 (feedback_cli_ciso_philosophy.md).
+ */
+export function buildVerdict(
+  severity: { critical: number; high: number; medium: number; low: number },
+  surface: SurfaceSummary,
+  findings?: VerdictFinding[],
+): { status: VerdictStatus; message: string } {
+  const { critical, high, medium, low } = severity;
+  const total = critical + high + medium + low;
+
+  if (total === 0) {
+    const surfaceLabel = surface.kind && surface.kind !== 'unknown' ? surface.kind : 'project';
+    return {
+      status: 'safe',
+      message: `No security issues detected. This ${surfaceLabel} looks safe to use.`,
+    };
+  }
+
+  // Pick the leading finding to name in the verdict: worst severity first.
+  // If multiple findings at the top severity, the verdict describes the first
+  // one (stable ordering from the scanner) and says "+ N more" for the rest.
+  const leadSeverity: VerdictFinding['severity'] | null =
+    critical > 0 ? 'critical' : high > 0 ? 'high' : medium > 0 ? 'medium' : low > 0 ? 'low' : null;
+
+  const leaders = (findings ?? []).filter(f => f.severity === leadSeverity);
+  const lead = leaders[0];
+
+  /** Format a finding as "NAME in file:line" — falls back to checkId or name. */
+  const formatLead = (f: VerdictFinding): string => {
+    const label = f.name?.trim() || f.checkId?.trim() || 'finding';
+    if (f.file) {
+      const loc = f.line ? `${f.file}:${f.line}` : f.file;
+      return `${label} in ${loc}`;
+    }
+    return label;
+  };
+
+  const extraCount = Math.max(0, total - 1);
+  const extraSuffix = extraCount > 0 ? ` + ${extraCount} more` : '';
+
+  if (critical > 0) {
+    const leadText = lead ? formatLead(lead) : `${critical} critical issue${critical > 1 ? 's' : ''}`;
+    return {
+      status: 'unsafe',
+      message: `Not safe to ship. ${leadText}${extraSuffix}. Fix before using in production.`,
+    };
+  }
+  if (high > 0) {
+    const leadText = lead ? formatLead(lead) : `${high} high-severity issue${high > 1 ? 's' : ''}`;
+    return {
+      status: 'unsafe',
+      message: `Not safe as-is. ${leadText}${extraSuffix}. Fix, then rescan.`,
+    };
+  }
+  // medium or low only
+  const leadText = lead ? formatLead(lead) : `${total} finding${total > 1 ? 's' : ''}`;
+  return {
+    status: 'needs-fix',
+    message: `Usable with caveats. ${leadText}${extraSuffix}. Run \`secure --fix\` to auto-remediate where possible.`,
+  };
+}
+
+/**
+ * Format the Categories line — names the buckets that fired, then
+ * collapses the remaining clear buckets into a "rest clear" tail.
+ */
+function formatCategoriesLine(categories: CategorySummary[], verbose: boolean): string {
+  const withFindings = categories.filter(c => !c.clear);
+  const clearCount = categories.length - withFindings.length;
+
+  if (withFindings.length === 0) {
+    // Zero-findings case: list first N categories, collapse the rest.
+    const allClear = categories.filter(c => c.clear);
+    if (verbose) {
+      return allClear.map(c => c.name).join(', ') + '  (all clear)';
+    }
+    const shown = allClear.slice(0, 9).map(c => c.name).join(', ');
+    const extra = allClear.length > 9 ? ` + ${allClear.length - 9} more` : '';
+    return `${shown}${extra}  (all clear)`;
+  }
+
+  const withPrefix = withFindings.map(c => {
+    const { critical, high, medium, low } = c.counts;
+    if (critical > 0) return `${c.name} (${critical} critical)`;
+    if (high > 0) return `${c.name} (${high} high)`;
+    if (medium > 0) return `${c.name} (${medium} medium)`;
+    if (low > 0) return `${c.name} (${low} low)`;
+    return c.name;
+  });
+  const tail = clearCount > 0 ? ` · ${clearCount} others clear` : '';
+  return `${withPrefix.join(' · ')}${tail}`;
+}
+
+/**
+ * Format the Checks line. `static · semantic · skipped` — skipped
+ * only shows when non-empty. Zero skipped is a positive signal we
+ * express by showing `0 skipped`.
+ */
+function formatChecksLine(checks: ChecksSummary): string {
+  const parts = [
+    `${checks.staticCount} static`,
+    `${checks.semanticCount} semantic (NanoMind AST)`,
+  ];
+  if (!checks.skipped || checks.skipped.length === 0) {
+    parts.push('0 skipped');
+  } else {
+    const skippedDetail = checks.skipped.map(s => `${s.category} — ${s.reason}`).join('; ');
+    parts.push(`${checks.skipped.length} skipped (${skippedDetail})`);
+  }
+  return parts.join(' · ');
+}
+
+/**
+ * Format one artifact as a single compact line.
+ *
+ * Shape: `<path>  <type> · <intent> · <capabilities>  [<constraints>]`
+ *
+ * Example:
+ *   `deploy.skill.md  skill · benign · cron + fs-write + net-egress  (2 constraints, 1 weak)`
+ *   `mcp.json         mcp_config · suspicious · shell-exec + fs-write`
+ */
+function formatArtifactLine(a: ArtifactLine): string {
+  const capText = a.capabilityLabels.length > 0
+    ? a.capabilityLabels.join(' + ')
+    : 'no inferred capabilities';
+  const parts = [a.type, a.intent, capText];
+  const head = `${a.path}  ${parts.join(' · ')}`;
+
+  if (a.constraintCount > 0) {
+    const weakSuffix = a.weakConstraintCount > 0 ? `, ${a.weakConstraintCount} weak` : '';
+    return `${head}  (${a.constraintCount} constraint${a.constraintCount === 1 ? '' : 's'}${weakSuffix})`;
+  }
+  if (a.type === 'skill' || a.type === 'mcp_config' || a.type === 'a2a_card' || a.type === 'agent_config') {
+    // Agent artifacts without any declared constraints — this is itself a signal worth flagging
+    return `${head}  (no declared constraints)`;
+  }
+  return head;
+}
+
+/**
+ * Select + format artifact lines for the Observations block.
+ * Defaults to up to 6 lines; verbose mode shows all. Ordering: risky
+ * first (malicious > suspicious > benign), then by capability count
+ * (more capabilities = more surface = more worth naming first).
+ */
+function formatArtifactsBlock(artifacts: ArtifactLine[], verbose: boolean): string[] {
+  const intentRank: Record<ArtifactLine['intent'], number> = {
+    malicious: 0, suspicious: 1, benign: 2, unknown: 3,
+  };
+  const sorted = [...artifacts].sort((a, b) => {
+    const r = intentRank[a.intent] - intentRank[b.intent];
+    if (r !== 0) return r;
+    return b.capabilityLabels.length - a.capabilityLabels.length;
+  });
+  const cap = verbose ? Infinity : 6;
+  const shown = sorted.slice(0, cap).map(formatArtifactLine);
+  const extra = sorted.length - shown.length;
+  if (extra > 0) {
+    shown.push(`+ ${extra} more (run with --verbose to see all)`);
+  }
+  return shown;
+}
+
+/**
+ * Format the Surfaces line. Always names the project kind; adds file
+ * count + detected artifacts when present.
+ */
+function formatSurfacesLine(surface: SurfaceSummary): string {
+  const parts: string[] = [surface.kind || 'unknown'];
+  if (typeof surface.filesScanned === 'number') {
+    parts.push(`${surface.filesScanned} file${surface.filesScanned === 1 ? '' : 's'}`);
+  }
+  if (typeof surface.artifactsCompiled === 'number' && surface.artifactsCompiled > 0) {
+    parts.push(`${surface.artifactsCompiled} semantic artifact${surface.artifactsCompiled === 1 ? '' : 's'}`);
+  }
+  if (surface.detected && surface.detected.length > 0) {
+    parts.push(surface.detected.join(', '));
+  }
+  return parts.join(' · ');
+}
+
+/**
+ * Render the full Observations block as an array of lines (no ANSI yet).
+ * The CLI caller wraps with colors + indentation.
+ *
+ * Returns `{ label, value }` tuples so the caller can align labels
+ * consistently with the rest of the unified-check layout.
+ */
+export interface RenderedObservations {
+  lines: Array<{ label: string; value: string; tone: 'default' | 'good' | 'warning' | 'critical' }>;
+  /** Multi-line Artifacts block. Each entry is rendered on its own line
+   *  (first entry gets the "Artifacts" label, rest are continuations).
+   *  Empty when no agent artifacts were compiled. */
+  artifactLines: string[];
+  verdict: { status: VerdictStatus; message: string };
+}
+
+export function renderObservationsBlock(input: ObservationsInput): RenderedObservations {
+  const { surfaces, checks, categories, verdict, artifacts, verbose } = input;
+
+  const lines: RenderedObservations['lines'] = [
+    { label: 'Surfaces', value: formatSurfacesLine(surfaces), tone: 'default' },
+    { label: 'Checks', value: formatChecksLine(checks), tone: 'default' },
+    {
+      label: 'Categories',
+      value: formatCategoriesLine(categories, !!verbose),
+      tone: categories.some(c => !c.clear) ? 'warning' : 'good',
+    },
+    {
+      label: 'Verdict',
+      value: verdict.message,
+      tone:
+        verdict.status === 'unsafe' ? 'critical' :
+        verdict.status === 'needs-fix' ? 'warning' :
+        verdict.status === 'safe' ? 'good' : 'default',
+    },
+  ];
+
+  const artifactLines = artifacts && artifacts.length > 0
+    ? formatArtifactsBlock(artifacts, !!verbose)
+    : [];
+
+  return { lines, artifactLines, verdict };
+}


### PR DESCRIPTION
## Summary

Extracts the Observations+Verdict block and NanoMind analyst-render helpers from `hackmyagent` into `@opena2a/cli-ui` so `hackmyagent`, `opena2a-cli`, and `ai-trust` consume the same source of truth. Implements **brief §7** of `hackmyagent/briefs/cli-observation-verdict-ux.md` and closes the outstanding criterion 6, 8, 9 of the same brief's §6 acceptance checklist.

Addresses:
- **[CA-030]** release gate: one owning package per shared capability; consumers are adapters.
- **[CA-030] §2.6**: CLI Observations block must live in `@opena2a/cli-ui`, not inlined in HMA.
- `memory/feedback_single_source_of_truth_scan.md` (cross-CLI propagation discipline).

### Behavior change

None on the library side. The observations.ts helper is ported verbatim with one mechanical adjustment: the hackmyagent-scoped `SecurityFinding` import is replaced with a **local structural** `CategorizableFinding` interface. Any `SecurityFinding` satisfies this by structural typing, so hackmyagent consumers need no adapter layer.

All 56 unit tests from hackmyagent's `__tests__/output/` are ported to `packages/cli-ui/src/*.test.ts` following the existing cli-ui convention (tests next to source, excluded from build via `tsconfig.json`).

### Files

- `packages/cli-ui/src/observations.ts` (new) — `renderObservationsBlock`, `buildCategorySummaries`, `buildVerdict`, `classifyCategory`, `ALL_CATEGORY_LABELS`, plus `CategorizableFinding`, `VerdictFinding`, `VerdictStatus`, `ObservationsInput`, `CategorySummary`, `ChecksSummary`, `SurfaceSummary`, `ArtifactLine`, `RenderedObservations` type exports.
- `packages/cli-ui/src/observations.test.ts` (new) — 28 tests.
- `packages/cli-ui/src/analyst-render.ts` (new) — `isRenderableAnalystFinding`, `formatAnalystDescription`, `capAnalystThreatLevel`, `formatAnalystConfidence`, `LOW_CONFIDENCE_CAP`.
- `packages/cli-ui/src/analyst-render.test.ts` (new) — 28 tests.
- `packages/cli-ui/src/index.ts` — re-exports the new APIs alongside the existing ones.
- `packages/cli-ui/package.json` — 0.1.0 → 0.2.0 (new minor: added exports, no breaking change).

### Runtime deps

No new runtime deps introduced. Both new modules are stdlib-only — no chalk, no kleur, no ora. They return tone tuples so callers apply their own color scheme.

### Consumer follow-ups (coordinated, per CA-030)

Three PRs will land against their respective repos within the same week, cross-linked back to this one:

1. **hackmyagent** — pin `@opena2a/cli-ui: "0.2.0"` exact (no caret per CLI-consolidation exact-pin rule), delete `src/output/observations.ts` + `src/output/analyst-render.ts`, switch imports in `src/cli.ts` to `@opena2a/cli-ui`. Fixture output must remain byte-identical.
2. **opena2a-cli** (packages/cli in this monorepo, same PR chain) — pin `@opena2a/cli-ui: "0.2.0"` exact, wire `renderObservationsBlock` between score meter and Next Steps in review/scan render paths.
3. **ai-trust** — pin `@opena2a/cli-ui: "0.2.0"` exact, either translate trust-query results to `ObservationsInput` or file a P1 skew for next release per brief §7 fallback.

### Trusted Publishing

Published via `cli-ui-v0.2.0` tag → GitHub Actions OIDC exchange. First publish under Trusted Publishing for this package.

```
$ npm view @opena2a/cli-ui@0.2.0 dist.attestations --json
{
  "url": "https://registry.npmjs.org/-/npm/v1/attestations/@opena2a%2fcli-ui@0.2.0",
  "provenance": {
    "predicateType": "https://slsa.dev/provenance/v1"
  }
}
```

SLSA v1 predicate confirmed. GHA run: https://github.com/opena2a-org/opena2a/actions/runs/24790568198

## Test plan

- [x] `npm -w packages/cli-ui run build` — clean
- [x] `npm -w packages/cli-ui test` — 69/69 pass (13 existing + 56 new)
- [x] GHA release workflow — succeeded in 1m2s
- [x] `npm view @opena2a/cli-ui@0.2.0 dist.attestations --json` — SLSA v1 present
- [ ] Cross-CLI parity diff (CA-030 release gate) — runs after the three consumer PRs open, diff saved in the hackmyagent consumer PR body