### PR TITLE
feat(cli): wire @opena2a/cli-ui renderObservationsBlock into opena2a review

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3840,6 +3840,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
+        "@opena2a/cli-ui": "0.2.0",
         "@opena2a/contribute": "0.1.0",
         "@opena2a/shared": "0.1.0",
         "ai-trust": "^0.2.23",
@@ -3883,6 +3884,15 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "packages/cli/node_modules/@opena2a/cli-ui": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.2.0.tgz",
+      "integrity": "sha512-6woViVb94/1K0LV9gbvtF0Ko1yzKRu+FK9mirKDWdODlhxiIFKC7tXBAjlJYEpv1XmedPtxTw9sOMCkzJj3XQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0"
       }
     },
     "packages/cli/node_modules/@opena2a/contribute": {

--- a/packages/cli/__tests__/commands/review.test.ts
+++ b/packages/cli/__tests__/commands/review.test.ts
@@ -166,4 +166,38 @@ describe('review', () => {
     expect(html).toContain('OpenA2A Security Review');
     expect(html).toContain('report-data');
   });
+
+  it('renders the @opena2a/cli-ui Observations block with Surfaces/Checks/Categories/Verdict labels', async () => {
+    // Smoke test for the CA-030 cli-ui wire at packages/cli/src/commands/review.ts:430.
+    // Asserts the dynamic import of @opena2a/cli-ui succeeded AND the four label
+    // strings appear between the Score summary and the Report line. A regression
+    // here means either cli-ui is missing from node_modules or the renderer was
+    // accidentally deleted from review() — both are blocking.
+    fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'obs-test', version: '1.0.0' }));
+    fs.writeFileSync(path.join(tempDir, '.gitignore'), '.env\nnode_modules\n');
+
+    const { exitCode, output } = await captureStdout(() => review({
+      targetDir: tempDir,
+      autoOpen: false,
+      skipHma: true,
+      ci: true,
+    }));
+
+    expect(exitCode).toBe(0);
+    // All four Observations labels must render.
+    expect(output).toContain('Surfaces');
+    expect(output).toContain('Checks');
+    expect(output).toContain('Categories');
+    expect(output).toContain('Verdict');
+    // Block appears between Score and Report.
+    const scoreIdx = output.indexOf('Score:');
+    const surfacesIdx = output.indexOf('Surfaces');
+    const reportIdx = output.indexOf('Report:');
+    expect(scoreIdx).toBeGreaterThanOrEqual(0);
+    expect(surfacesIdx).toBeGreaterThan(scoreIdx);
+    expect(reportIdx).toBeGreaterThan(surfacesIdx);
+    // cli-ui's standard Checks line shape survives the wire.
+    expect(output).toMatch(/\d+ static/);
+    expect(output).toContain('semantic (NanoMind AST)');
+  });
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^7.0.0",
+    "@opena2a/cli-ui": "0.2.0",
     "@opena2a/contribute": "0.1.0",
     "@opena2a/shared": "0.1.0",
     "ai-trust": "^0.2.23",

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -474,9 +474,14 @@ export async function review(options: ReviewOptions): Promise<number> {
       process.stdout.write(`  ${dim(labelPad)}${color(line.value)}\n`);
     }
     process.stdout.write('\n');
-  } catch {
+  } catch (err: unknown) {
     // cli-ui import failed — non-critical, skip the Observations block.
     // The existing Score + findings summary above still carries the result.
+    // Log in verbose mode so debugging isn't silent.
+    if (options.verbose) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(dim(`  [observations] skipped — ${msg}\n`));
+    }
   }
 
   // Generate HTML report

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -12,6 +12,27 @@ import * as path from 'node:path';
 import { spawn } from 'node:child_process';
 import { platform, tmpdir } from 'node:os';
 import { bold, green, yellow, red, cyan, dim, gray } from '../util/colors.js';
+
+/** Local structural subset of @opena2a/cli-ui types. Duplicated here
+ *  because this package is CJS and cli-ui is ESM; static type imports
+ *  from ESM require a resolution-mode attribute unsupported by our
+ *  toolchain. The shape matches cli-ui's CategorizableFinding + VerdictFinding
+ *  exactly so the runtime values flow through unchanged. */
+type LocalSeverity = 'critical' | 'high' | 'medium' | 'low';
+interface LocalCategorizableFinding {
+  checkId?: string;
+  name?: string;
+  category?: string;
+  passed: boolean;
+  severity: LocalSeverity;
+}
+interface LocalVerdictFinding {
+  severity: LocalSeverity;
+  name?: string;
+  checkId?: string;
+  file?: string;
+  line?: number;
+}
 import { detectProject } from '../util/detect.js';
 import { quickCredentialScan, type CredentialMatch } from '../util/credential-patterns.js';
 import { checkAdvisories, type AdvisoryCheck } from '../util/advisories.js';
@@ -400,6 +421,63 @@ export async function review(options: ReviewOptions): Promise<number> {
     `  Score: ${scoreColor(`${compositeScore}/100`)}${dim(recoveryHint)}` +
     `\n  ${totalFindings} findings (${sevCounts.critical} critical, ${sevCounts.high} high, ${sevCounts.medium} medium)\n`,
   );
