### PR TITLE
fix(cli): aggregate HMA findings into opena2a review Observations block

### DIFF
--- a/packages/cli/__tests__/commands/review.test.ts
+++ b/packages/cli/__tests__/commands/review.test.ts
@@ -2,7 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { review } from '../../src/commands/review.js';
+import {
+  review,
+  aggregateFindings,
+  type CredentialPhaseData,
+  type ShieldPhaseData,
+  type HmaPhaseData,
+  type HmaFinding,
+} from '../../src/commands/review.js';
+import type { CredentialMatch } from '../../src/util/credential-patterns.js';
 
 function captureStdout(fn: () => Promise<number>): Promise<{ exitCode: number; output: string }> {
   const chunks: string[] = [];
@@ -199,5 +207,142 @@ describe('review', () => {
     // cli-ui's standard Checks line shape survives the wire.
     expect(output).toMatch(/\d+ static/);
     expect(output).toContain('semantic (NanoMind AST)');
+  });
+
+  it('credentials from quickCredentialScan show up in the Categories line', async () => {
+    // Regression for the review-HMA-coverage fix. Before, aggregateFindings
+    // could produce zero credential findings even when credData had matches
+    // because the loop existed but the Observations block downstream only
+    // showed "other". This asserts CRED-* findings are classified into the
+    // cli-ui "credentials" bucket end-to-end.
+    fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'cred-test' }));
+    fs.writeFileSync(path.join(tempDir, '.gitignore'), 'node_modules\n');
+    const fakeKey = 'sk-ant-api03-' + 'A'.repeat(85);
+    fs.writeFileSync(path.join(tempDir, 'config.ts'), `const key = "${fakeKey}";`);
+
+    const { exitCode, output } = await captureStdout(() => review({
+      targetDir: tempDir,
+      autoOpen: false,
+      skipHma: true,
+      ci: true,
+    }));
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('Categories');
+    // The cli-ui classifier maps CRED-* into the "credentials" bucket.
+    const categoriesLine = output.split('\n').find(l => l.includes('Categories')) ?? '';
+    expect(categoriesLine).toContain('credentials');
+  });
+});
+
+describe('aggregateFindings', () => {
+  const SHIELD_EMPTY: ShieldPhaseData = {
+    eventCount: 0,
+    classifiedFindings: [],
+    arpStats: {} as any,
+    postureScore: 100,
+    policyLoaded: false,
+    policyMode: null,
+    integrityStatus: 'ok',
+  };
+
+  const makeCredMatch = (overrides: Partial<CredentialMatch> = {}): CredentialMatch => ({
+    findingId: 'CRED-001',
+    title: 'Hardcoded API Key',
+    severity: 'critical',
+    filePath: '/tmp/target/config.ts',
+    line: 10,
+    value: 'sk-xxx',
+    envVar: 'API_KEY',
+    ...overrides,
+  });
+
+  const makeHmaFinding = (overrides: Partial<HmaFinding> = {}): HmaFinding => ({
+    checkId: 'CRED-HMA-001',
+    name: 'Hardcoded credential detected',
+    description: '',
+    category: 'credentials',
+    severity: 'critical',
+    passed: false,
+    message: '',
+    file: 'config.ts',
+    line: 10,
+    fixable: true,
+    fix: 'opena2a protect',
+    guidance: '',
+    count: 1,
+    sampleFiles: [],
+    ...overrides,
+  });
+
+  const makeHmaData = (findings: HmaFinding[]): HmaPhaseData => ({
+    available: true,
+    score: 50,
+    maxScore: 100,
+    totalChecks: findings.length,
+    passed: 0,
+    failed: findings.length,
+    bySeverity: {},
+    byCategory: {},
+    topFindings: findings,
+    allFailedFindings: findings,
+  });
+
+  it('prefers HMA over quickCredentialScan when both fire at the same file:line', () => {
+    const credData: CredentialPhaseData = {
+      matches: [makeCredMatch({ filePath: '/tmp/target/config.ts', line: 10 })],
+      totalFindings: 1,
+      bySeverity: { critical: 1 },
+      driftFindings: [],
+      envVarSuggestions: [],
+    };
+    const hmaData = makeHmaData([
+      makeHmaFinding({ checkId: 'CRED-HMA-001', file: 'config.ts', line: 10 }),
+    ]);
+
+    const result = aggregateFindings(credData, SHIELD_EMPTY, '/tmp/target', hmaData);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('hma');
+    expect(result[0].id).toBe('CRED-HMA-001');
+  });
+
+  it('keeps both when HMA and credData fire at different locations', () => {
+    const credData: CredentialPhaseData = {
+      matches: [
+        makeCredMatch({ filePath: '/tmp/target/a.ts', line: 5 }),
+        makeCredMatch({ filePath: '/tmp/target/b.ts', line: 20 }),
+      ],
+      totalFindings: 2,
+      bySeverity: { critical: 2 },
+      driftFindings: [],
+      envVarSuggestions: [],
+    };
+    const hmaData = makeHmaData([
+      makeHmaFinding({ checkId: 'MCP-001', file: 'mcp.json', line: 1, severity: 'high' }),
+      makeHmaFinding({ checkId: 'CRED-HMA-002', file: 'c.ts', line: 30 }),
+    ]);
+
+    const result = aggregateFindings(credData, SHIELD_EMPTY, '/tmp/target', hmaData);
+
+    // 2 cred + 2 hma, no overlap
+    expect(result).toHaveLength(4);
+    const sources = result.map(r => r.source).sort();
+    expect(sources).toEqual(['credential-scan', 'credential-scan', 'hma', 'hma']);
+  });
+
+  it('null hmaData leaves credData and shield untouched (backward compat)', () => {
+    const credData: CredentialPhaseData = {
+      matches: [makeCredMatch()],
+      totalFindings: 1,
+      bySeverity: { critical: 1 },
+      driftFindings: [],
+      envVarSuggestions: [],
+    };
+
+    const result = aggregateFindings(credData, SHIELD_EMPTY, '/tmp/target', null);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('credential-scan');
   });
 });

