### PR TITLE
ci(release): enable @opena2a/aim-core publish step for TP Stage 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,11 +66,7 @@ jobs:
           publish_if_new packages/cli-ui @opena2a/cli-ui
           publish_if_new packages/contribute @opena2a/contribute
           publish_if_new packages/ai-classifier @opena2a/ai-classifier
-          # TODO(trusted-publishing-stage2): uncomment once @opena2a/aim-core
-          # has a Trusted Publisher configured on npmjs.com and the 0.1.2 -> 0.2.0
-          # migration from hackmyagent is signed off. Leaving commented prevents
-          # aim-core 0.2.0 from auto-publishing (and failing) on the next v* tag.
-          # publish_if_new packages/aim-core @opena2a/aim-core
+          publish_if_new packages/aim-core @opena2a/aim-core
           publish_if_new packages/registry-client @opena2a/registry-client
           echo "=== Published this run ==="
           cat /tmp/published.txt


### PR DESCRIPTION
## Summary

Uncomments `publish_if_new packages/aim-core @opena2a/aim-core` in `release.yml` so the next `aim-core-v*` tag push publishes `@opena2a/aim-core@0.2.0` via the existing Trusted Publishing workflow. No other change.

## Why this matters — secretless vault is silently broken in production

- `secretless-ai` pins `"@opena2a/aim-core": ">=0.2.0"` in its `package.json`.
- Only `0.1.2` is on npm today, and `0.1.2` does not contain the vault module.
- `secretless/src/vault-core.ts` does a dynamic `require('@opena2a/aim-core')` and surfaces a friendly "Install it: `npm install @opena2a/aim-core`" error — but that install currently resolves to `0.1.2`, which lacks the module the error message is trying to lead the user to.

Publishing `0.2.0` closes this. Full analysis: `briefs/aim-core-0.2.0-publish-decision.md`.

## Blast radius on downstream consumers

| Consumer | Pin | Behavior after 0.2.0 is on npm |
|----------|-----|--------------------------------|
| `hackmyagent` | `^0.1.2` | Caret respects major. `^0.1.2 = >=0.1.2 <0.2.0`. No auto-upgrade, no surprise. |
| `secretless-ai` | `>=0.2.0` | Now resolves. Vault feature becomes usable. |
| `opena2a-cli` (monorepo) | `*` | Next install pulls 0.2.0. Monorepo CI catches regressions before any user install. |
| `ai-trust` | (not a dependent) | No change. |

## Prerequisites landed

- TP configured on npmjs.com for `@opena2a/aim-core` — `opena2a-org/opena2a/release.yml`, env blank (confirmed 2026-04-22).
- `aim-core-v*` is already in the `on.push.tags` trigger list.
- `packages/aim-core/package.json` already at `0.2.0` (vault module merged via #74).

## Post-merge steps (this PR does not tag)

1. `git tag aim-core-v0.2.0` on main → push.
2. Watch workflow: `gh run watch`.
3. Verify SLSA v1: `npm view @opena2a/aim-core dist.attestations --json`.
4. Optional: `npm deprecate @opena2a/aim-core@0.1.2 "Install 0.2.0 or later for the vault module"`.
5. Smoke test secretless vault bridge against the freshly-published 0.2.0.

## Pre-push review

- **Phase 1 sensitive files:** clean.
- **Phase 2 build/test:** turbo build across all 6 packages green; `@opena2a/shared` 8/8 tests pass; workspace test suites pass.
- **Phase 3 code review:** single-line uncomment. No code change. The previous TODO comment's 3 concerns are now all resolved (TP configured, 0.2.0 sign-off landed via this decision, aim-core-v* in tag triggers).
- **Phase 4 HMA scan:** pre-existing 14 CRITICAL / 17 HIGH / 25 MEDIUM on main (same set as PR #87 2026-04-22). None introduced by this diff. Same disclosure precedent as #87.
- **Phases 4.5 / 5 / 6 / 7:** skipped per SKILL conditions.