+
+  // ── Observations + Verdict ──────────────────────────────────────────
+  // Shared block from @opena2a/cli-ui so review/scan output stays
+  // consistent with hackmyagent secure output per [CA-030]. Dynamic
+  // import because cli-ui is ESM and this package is CJS (same pattern
+  // as @opena2a/shared / @opena2a/contribute usage elsewhere).
+  try {
+    const cliUi = await import('@opena2a/cli-ui');
+    const projectLabel = report.projectType && report.projectType !== 'unknown'
+      ? report.projectType
+      : 'project';
+    const categorizable: LocalCategorizableFinding[] = findings.map(f => ({
+      checkId: f.id,
+      name: f.title,
+      category: f.source,
+      passed: false,
+      severity: f.severity as LocalSeverity,
+    }));
+    const verdictFindings: LocalVerdictFinding[] = findings.map(f => ({
+      severity: f.severity as LocalSeverity,
+      name: f.title,
+      checkId: f.id,
+    }));
+    const categorySummaries = cliUi.buildCategorySummaries(categorizable);
+    const verdict = cliUi.buildVerdict(
+      { critical: sevCounts.critical, high: sevCounts.high, medium: sevCounts.medium, low: sevCounts.low },
+      { kind: projectLabel },
+      verdictFindings,
+    );
+    const { lines } = cliUi.renderObservationsBlock({
+      surfaces: { kind: projectLabel },
+      checks: {
+        staticCount: phases.length,
+        semanticCount: 0,
+      },
+      categories: categorySummaries,
+      verdict,
+      verbose: !!options.verbose,
+    });
+    process.stdout.write('\n');
+    const toneColor = (tone: 'default' | 'good' | 'warning' | 'critical'): (s: string) => string => {
+      if (tone === 'good') return green;
+      if (tone === 'warning') return yellow;
+      if (tone === 'critical') return red;
+      return (s: string): string => s;
+    };
+    const LABEL_WIDTH = 12;
+    for (const line of lines) {
+      const labelPad = line.label.padEnd(LABEL_WIDTH, ' ');
+      const color = toneColor(line.tone);
+      process.stdout.write(`  ${dim(labelPad)}${color(line.value)}\n`);
+    }
+    process.stdout.write('\n');
+  } catch {
+    // cli-ui import failed — non-critical, skip the Observations block.
+    // The existing Score + findings summary above still carries the result.
+  }
 
   // Generate HTML report
   const reportPath = options.reportPath ??


### PR DESCRIPTION
## Summary

Consumer bump for [CA-030] cli-ui extraction. Coordinated with:
- opena2a#88 (cli-ui 0.2.0 extraction — published to npm with SLSA v1 provenance)
- hackmyagent#112 (HMA consumes cli-ui 0.2.0 + semanticCount fix)
- ai-trust#<TBD> (ai-trust scan-result wire)

### Changes

1. **Pin `@opena2a/cli-ui: \"0.2.0\"` exact** in `packages/cli/package.json` (no caret).
2. **Wire `renderObservationsBlock`** between the Score line and the Report line in `review` output (`packages/cli/src/commands/review.ts`).
3. **Dynamic `await import()`** for cli-ui because `opena2a-cli` is CJS and cli-ui is ESM — same pattern as `@opena2a/shared` / `@opena2a/contribute` usage elsewhere in this package.
4. **Local type subset** for `CategorizableFinding` + `VerdictFinding` instead of a static `import type` (TS resolution-mode for ESM-typed-imports isn't wired here — runtime values still flow through cli-ui's ESM module unchanged, so rendering is byte-identical).

### Output on test/hma/ fixture

```
  Score: 66/100 -- path to 100 available (+15 shadow ai, +11 shield, +8 hma scan)
  1 findings (1 critical, 0 high, 0 medium)

  Surfaces    Node.js + MCP server
  Checks      6 static · 0 semantic (NanoMind AST) · 0 skipped
  Categories  other (1 critical) · 25 others clear
  Verdict     Not safe to ship. Configuration file tampered. Fix before using in production.

  Report: /var/folders/.../opena2a-review-...html
```

### Known coverage caveat (separate from this PR)

`opena2a review`'s `aggregateFindings` only merges credentials + shield findings, NOT HMA phase findings. On test/hma/ this shows up as \"other (1 critical) · 25 others clear\" (just the guard integrity finding) versus hackmyagent secure's 34 critical across 17 categories on the same dir.

The Observations block renders correctly; the sparse category list reflects opena2a review's current phase coverage, which is scoped OUT of this PR. File as P1 follow-up if category coverage parity with HMA is wanted.

### CA-030 parity gate

Byte-identical rendering across hackmyagent secure, opena2a review, and ai-trust formatScanResult for IDENTICAL finding inputs is guaranteed by cli-ui's 56 unit tests (28 observations + 28 analyst-render), all running against the same @opena2a/cli-ui@0.2.0 npm package. Finding-set divergence between CLIs is expected — different scan scopes.

## Test plan

- [x] 876/876 opena2a-cli tests pass
- [x] Build clean
- [x] opena2a review --ci test/hma/ renders Observations block between Score and Report lines
- [x] Score + findings summary unchanged; Observations block is additive

Refs:
- opena2a-org/opena2a#88
- opena2a-org/hackmyagent/briefs/cli-observation-verdict-ux.md §7
- memory/feedback_single_source_of_truth_scan.md