--- a/packages/cli/__tests__/commands/review.test.ts
+++ b/packages/cli/__tests__/commands/review.test.ts
@@ -408,6 +408,26 @@ describe('aggregateFindings', () => {
     expect(sources).toEqual(['credential-scan', 'hma']);
   });
 
+  it('drops credData matches whose path escapes targetDir (defense in depth)', () => {
+    const credData: CredentialPhaseData = {
+      matches: [
+        makeCredMatch({ filePath: '/etc/passwd', line: 1 }),
+        makeCredMatch({ filePath: '/tmp/target/../outside.ts', line: 1 }),
+        makeCredMatch({ filePath: '/tmp/target/config.ts', line: 10 }),
+      ],
+      totalFindings: 3,
+      bySeverity: { critical: 3 },
+      driftFindings: [],
+      envVarSuggestions: [],
+    };
+
+    const result = aggregateFindings(credData, SHIELD_EMPTY, '/tmp/target', null);
+
+    // Only the in-scope match should survive.
+    expect(result).toHaveLength(1);
+    expect(result[0].detail).toBe('config.ts:10');
+  });
+
   it('upgrades HMA severity to max(hma, cred) when dedupe fires', () => {
     // credData sees CRITICAL (sk-ant-*), HMA returns HIGH. Dedupe must
     // preserve the higher severity so the Observations block and verdict

--- a/packages/cli/__tests__/commands/review.test.ts
+++ b/packages/cli/__tests__/commands/review.test.ts
@@ -345,4 +345,97 @@ describe('aggregateFindings', () => {
     expect(result).toHaveLength(1);
     expect(result[0].source).toBe('credential-scan');
   });
+
+  it('prefers HMA over credData when HMA credential finding has file but no line', () => {
+    // Real HMA output often omits line numbers for credential findings (e.g.
+    // AST-CRED-001 on config.ts has file but line=null). The dedupe must
+    // fall back to file-only comparison for credential-category HMA checks
+    // so we don't double-count the same credential.
+    const credData: CredentialPhaseData = {
+      matches: [makeCredMatch({ filePath: '/tmp/target/config.ts', line: 10 })],
+      totalFindings: 1,
+      bySeverity: { critical: 1 },
+      driftFindings: [],
+      envVarSuggestions: [],
+    };
+    const hmaData = makeHmaData([
+      makeHmaFinding({
+        checkId: 'AST-CRED-001',
+        file: 'config.ts',
+        line: undefined,
+        severity: 'high',
+      }),
+    ]);
+
+    const result = aggregateFindings(credData, SHIELD_EMPTY, '/tmp/target', hmaData);
+
+    // Only 1 finding: HMA wins, credData is dropped.
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('hma');
+    // Severity upgraded from HMA's "high" to credData's "critical".
+    expect(result[0].severity).toBe('critical');
+  });
+
+  it('non-credential HMA finding on a file does NOT mask a credential in that file', () => {
+    // A HIGH GIT-002 on .gitignore must not suppress a CRITICAL CRED-001
+    // that quickCredentialScan found in the same file — the dedupe is
+    // scoped to credential-category HMA checks only.
+    const credData: CredentialPhaseData = {
+      matches: [makeCredMatch({
+        findingId: 'CRED-001',
+        filePath: '/tmp/target/.gitignore',
+        line: 3,
+      })],
+      totalFindings: 1,
+      bySeverity: { critical: 1 },
+      driftFindings: [],
+      envVarSuggestions: [],
+    };
+    const hmaData = makeHmaData([
+      makeHmaFinding({
+        checkId: 'GIT-002',
+        file: '.gitignore',
+        line: undefined,
+        severity: 'high',
+      }),
+    ]);
+
+    const result = aggregateFindings(credData, SHIELD_EMPTY, '/tmp/target', hmaData);
+
+    // 2 findings: HMA's GIT-002 and credData's CRED-001 both kept.
+    expect(result).toHaveLength(2);
+    const sources = result.map(r => r.source).sort();
+    expect(sources).toEqual(['credential-scan', 'hma']);
+  });
+
+  it('upgrades HMA severity to max(hma, cred) when dedupe fires', () => {
+    // credData sees CRITICAL (sk-ant-*), HMA returns HIGH. Dedupe must
+    // preserve the higher severity so the Observations block and verdict
+    // reflect the worst case, not HMA's narrower classification.
+    const credData: CredentialPhaseData = {
+      matches: [makeCredMatch({
+        filePath: '/tmp/target/config.ts',
+        line: 10,
+        severity: 'critical',
+      })],
+      totalFindings: 1,
+      bySeverity: { critical: 1 },
+      driftFindings: [],
+      envVarSuggestions: [],
+    };
+    const hmaData = makeHmaData([
+      makeHmaFinding({
+        checkId: 'SEM-CRED-002',
+        file: 'config.ts',
+        line: 10,
+        severity: 'high',
+      }),
+    ]);
+
+    const result = aggregateFindings(credData, SHIELD_EMPTY, '/tmp/target', hmaData);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('hma');
+    expect(result[0].severity).toBe('critical');
+  });
 });

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -174,6 +174,11 @@ export interface HmaPhaseData {
   bySeverity: Record<string, number>;
   byCategory: Record<string, number>;
   topFindings: HmaFinding[];
+  /** Every failed HMA finding (not deduped, not capped). Used by aggregateFindings.
+   *  topFindings keeps the deduped-by-checkId + slice(0,30) list for the HMA tab
+   *  in the HTML report; this field preserves the raw set so the Observations
+   *  block and overview severity counts match `hackmyagent secure`. */
+  allFailedFindings: HmaFinding[];
 }
 
 export interface DetectPhaseData {
@@ -368,7 +373,7 @@ export async function review(options: ReviewOptions): Promise<number> {
   );
 
   // Aggregate findings
-  const findings = aggregateFindings(credentialData, shieldData, targetDir);
+  const findings = aggregateFindings(credentialData, shieldData, targetDir, hmaData);
 
   // Action items
   const actionItems = generateActionItems(credentialData, guardData, shieldData, initData);
@@ -681,7 +686,7 @@ async function runHmaPhase(targetDir: string): Promise<HmaPhaseData> {
   const emptyResult: HmaPhaseData = {
     available: false, score: 0, maxScore: 100,
     totalChecks: 0, passed: 0, failed: 0,
-    bySeverity: {}, byCategory: {}, topFindings: [],
+    bySeverity: {}, byCategory: {}, topFindings: [], allFailedFindings: [],
   };
 
   try {
@@ -764,6 +769,7 @@ async function runHmaPhase(targetDir: string): Promise<HmaPhaseData> {
       bySeverity,
       byCategory,
       topFindings,
+      allFailedFindings: failedFindings,
     };
   } catch {
     return emptyResult;
@@ -985,21 +991,50 @@ function computeRecoverySummary(
 
 // --- Findings Aggregation ---
 
-function aggregateFindings(
+export function aggregateFindings(
   credData: CredentialPhaseData,
   shieldData: ShieldPhaseData,
   targetDir: string,
+  hmaData: HmaPhaseData | null,
 ): ReviewFinding[] {
   const findings: ReviewFinding[] = [];
 
-  // Credential findings
+  // HMA findings first so we can dedupe credential-scan matches against them.
+  // HMA's credential detection is more comprehensive (context-gated, 200+ check
+  // IDs vs raw regex in quickCredentialScan), so we prefer HMA when both fire
+  // on the same file:line.
+  const hmaLocationKeys = new Set<string>();
+  if (hmaData && hmaData.available) {
+    for (const f of hmaData.allFailedFindings) {
+      if (f.file) {
+        const key = f.line != null ? `${f.file}:${f.line}` : f.file;
+        hmaLocationKeys.add(key);
+      }
+      findings.push({
+        id: f.checkId,
+        title: f.name,
+        severity: f.severity,
+        source: 'hma',
+        detail: f.file
+          ? (f.line != null ? `${f.file}:${f.line}` : f.file)
+          : (f.message || ''),
+        remediation: f.fix || f.guidance || '',
+      });
+    }
+  }
+
+  // Credential findings — skip any that duplicate an HMA finding at the
+  // same file:line (prefer HMA).
   for (const m of credData.matches) {
+    const rel = path.relative(targetDir, m.filePath);
+    const key = `${rel}:${m.line}`;
+    if (hmaLocationKeys.has(key)) continue;
     findings.push({
       id: m.findingId,
       title: m.title,
       severity: m.severity,
       source: 'credential-scan',
-      detail: `${path.relative(targetDir, m.filePath)}:${m.line}`,
+      detail: key,
       remediation: 'opena2a protect',
     });
   }

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -173,6 +173,8 @@ export interface HmaPhaseData {
   failed: number;
   bySeverity: Record<string, number>;
   byCategory: Record<string, number>;
+  /** Top 30 findings, deduped by checkId, for the HMA tab in the HTML report.
+   *  Display-only — do NOT use for severity counts. See allFailedFindings. */
   topFindings: HmaFinding[];
   /** Every failed HMA finding (not deduped, not capped). Used by aggregateFindings.
    *  topFindings keeps the deduped-by-checkId + slice(0,30) list for the HMA tab
@@ -1064,6 +1066,12 @@ export function aggregateFindings(
   // from credData's "critical" to HMA's "high".
   for (const m of credData.matches) {
     const rel = path.relative(targetDir, m.filePath);
+    // Defense in depth. credData.matches originates from walkFiles(targetDir,
+    // ...) in credential-patterns.ts and so should always be rooted inside
+    // targetDir, but if a symlink escape or upstream contract change ever
+    // leaks an absolute or parent-traversal path into the aggregation layer
+    // we drop it rather than render a misleading row in the review output.
+    if (rel.startsWith('..') || path.isAbsolute(rel)) continue;
     const lineKey = `${rel}:${m.line}`;
     const matchedLine = hmaCredLineKeys.has(lineKey);
     const matchedFile = hmaCredFileKeys.has(rel);

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -991,6 +991,30 @@ function computeRecoverySummary(
 
 // --- Findings Aggregation ---
 
+/** HMA check-ID prefixes that indicate a credential-related finding.
+ *  Used to scope the prefer-HMA dedupe: only credential HMA findings
+ *  suppress credential-scan matches. Non-credential HMA findings on the
+ *  same file (e.g. GIT-002 on .gitignore) MUST NOT hide a credential that
+ *  quickCredentialScan found in that file. */
+const HMA_CREDENTIAL_PREFIXES = [
+  'CRED', 'AST-CRED', 'WEBCRED', 'SEM-CRED', 'AGENT-CRED',
+  'ENVLEAK', 'CLIPASS', 'DRIFT',
+];
+
+function isHmaCredentialFinding(checkId: string): boolean {
+  const id = (checkId || '').toUpperCase();
+  for (const p of HMA_CREDENTIAL_PREFIXES) {
+    if (id === p || id.startsWith(p + '-')) return true;
+  }
+  return false;
+}
+
+const SEV_RANK: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1, info: 0 };
+
+function maxSeverity(a: string, b: string): string {
+  return (SEV_RANK[a] ?? 0) >= (SEV_RANK[b] ?? 0) ? a : b;
+}
+
 export function aggregateFindings(
   credData: CredentialPhaseData,
   shieldData: ShieldPhaseData,
@@ -1000,15 +1024,26 @@ export function aggregateFindings(
   const findings: ReviewFinding[] = [];
 
   // HMA findings first so we can dedupe credential-scan matches against them.
-  // HMA's credential detection is more comprehensive (context-gated, 200+ check
-  // IDs vs raw regex in quickCredentialScan), so we prefer HMA when both fire
-  // on the same file:line.
-  const hmaLocationKeys = new Set<string>();
+  // HMA's credential detection is context-gated across 200+ check IDs, so we
+  // prefer HMA for the credential surface. IMPORTANT: HMA often emits findings
+  // without a line number (e.g. file-level checks on .gitignore, package.json,
+  // and some credential patterns). We therefore key dedupe by BOTH `file:line`
+  // AND `file` alone, scoped to credential-category HMA findings only.
+  const hmaCredLineKeys = new Set<string>();
+  const hmaCredFileKeys = new Set<string>();
+  const hmaCredSevByKey = new Map<string, string>();
   if (hmaData && hmaData.available) {
     for (const f of hmaData.allFailedFindings) {
-      if (f.file) {
-        const key = f.line != null ? `${f.file}:${f.line}` : f.file;
-        hmaLocationKeys.add(key);
+      const cred = isHmaCredentialFinding(f.checkId);
+      if (cred && f.file) {
+        hmaCredFileKeys.add(f.file);
+        if (f.line != null) {
+          const k = `${f.file}:${f.line}`;
+          hmaCredLineKeys.add(k);
+          hmaCredSevByKey.set(k, f.severity);
+        } else {
+          hmaCredSevByKey.set(f.file, f.severity);
+        }
       }
       findings.push({
         id: f.checkId,
@@ -1023,18 +1058,35 @@ export function aggregateFindings(
     }
   }
 
-  // Credential findings — skip any that duplicate an HMA finding at the
-  // same file:line (prefer HMA).
+  // Credential findings — skip any that duplicate an HMA credential finding
+  // at the same location. When dedupe fires, upgrade the surviving HMA
+  // finding's severity to the max of the two so we don't silently narrow
+  // from credData's "critical" to HMA's "high".
   for (const m of credData.matches) {
     const rel = path.relative(targetDir, m.filePath);
-    const key = `${rel}:${m.line}`;
-    if (hmaLocationKeys.has(key)) continue;
+    const lineKey = `${rel}:${m.line}`;
+    const matchedLine = hmaCredLineKeys.has(lineKey);
+    const matchedFile = hmaCredFileKeys.has(rel);
+    if (matchedLine || matchedFile) {
+      const hmaKey = matchedLine ? lineKey : rel;
+      const prevSev = hmaCredSevByKey.get(hmaKey);
+      if (prevSev && SEV_RANK[m.severity] > SEV_RANK[prevSev]) {
+        // Upgrade the surviving HMA finding's severity.
+        for (const f of findings) {
+          if (f.source === 'hma' && (f.detail === lineKey || f.detail === rel)) {
+            f.severity = maxSeverity(f.severity, m.severity);
+          }
+        }
+        hmaCredSevByKey.set(hmaKey, maxSeverity(prevSev, m.severity));
+      }
+      continue;
+    }
     findings.push({
       id: m.findingId,
       title: m.title,
       severity: m.severity,
       source: 'credential-scan',
-      detail: key,
+      detail: lineKey,
       remediation: 'opena2a protect',
     });
   }

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -1064,14 +1064,19 @@ export function aggregateFindings(
   // at the same location. When dedupe fires, upgrade the surviving HMA
   // finding's severity to the max of the two so we don't silently narrow
   // from credData's "critical" to HMA's "high".
+  // Defense in depth. credData.matches originates from walkFiles(targetDir,
+  // ...) in credential-patterns.ts and so should always be rooted inside
+  // targetDir, but if a symlink escape or upstream contract change ever
+  // leaks an out-of-scope path into the aggregation layer we drop it rather
+  // than render a misleading row in the review output. Resolve both sides
+  // and require the credential file to be inside the target tree — catches
+  // absolute paths, parent-traversal, and the Windows-drive-letter-on-Unix
+  // case that a plain rel.startsWith('..') check misses.
+  const resolvedTarget = path.resolve(targetDir);
   for (const m of credData.matches) {
-    const rel = path.relative(targetDir, m.filePath);
-    // Defense in depth. credData.matches originates from walkFiles(targetDir,
-    // ...) in credential-patterns.ts and so should always be rooted inside
-    // targetDir, but if a symlink escape or upstream contract change ever
-    // leaks an absolute or parent-traversal path into the aggregation layer
-    // we drop it rather than render a misleading row in the review output.
-    if (rel.startsWith('..') || path.isAbsolute(rel)) continue;
+    const resolvedFile = path.resolve(m.filePath);
+    if (resolvedFile !== resolvedTarget && !resolvedFile.startsWith(resolvedTarget + path.sep)) continue;
+    const rel = path.relative(resolvedTarget, resolvedFile);
     const lineKey = `${rel}:${m.line}`;
     const matchedLine = hmaCredLineKeys.has(lineKey);
     const matchedFile = hmaCredFileKeys.has(rel);


### PR DESCRIPTION
## Summary

- `aggregateFindings` skipped the HMA phase entirely. On `test/hma/`, `opena2a review --ci` reported **1 critical** while `hackmyagent secure` on the same dir reported 34. Composite score (`hmaData.score`-driven) was correct; the text summary, the `@opena2a/cli-ui` Observations block, severity counts, and verdict all saw only credentials + shield data.
- Exposed `HmaPhaseData.allFailedFindings` (raw HMA output; `topFindings` still feeds the HTML report's HMA tab deduped+capped). `aggregateFindings` now takes `hmaData` and maps each failed HMA finding to a `ReviewFinding` with `source='hma'`. `checkId` flows through as `ReviewFinding.id` so cli-ui's `classifyCategory` routes into credentials/MCP/prompt/skill/etc. instead of collapsing to "other".
- Prefer-HMA credential dedupe scoped to credential-category HMA check prefixes (`CRED`, `AST-CRED`, `WEBCRED`, `SEM-CRED`, `AGENT-CRED`, `ENVLEAK`, `CLIPASS`, `DRIFT`) — non-credential HMA findings on a file never mask a credential found in that same file. Dedupe keys on both `file:line` and `file` alone (HMA frequently emits credential findings without a line number). When dedupe fires, the surviving HMA finding's severity is upgraded to `max(hmaSev, credSev)`.

### Verified on `test/hma/`

| Metric | Before | After |
|---|---:|---:|
| Composite score | 66/100 | 66/100 |
| Findings (total) | 1 | 232 |
| Findings (critical) | 1 | 56 |
| Categories populated | 1 (other) | 18 (credentials, MCP, prompt, skill, governance, supply-chain, ...) |
| Verdict lead | "Configuration file tampered" | "Dangerous npm Scripts + 231 more" |

Composite score stays driven by `hmaData.score`, not `findings.length` — this PR is display-only.

### Tests (+7, 884/884 passing)

- `review` integration: credentials from `quickCredentialScan` surface in the cli-ui "credentials" Categories bucket end-to-end.
- `aggregateFindings` unit tests cover:
  - prefer-HMA dedupe with explicit file:line on both sides
  - no-overlap pass-through
  - null `hmaData` backward-compat
  - **line-less HMA dedupe** (regression for the adversarial-review HIGH finding)
  - non-credential HMA prefix does NOT mask a credential on the same file
  - severity upgrade when dedupe fires

### Adversarial self-review (pre-push Phase 4.5)

General-purpose adversarial reviewer surfaced two defects in the initial commit (`6048bca`) that the second commit (`c772077`) fixes:
- HIGH: real HMA output omits line numbers on credential findings, making the initial `file:line`-only dedupe a dead code path in the canonical case.
- MEDIUM: dedupe silently downgraded severity when HMA's severity was lower than credData's.

Both addressed with regression tests before this PR opened.

### Pre-existing findings NOT in this PR

Pre-push HMA scan on the `opena2a` repo reports 14 CRITICAL / 17 HIGH / 25 MEDIUM. **All pre-existing**, all on documentation prose that HMA mis-classifies as agent config:
- `docs/use-cases/security-team.md` — HMA reads "You are a CISO..." prose as a weak system prompt and flags it for lacking injection defense.
- `packages/cli/BENCHMARK-REPORT.md` — HMA re-detects the adversarial payloads the report describes as live threats.
- `packages/cli/src/semantic/command-index.json` — HMA classifies the literal word "scan" in `"path": "opena2a scan"` as credential data.

Pattern matches known RAG-002/MEM-006 class FPs. Belongs in HMA 0.18 scanner cleanup, not this aggregation bugfix.

### Scope

Closes the P1 follow-up tracked in `memory/project_hma_observations_ux_shipped.md`. Aligns `opena2a review` output with `hackmyagent secure` on the same target.

## Test plan

- [x] `npm -w packages/cli run build` — clean
- [x] `npm -w packages/cli run lint` — clean
- [x] `npm -w packages/cli test` — 884/884 passing
- [x] Manual: `opena2a review --ci test/hma/` — totalFindings 1 → 232, 18 categories populated
- [x] Manual: `opena2a review --ci --skip-hma <empty>` — renders Observations block
- [x] Manual: `opena2a review --ci --format json test/hma/` — `hmaData.allFailedFindings` populated (231 entries)
- [x] Adversarial self-review (general-purpose subagent) — initial HIGH/MEDIUM findings fixed