### PR TITLE
ci: cross-CLI parity gate workflow (M0)

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -1,0 +1,26 @@
+name: parity
+
+on:
+  pull_request:
+    paths:
+      - "packages/cli/**"
+      - "packages/cli-ui/**"
+      - "packages/registry-client/**"
+      - "packages/check-core/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/parity.yml"
+  push:
+    branches: [main]
+
+concurrency:
+  group: parity-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  parity:
+    uses: opena2a-org/opena2a-parity/.github/workflows/parity.yml@main
+    with:
+      hma_ref: main
+      opena2a_ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      ai_trust_ref: main


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/parity.yml` in the monorepo. Path filter triggers on `packages/cli/**`, `packages/cli-ui/**`, and the future `packages/registry-client/**` and `packages/check-core/**`.
- Invokes the reusable workflow in `opena2a-org/opena2a-parity` with this PR's SHA.

This is one of four coordinated PRs delivering M0 of the CLI consolidation plan (CA-034 / CPO-019, committed 2026-04-22). See `opena2a-org/todo/2026-04-22-cli-consolidation-sequenced.md`.

Companion PRs:
- `opena2a-org/hackmyagent#113`
- `opena2a-org/ai-trust#30`
- `opena2a-org/opena2a-architecture` — `feat/parity-gate-mvp`

Harness: `opena2a-org/opena2a-parity` (new private repo, `main`).

## Why this matters for the opena2a monorepo specifically

End users increasingly land on the `opena2a` umbrella CLI as the primary surface. Contributors still work in the independent CLI repos. The parity gate is what keeps those two surfaces coherent as shared packages (`@opena2a/cli-ui`, future `registry-client`, `check-core`) absorb more logic. A change to any shared package in this monorepo runs the full parity harness before it can land.

## Known drift the gate will report but not fail on (M0)

`opena2a scan` (passthrough to HMA) currently emits ~2x findings vs `hackmyagent secure` on the same input — symptom of the hygiene overlay documented in the 2026-04-22 memory. The M0 contract is narrow (`platform`, `projectType`, `score`, `maxScore`) and accepts `findings` / `allFindings` as `may_differ` with a tracked reason. Closing that drift is M3 / M4 scope.

## Test plan

- [ ] Chief review (CA-034, CPO-019).
- [ ] First CI run post-merge triggered by a trivial `packages/cli/**` follow-up.

Do not merge. Chief sign-off required.