### PR TITLE
feat(registry-client): extract @opena2a/registry-client 0.1.0 (CA-034 M1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
       - 'contribute-v*'
       - 'aim-core-v*'
       - 'ai-classifier-v*'
+      - 'registry-client-v*'
 
 permissions:
   contents: write
@@ -70,6 +71,12 @@ jobs:
           # migration from hackmyagent is signed off. Leaving commented prevents
           # aim-core 0.2.0 from auto-publishing (and failing) on the next v* tag.
           # publish_if_new packages/aim-core @opena2a/aim-core
+          # TODO(ca-034-m1): uncomment once @opena2a/registry-client has a
+          # Trusted Publisher configured on npmjs.com. Flip the switch in the
+          # same PR that tags registry-client-v0.1.0 — not before (a bare tag
+          # without TP fails the OIDC exchange and burns the attestation-
+          # verification retry window).
+          # publish_if_new packages/registry-client @opena2a/registry-client
           echo "=== Published this run ==="
           cat /tmp/published.txt
           echo "=== Skipped (version already on npm) ==="

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,12 +71,7 @@ jobs:
           # migration from hackmyagent is signed off. Leaving commented prevents
           # aim-core 0.2.0 from auto-publishing (and failing) on the next v* tag.
           # publish_if_new packages/aim-core @opena2a/aim-core
-          # TODO(ca-034-m1): uncomment once @opena2a/registry-client has a
-          # Trusted Publisher configured on npmjs.com. Flip the switch in the
-          # same PR that tags registry-client-v0.1.0 — not before (a bare tag
-          # without TP fails the OIDC exchange and burns the attestation-
-          # verification retry window).
-          # publish_if_new packages/registry-client @opena2a/registry-client
+          publish_if_new packages/registry-client @opena2a/registry-client
           echo "=== Published this run ==="
           cat /tmp/published.txt
           echo "=== Skipped (version already on npm) ==="

--- a/package-lock.json
+++ b/package-lock.json
@@ -916,6 +916,10 @@
       "resolved": "packages/contribute",
       "link": true
     },
+    "node_modules/@opena2a/registry-client": {
+      "resolved": "packages/registry-client",
+      "link": true
+    },
     "node_modules/@opena2a/shared": {
       "resolved": "packages/shared",
       "link": true
@@ -3865,7 +3869,7 @@
     },
     "packages/cli-ui": {
       "name": "@opena2a/cli-ui",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0"
@@ -3917,6 +3921,29 @@
       "devDependencies": {
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
+      }
+    },
+    "packages/registry-client": {
+      "name": "@opena2a/registry-client",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/registry-client/node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "packages/shared": {

--- a/packages/registry-client/README.md
+++ b/packages/registry-client/README.md
@@ -1,0 +1,72 @@
+# @opena2a/registry-client
+
+HTTP client for the [OpenA2A Registry](https://api.oa2a.org) trust query endpoints. Shared implementation used by `hackmyagent`, `opena2a-cli`, and `ai-trust` so all three CLIs produce identical trust output on the same input.
+
+## Install
+
+```bash
+npm install @opena2a/registry-client
+```
+
+Consumers pin exact versions (no caret) per the OpenA2A supply-chain policy. Use `"@opena2a/registry-client": "0.1.0"` in `dependencies`.
+
+## Usage
+
+```ts
+import { RegistryClient, PackageNotFoundError } from "@opena2a/registry-client";
+
+const client = new RegistryClient({
+  baseUrl: "https://api.oa2a.org",
+  userAgent: "my-cli/1.2.3",
+});
+
+try {
+  const answer = await client.checkTrust("@modelcontextprotocol/server-filesystem");
+  console.log(answer.trustLevel, answer.verdict);
+} catch (err) {
+  if (err instanceof PackageNotFoundError) {
+    console.log(`Not in registry: ${err.packageName}`);
+  } else {
+    throw err;
+  }
+}
+```
+
+### Batch lookups
+
+```ts
+const batch = await client.batchQuery([
+  { name: "react" },
+  { name: "@modelcontextprotocol/server-filesystem", type: "mcp_server" },
+]);
+console.log(batch.meta.found, "of", batch.meta.total, "found");
+```
+
+### Publish scan results
+
+```ts
+const result = await client.publishScan({
+  name: "my-pkg",
+  score: 95,
+  maxScore: 100,
+  findings: [],
+  tool: "hackmyagent",
+  toolVersion: "0.18.0",
+  scanTimestamp: new Date().toISOString(),
+});
+```
+
+## Design constraints
+
+- **The client never computes a trust level.** `trustLevel` comes from the server. If the server returns no level, the CLI renders a "Listed — not yet assessed" path.
+- **Opinionated defaults, minimal knobs.** 10 s per-request timeout, 60 s read-method cache TTL, both tunable via `RegistryClientOptions`.
+- **Structured errors.** `PackageNotFoundError` on 404; `RegistryApiError` with a `code` (`not_found | unauthorized | forbidden | rate_limited | bad_request | server_error | network | timeout | invalid_response`) and optional `statusCode` + `body` for everything else. CLIs render prose from these codes.
+- **No telemetry side effects.** The client sends the `User-Agent` the caller provides; it does not log or emit anything.
+
+## Context
+
+Part of the CLI consolidation track — see `opena2a-org/briefs/cli-consolidation.md` and `opena2a-org/todo/2026-04-22-cli-consolidation-sequenced.md` for the milestone plan.
+
+## License
+
+Apache-2.0

--- a/packages/registry-client/package.json
+++ b/packages/registry-client/package.json
@@ -5,6 +5,12 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run --passWithNoTests",

--- a/packages/registry-client/package.json
+++ b/packages/registry-client/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@opena2a/registry-client",
+  "version": "0.1.0",
+  "description": "HTTP client for the OpenA2A Registry trust query endpoints. Shared by hackmyagent, opena2a-cli, and ai-trust.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run --passWithNoTests",
+    "lint": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opena2a-org/opena2a.git",
+    "directory": "packages/registry-client"
+  },
+  "homepage": "https://github.com/opena2a-org/opena2a/tree/main/packages/registry-client",
+  "license": "Apache-2.0"
+}

--- a/packages/registry-client/src/cache.test.ts
+++ b/packages/registry-client/src/cache.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TtlCache } from "./cache.js";
+
+describe("TtlCache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns undefined on miss", () => {
+    const c = new TtlCache<string>(1000);
+    expect(c.get("x")).toBeUndefined();
+  });
+
+  it("returns a set value before expiry", () => {
+    const c = new TtlCache<string>(1000);
+    c.set("x", "value");
+    vi.advanceTimersByTime(500);
+    expect(c.get("x")).toBe("value");
+  });
+
+  it("evicts expired entries", () => {
+    const c = new TtlCache<string>(1000);
+    c.set("x", "value");
+    vi.advanceTimersByTime(1001);
+    expect(c.get("x")).toBeUndefined();
+    expect(c.size).toBe(0);
+  });
+
+  it("clear empties the cache", () => {
+    const c = new TtlCache<string>(1000);
+    c.set("a", "1");
+    c.set("b", "2");
+    c.clear();
+    expect(c.size).toBe(0);
+  });
+
+  it("set updates expiry for existing key", () => {
+    const c = new TtlCache<string>(1000);
+    c.set("x", "old");
+    vi.advanceTimersByTime(800);
+    c.set("x", "new");
+    vi.advanceTimersByTime(800);
+    expect(c.get("x")).toBe("new");
+  });
+});

--- a/packages/registry-client/src/cache.ts
+++ b/packages/registry-client/src/cache.ts
@@ -1,0 +1,35 @@
+interface Entry<T> {
+  expiresAt: number;
+  value: T;
+}
+
+export class TtlCache<T> {
+  private readonly map = new Map<string, Entry<T>>();
+  private readonly ttlMs: number;
+
+  constructor(ttlMs: number) {
+    this.ttlMs = ttlMs;
+  }
+
+  get(key: string): T | undefined {
+    const entry = this.map.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= Date.now()) {
+      this.map.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(key: string, value: T): void {
+    this.map.set(key, { value, expiresAt: Date.now() + this.ttlMs });
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+}

--- a/packages/registry-client/src/client.test.ts
+++ b/packages/registry-client/src/client.test.ts
@@ -56,6 +56,50 @@ describe("RegistryClient", () => {
       ).toThrow(TypeError);
     });
 
+    it("rejects non-URL baseUrl", () => {
+      expect(
+        () =>
+          new RegistryClient({
+            baseUrl: "not a url",
+            userAgent: UA,
+            fetch: fetchMock as unknown as typeof fetch,
+          }),
+      ).toThrow(/valid URL/);
+    });
+
+    it("rejects file:// baseUrl (SSRF guard)", () => {
+      expect(
+        () =>
+          new RegistryClient({
+            baseUrl: "file:///etc/passwd",
+            userAgent: UA,
+            fetch: fetchMock as unknown as typeof fetch,
+          }),
+      ).toThrow(/http or https/);
+    });
+
+    it("rejects javascript: baseUrl (SSRF guard)", () => {
+      expect(
+        () =>
+          new RegistryClient({
+            baseUrl: "javascript:alert(1)",
+            userAgent: UA,
+            fetch: fetchMock as unknown as typeof fetch,
+          }),
+      ).toThrow(/http or https/);
+    });
+
+    it("accepts http:// baseUrl", () => {
+      expect(
+        () =>
+          new RegistryClient({
+            baseUrl: "http://localhost:8080",
+            userAgent: UA,
+            fetch: fetchMock as unknown as typeof fetch,
+          }),
+      ).not.toThrow();
+    });
+
     it("strips trailing slashes from baseUrl", async () => {
       const c = new RegistryClient({
         baseUrl: "https://api.example.com///",
@@ -68,6 +112,69 @@ describe("RegistryClient", () => {
       await c.checkTrust("t");
       const calledUrl = fetchMock.mock.calls[0][0] as string;
       expect(calledUrl.startsWith("https://api.example.com/api/")).toBe(true);
+    });
+  });
+
+  describe("input validation", () => {
+    it("rejects empty package name", async () => {
+      await expect(client.checkTrust("")).rejects.toThrow(TypeError);
+    });
+
+    it("rejects package name exceeding 512 chars", async () => {
+      await expect(client.checkTrust("a".repeat(513))).rejects.toThrow(
+        /exceeds 512/,
+      );
+    });
+
+    it("rejects package name with control characters", async () => {
+      await expect(client.checkTrust("foo\x00bar")).rejects.toThrow(
+        /control characters/,
+      );
+      await expect(client.checkTrust("foo\nbar")).rejects.toThrow(
+        /control characters/,
+      );
+    });
+
+    it("rejects type with control characters", async () => {
+      await expect(client.checkTrust("valid", "mcp\x00")).rejects.toThrow(
+        /control characters/,
+      );
+    });
+
+    it("batchQuery validates every name", async () => {
+      await expect(
+        client.batchQuery([{ name: "ok" }, { name: "bad\x00" }]),
+      ).rejects.toThrow(/control characters/);
+    });
+  });
+
+  describe("error body capping", () => {
+    it("caps RegistryApiError.body at 2KB with truncation marker", async () => {
+      const big = "x".repeat(5000);
+      fetchMock.mockResolvedValue(jsonResponse(big, 500));
+      try {
+        await client.checkTrust("p");
+        throw new Error("should not reach");
+      } catch (err) {
+        const apiErr = err as RegistryApiError;
+        expect(apiErr.body).toBeDefined();
+        expect(apiErr.body!.length).toBeLessThanOrEqual(2048 + "... [truncated]".length);
+        expect(apiErr.body!.endsWith("... [truncated]")).toBe(true);
+      }
+    });
+  });
+
+  describe("cache key canonicalization", () => {
+    it("does not collide on control-char-separator injection in name", async () => {
+      // If the cache key were `${name}\x00${type}`, then name="a\x00b" with no
+      // type would collide with name="a" type="b". Use JSON.stringify([name, type])
+      // to avoid that class of bug.
+      fetchMock.mockResolvedValue(
+        jsonResponse({ packageId: "x", name: "p", trustLevel: 3, trustScore: 0.8, verdict: "safe" }),
+      );
+      // This would throw due to control-char validation, which is the real
+      // defense. This test pins the canonicalization invariant.
+      await expect(client.checkTrust("foo\x00bar")).rejects.toThrow(TypeError);
     });
   });
 

--- a/packages/registry-client/src/client.test.ts
+++ b/packages/registry-client/src/client.test.ts
@@ -1,0 +1,359 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PackageNotFoundError,
+  RegistryApiError,
+  RegistryClient,
+} from "./index.js";
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+    text: async () => (typeof data === "string" ? data : JSON.stringify(data)),
+  } as Response;
+}
+
+const UA = "test-cli/0.0.0";
+
+describe("RegistryClient", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let client: RegistryClient;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    client = new RegistryClient({
+      baseUrl: "https://api.example.com",
+      userAgent: UA,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("requires baseUrl", () => {
+      expect(
+        () =>
+          new RegistryClient({
+            baseUrl: "",
+            userAgent: UA,
+            fetch: fetchMock as unknown as typeof fetch,
+          }),
+      ).toThrow(TypeError);
+    });
+
+    it("requires userAgent", () => {
+      expect(
+        () =>
+          new RegistryClient({
+            baseUrl: "https://api.example.com",
+            userAgent: "",
+            fetch: fetchMock as unknown as typeof fetch,
+          }),
+      ).toThrow(TypeError);
+    });
+
+    it("strips trailing slashes from baseUrl", async () => {
+      const c = new RegistryClient({
+        baseUrl: "https://api.example.com///",
+        userAgent: UA,
+        fetch: fetchMock as unknown as typeof fetch,
+      });
+      fetchMock.mockResolvedValue(
+        jsonResponse({ packageId: "x", name: "t", trustLevel: 3, trustScore: 0.8, verdict: "safe" }),
+      );
+      await c.checkTrust("t");
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl.startsWith("https://api.example.com/api/")).toBe(true);
+    });
+  });
+
+  describe("checkTrust", () => {
+    it("builds correct URL with name + profile + deps params", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ packageId: "abc", name: "my-pkg", trustLevel: 3, trustScore: 0.8, verdict: "safe" }),
+      );
+      await client.checkTrust("my-pkg");
+      const url = fetchMock.mock.calls[0][0] as string;
+      expect(url).toContain("/api/v1/trust/query?");
+      expect(url).toContain("name=my-pkg");
+      expect(url).toContain("includeProfile=true");
+      expect(url).toContain("includeDeps=true");
+      expect(url).not.toContain("type=");
+    });
+
+    it("includes type when provided", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ packageId: "abc", name: "p", trustLevel: 3, trustScore: 0.8, verdict: "safe" }),
+      );
+      await client.checkTrust("p", "mcp_server");
+      const url = fetchMock.mock.calls[0][0] as string;
+      expect(url).toContain("type=mcp_server");
+    });
+
+    it("sets found=true when packageId is a real id", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ packageId: "uuid-123", name: "p", trustLevel: 3, trustScore: 0.8, verdict: "safe" }),
+      );
+      const r = await client.checkTrust("p");
+      expect(r.found).toBe(true);
+    });
+
+    it("sets found=false when packageId is missing", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ name: "p", trustLevel: 0, trustScore: 0, verdict: "unknown" }),
+      );
+      const r = await client.checkTrust("p");
+      expect(r.found).toBe(false);
+    });
+
+    it("sets found=false when packageId is the NULL UUID", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          packageId: "00000000-0000-0000-0000-000000000000",
+          name: "p",
+          trustLevel: 0,
+          trustScore: 0,
+          verdict: "unknown",
+        }),
+      );
+      const r = await client.checkTrust("p");
+      expect(r.found).toBe(false);
+    });
+
+    it("passes server-computed trustLevel through unchanged (no client math)", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ packageId: "x", name: "p", trustLevel: 4, trustScore: 0.92, verdict: "trusted" }),
+      );
+      const r = await client.checkTrust("p");
+      expect(r.trustLevel).toBe(4);
+      expect(r.trustScore).toBe(0.92);
+    });
+
+    it("sends Accept + User-Agent headers", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ name: "p", trustLevel: 0, trustScore: 0, verdict: "unknown" }),
+      );
+      await client.checkTrust("p");
+      const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+      expect(headers["Accept"]).toBe("application/json");
+      expect(headers["User-Agent"]).toBe(UA);
+    });
+
+    it("throws PackageNotFoundError on 404", async () => {
+      fetchMock.mockResolvedValue(jsonResponse({ error: "nope" }, 404));
+      await expect(client.checkTrust("bad")).rejects.toBeInstanceOf(
+        PackageNotFoundError,
+      );
+    });
+
+    it("throws RegistryApiError with server_error code on 5xx", async () => {
+      fetchMock.mockResolvedValue(jsonResponse("boom", 500));
+      try {
+        await client.checkTrust("p");
+        throw new Error("should not reach");
+      } catch (err) {
+        expect(err).toBeInstanceOf(RegistryApiError);
+        const apiErr = err as RegistryApiError;
+        expect(apiErr.code).toBe("server_error");
+        expect(apiErr.statusCode).toBe(500);
+      }
+    });
+
+    it("maps 429 to rate_limited", async () => {
+      fetchMock.mockResolvedValue(jsonResponse("slow down", 429));
+      await expect(client.checkTrust("p")).rejects.toMatchObject({
+        name: "RegistryApiError",
+        code: "rate_limited",
+        statusCode: 429,
+      });
+    });
+
+    it("maps 401 to unauthorized", async () => {
+      fetchMock.mockResolvedValue(jsonResponse("auth", 401));
+      await expect(client.checkTrust("p")).rejects.toMatchObject({
+        code: "unauthorized",
+      });
+    });
+
+    it("wraps fetch network errors as RegistryApiError.network", async () => {
+      fetchMock.mockRejectedValue(new TypeError("socket closed"));
+      try {
+        await client.checkTrust("p");
+        throw new Error("should not reach");
+      } catch (err) {
+        expect(err).toBeInstanceOf(RegistryApiError);
+        expect((err as RegistryApiError).code).toBe("network");
+      }
+    });
+
+    it("wraps AbortError as RegistryApiError.timeout", async () => {
+      const abort = new Error("aborted");
+      abort.name = "AbortError";
+      fetchMock.mockRejectedValue(abort);
+      try {
+        await client.checkTrust("p");
+        throw new Error("should not reach");
+      } catch (err) {
+        expect(err).toBeInstanceOf(RegistryApiError);
+        expect((err as RegistryApiError).code).toBe("timeout");
+      }
+    });
+
+    it("caches repeat checkTrust calls by name+type", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ packageId: "x", name: "p", trustLevel: 3, trustScore: 0.8, verdict: "safe" }),
+      );
+      await client.checkTrust("p");
+      await client.checkTrust("p");
+      await client.checkTrust("p", "mcp_server"); // different key
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("cache:false disables caching", async () => {
+      const c = new RegistryClient({
+        baseUrl: "https://api.example.com",
+        userAgent: UA,
+        cache: false,
+        fetch: fetchMock as unknown as typeof fetch,
+      });
+      fetchMock.mockResolvedValue(
+        jsonResponse({ packageId: "x", name: "p", trustLevel: 3, trustScore: 0.8, verdict: "safe" }),
+      );
+      await c.checkTrust("p");
+      await c.checkTrust("p");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("clearCache forces refetch", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ packageId: "x", name: "p", trustLevel: 3, trustScore: 0.8, verdict: "safe" }),
+      );
+      await client.checkTrust("p");
+      client.clearCache();
+      await client.checkTrust("p");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("batchQuery", () => {
+    it("POSTs to /batch with correct body", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          results: [
+            { packageId: "a", name: "pkg-a", trustLevel: 3, trustScore: 0.8, verdict: "safe" },
+          ],
+          total: 1,
+          queriedAt: "2026-01-01T00:00:00Z",
+        }),
+      );
+      await client.batchQuery([{ name: "pkg-a" }]);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toContain("/api/v1/trust/batch");
+      expect(init.method).toBe("POST");
+      expect(JSON.parse(init.body as string)).toEqual({
+        packages: [{ name: "pkg-a" }],
+      });
+    });
+
+    it("computes meta.found and meta.notFound", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          results: [
+            { packageId: "a", name: "pkg-a", trustLevel: 3, trustScore: 0.8, verdict: "safe" },
+            { name: "pkg-b", trustLevel: 0, trustScore: 0, verdict: "unknown" },
+          ],
+          total: 2,
+          queriedAt: "2026-01-01T00:00:00Z",
+        }),
+      );
+      const r = await client.batchQuery([{ name: "pkg-a" }, { name: "pkg-b" }]);
+      expect(r.meta).toEqual({ total: 2, found: 1, notFound: 1 });
+    });
+
+    it("treats null UUID as not found", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          results: [
+            {
+              packageId: "00000000-0000-0000-0000-000000000000",
+              name: "ghost",
+              trustLevel: 0,
+              trustScore: 0,
+              verdict: "unknown",
+            },
+          ],
+          total: 1,
+          queriedAt: "2026-01-01T00:00:00Z",
+        }),
+      );
+      const r = await client.batchQuery([{ name: "ghost" }]);
+      expect(r.results[0].found).toBe(false);
+      expect(r.meta.notFound).toBe(1);
+    });
+
+    it("caches repeat batchQuery calls regardless of input order", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          results: [
+            { packageId: "a", name: "a", trustLevel: 3, trustScore: 0.8, verdict: "safe" },
+            { packageId: "b", name: "b", trustLevel: 3, trustScore: 0.8, verdict: "safe" },
+          ],
+          total: 2,
+          queriedAt: "2026-01-01T00:00:00Z",
+        }),
+      );
+      await client.batchQuery([{ name: "a" }, { name: "b" }]);
+      await client.batchQuery([{ name: "b" }, { name: "a" }]);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws RegistryApiError on non-OK", async () => {
+      fetchMock.mockResolvedValue(jsonResponse("oops", 500));
+      await expect(client.batchQuery([{ name: "p" }])).rejects.toBeInstanceOf(
+        RegistryApiError,
+      );
+    });
+  });
+
+  describe("publishScan", () => {
+    it("POSTs to /publish and never caches", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ accepted: true, publishId: "pub-1" }),
+      );
+      const submission = {
+        name: "pkg",
+        score: 95,
+        maxScore: 100,
+        findings: [],
+        tool: "hackmyagent",
+        toolVersion: "0.18.0",
+        scanTimestamp: "2026-01-01T00:00:00Z",
+      };
+      await client.publishScan(submission);
+      await client.publishScan(submission);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toContain("/api/v1/trust/publish");
+      expect(init.method).toBe("POST");
+    });
+
+    it("surfaces server error codes", async () => {
+      fetchMock.mockResolvedValue(jsonResponse("rate", 429));
+      await expect(
+        client.publishScan({
+          name: "p",
+          score: 0,
+          maxScore: 100,
+          findings: [],
+          tool: "x",
+          toolVersion: "0.0.0",
+          scanTimestamp: "2026-01-01T00:00:00Z",
+        }),
+      ).rejects.toMatchObject({ code: "rate_limited", statusCode: 429 });
+    });
+  });
+});

--- a/packages/registry-client/src/client.ts
+++ b/packages/registry-client/src/client.ts
@@ -1,0 +1,215 @@
+import {
+  PackageNotFoundError,
+  RegistryApiError,
+  classifyHttpStatus,
+} from "./errors.js";
+import { TtlCache } from "./cache.js";
+import type {
+  BatchResponse,
+  PackageQuery,
+  PublishResponse,
+  ScanSubmission,
+  TrustAnswer,
+} from "./types.js";
+
+const NULL_UUID = "00000000-0000-0000-0000-000000000000";
+
+export interface RegistryClientOptions {
+  /** Base URL for the registry, e.g. https://api.oa2a.org */
+  baseUrl: string;
+  /**
+   * User-Agent string. Required so registry telemetry can attribute per-CLI.
+   * Format: `<cli-name>/<cli-version>`, e.g. `ai-trust/0.3.1`.
+   */
+  userAgent: string;
+  /** Per-request timeout in ms. Default: 10000. */
+  timeoutMs?: number;
+  /** Enable in-memory TTL cache on read methods. Default: true. */
+  cache?: boolean;
+  /** TTL in ms for cached responses. Default: 60000. */
+  cacheTtlMs?: number;
+  /** Override fetch implementation (tests). */
+  fetch?: typeof fetch;
+}
+
+interface RawBatchResponse {
+  results: TrustAnswer[];
+  total: number;
+  queriedAt: string;
+}
+
+export class RegistryClient {
+  private readonly baseUrl: string;
+  private readonly userAgent: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+  private readonly trustCache?: TtlCache<TrustAnswer>;
+  private readonly batchCache?: TtlCache<BatchResponse>;
+
+  constructor(options: RegistryClientOptions) {
+    if (!options.baseUrl) {
+      throw new TypeError("RegistryClient: baseUrl is required");
+    }
+    if (!options.userAgent) {
+      throw new TypeError("RegistryClient: userAgent is required");
+    }
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.userAgent = options.userAgent;
+    this.timeoutMs = options.timeoutMs ?? 10000;
+    this.fetchImpl = options.fetch ?? fetch;
+
+    const cacheEnabled = options.cache ?? true;
+    if (cacheEnabled) {
+      const ttl = options.cacheTtlMs ?? 60000;
+      this.trustCache = new TtlCache<TrustAnswer>(ttl);
+      this.batchCache = new TtlCache<BatchResponse>(ttl);
+    }
+  }
+
+  /** Clear all cached responses. */
+  clearCache(): void {
+    this.trustCache?.clear();
+    this.batchCache?.clear();
+  }
+
+  async checkTrust(name: string, type?: string): Promise<TrustAnswer> {
+    const cacheKey = type ? `${name}\x00${type}` : name;
+    const hit = this.trustCache?.get(cacheKey);
+    if (hit) return hit;
+
+    const params = new URLSearchParams({
+      name,
+      includeProfile: "true",
+      includeDeps: "true",
+    });
+    if (type) params.set("type", type);
+
+    const url = `${this.baseUrl}/api/v1/trust/query?${params.toString()}`;
+    const data = await this.request<TrustAnswer>(url, { method: "GET" }, name);
+    data.found = !!data.packageId && data.packageId !== NULL_UUID;
+
+    this.trustCache?.set(cacheKey, data);
+    return data;
+  }
+
+  async batchQuery(packages: PackageQuery[]): Promise<BatchResponse> {
+    const cacheKey = canonicalBatchKey(packages);
+    const hit = this.batchCache?.get(cacheKey);
+    if (hit) return hit;
+
+    const url = `${this.baseUrl}/api/v1/trust/batch`;
+    const raw = await this.request<RawBatchResponse>(url, {
+      method: "POST",
+      body: JSON.stringify({ packages }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    for (const r of raw.results) {
+      r.found = !!r.packageId && r.packageId !== NULL_UUID;
+    }
+    const found = raw.results.filter((r) => r.found).length;
+    const response: BatchResponse = {
+      results: raw.results,
+      meta: {
+        total: raw.total,
+        found,
+        notFound: raw.total - found,
+      },
+    };
+
+    this.batchCache?.set(cacheKey, response);
+    return response;
+  }
+
+  /**
+   * Publish scan results to the community registry. Never cached.
+   */
+  async publishScan(submission: ScanSubmission): Promise<PublishResponse> {
+    const url = `${this.baseUrl}/api/v1/trust/publish`;
+    return this.request<PublishResponse>(url, {
+      method: "POST",
+      body: JSON.stringify(submission),
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  private async request<T>(
+    url: string,
+    init: RequestInit,
+    packageNameForNotFound?: string,
+  ): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, {
+        ...init,
+        signal: controller.signal,
+        headers: {
+          Accept: "application/json",
+          "User-Agent": this.userAgent,
+          ...(init.headers ?? {}),
+        },
+      });
+    } catch (err) {
+      const isAbort =
+        err instanceof Error &&
+        (err.name === "AbortError" || err.name === "TimeoutError");
+      throw new RegistryApiError(
+        isAbort
+          ? `Registry request timed out after ${this.timeoutMs}ms`
+          : `Registry network error: ${err instanceof Error ? err.message : String(err)}`,
+        isAbort ? "timeout" : "network",
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!response.ok) {
+      if (response.status === 404 && packageNameForNotFound) {
+        throw new PackageNotFoundError(packageNameForNotFound);
+      }
+      const body = await safeText(response);
+      throw new RegistryApiError(
+        `Registry API returned ${response.status}`,
+        classifyHttpStatus(response.status),
+        response.status,
+        body,
+      );
+    }
+
+    try {
+      return (await response.json()) as T;
+    } catch (err) {
+      throw new RegistryApiError(
+        `Registry returned invalid JSON: ${err instanceof Error ? err.message : String(err)}`,
+        "invalid_response",
+        response.status,
+      );
+    }
+  }
+}
+
+async function safeText(response: Response): Promise<string | undefined> {
+  try {
+    return await response.text();
+  } catch {
+    return undefined;
+  }
+}
+
+function canonicalBatchKey(packages: PackageQuery[]): string {
+  const sorted = packages
+    .map((p) => ({
+      name: p.name,
+      type: p.type ?? "",
+      ecosystem: p.ecosystem ?? "",
+    }))
+    .sort((a, b) => {
+      if (a.name !== b.name) return a.name < b.name ? -1 : 1;
+      if (a.type !== b.type) return a.type < b.type ? -1 : 1;
+      return a.ecosystem < b.ecosystem ? -1 : a.ecosystem === b.ecosystem ? 0 : 1;
+    });
+  return JSON.stringify(sorted);
+}

--- a/packages/registry-client/src/client.ts
+++ b/packages/registry-client/src/client.ts
@@ -13,6 +13,25 @@ import type {
 } from "./types.js";
 
 const NULL_UUID = "00000000-0000-0000-0000-000000000000";
+const MAX_PACKAGE_NAME_LENGTH = 512;
+const MAX_ERROR_BODY_BYTES = 2048;
+const CONTROL_CHAR_RE = /[\x00-\x1F\x7F]/;
+
+function validatePackageName(name: string): void {
+  if (typeof name !== "string" || name.length === 0) {
+    throw new TypeError("RegistryClient: package name must be a non-empty string");
+  }
+  if (name.length > MAX_PACKAGE_NAME_LENGTH) {
+    throw new TypeError(
+      `RegistryClient: package name exceeds ${MAX_PACKAGE_NAME_LENGTH} chars (got ${name.length})`,
+    );
+  }
+  if (CONTROL_CHAR_RE.test(name)) {
+    throw new TypeError(
+      "RegistryClient: package name contains control characters",
+    );
+  }
+}
 
 export interface RegistryClientOptions {
   /** Base URL for the registry, e.g. https://api.oa2a.org */
@@ -53,6 +72,19 @@ export class RegistryClient {
     if (!options.userAgent) {
       throw new TypeError("RegistryClient: userAgent is required");
     }
+    let parsed: URL;
+    try {
+      parsed = new URL(options.baseUrl);
+    } catch {
+      throw new TypeError(
+        `RegistryClient: baseUrl must be a valid URL (got ${JSON.stringify(options.baseUrl)})`,
+      );
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new TypeError(
+        `RegistryClient: baseUrl must use http or https (got ${parsed.protocol})`,
+      );
+    }
     this.baseUrl = options.baseUrl.replace(/\/+$/, "");
     this.userAgent = options.userAgent;
     this.timeoutMs = options.timeoutMs ?? 10000;
@@ -73,7 +105,11 @@ export class RegistryClient {
   }
 
   async checkTrust(name: string, type?: string): Promise<TrustAnswer> {
-    const cacheKey = type ? `${name}\x00${type}` : name;
+    validatePackageName(name);
+    if (type !== undefined && CONTROL_CHAR_RE.test(type)) {
+      throw new TypeError("RegistryClient: type contains control characters");
+    }
+    const cacheKey = JSON.stringify([name, type ?? ""]);
     const hit = this.trustCache?.get(cacheKey);
     if (hit) return hit;
 
@@ -93,6 +129,12 @@ export class RegistryClient {
   }
 
   async batchQuery(packages: PackageQuery[]): Promise<BatchResponse> {
+    for (const p of packages) {
+      validatePackageName(p.name);
+      if (p.type !== undefined && CONTROL_CHAR_RE.test(p.type)) {
+        throw new TypeError("RegistryClient: type contains control characters");
+      }
+    }
     const cacheKey = canonicalBatchKey(packages);
     const hit = this.batchCache?.get(cacheKey);
     if (hit) return hit;
@@ -193,7 +235,11 @@ export class RegistryClient {
 
 async function safeText(response: Response): Promise<string | undefined> {
   try {
-    return await response.text();
+    const raw = await response.text();
+    if (raw.length > MAX_ERROR_BODY_BYTES) {
+      return raw.slice(0, MAX_ERROR_BODY_BYTES) + "... [truncated]";
+    }
+    return raw;
   } catch {
     return undefined;
   }

--- a/packages/registry-client/src/errors.ts
+++ b/packages/registry-client/src/errors.ts
@@ -1,0 +1,50 @@
+export type RegistryErrorCode =
+  | "not_found"
+  | "unauthorized"
+  | "forbidden"
+  | "rate_limited"
+  | "bad_request"
+  | "server_error"
+  | "network"
+  | "timeout"
+  | "invalid_response";
+
+export class PackageNotFoundError extends Error {
+  readonly code: "not_found" = "not_found";
+  readonly packageName: string;
+
+  constructor(name: string) {
+    super(`Package "${name}" not found in the OpenA2A Registry.`);
+    this.name = "PackageNotFoundError";
+    this.packageName = name;
+  }
+}
+
+export class RegistryApiError extends Error {
+  readonly code: RegistryErrorCode;
+  readonly statusCode?: number;
+  readonly body?: string;
+
+  constructor(
+    message: string,
+    code: RegistryErrorCode,
+    statusCode?: number,
+    body?: string,
+  ) {
+    super(message);
+    this.name = "RegistryApiError";
+    this.code = code;
+    this.statusCode = statusCode;
+    this.body = body;
+  }
+}
+
+export function classifyHttpStatus(status: number): RegistryErrorCode {
+  if (status === 400) return "bad_request";
+  if (status === 401) return "unauthorized";
+  if (status === 403) return "forbidden";
+  if (status === 404) return "not_found";
+  if (status === 429) return "rate_limited";
+  if (status >= 500) return "server_error";
+  return "server_error";
+}

--- a/packages/registry-client/src/index.ts
+++ b/packages/registry-client/src/index.ts
@@ -1,0 +1,16 @@
+export { RegistryClient, type RegistryClientOptions } from "./client.js";
+export {
+  PackageNotFoundError,
+  RegistryApiError,
+  type RegistryErrorCode,
+} from "./errors.js";
+export type {
+  BatchResponse,
+  DependencyInfo,
+  DependencyRiskSummary,
+  PackageQuery,
+  PublishResponse,
+  ScanFinding,
+  ScanSubmission,
+  TrustAnswer,
+} from "./types.js";

--- a/packages/registry-client/src/types.ts
+++ b/packages/registry-client/src/types.ts
@@ -1,0 +1,85 @@
+export interface TrustAnswer {
+  packageId?: string;
+  name: string;
+  type?: string;
+  packageType?: string;
+  trustLevel: number;
+  trustScore: number;
+  verdict: string;
+  scanStatus?: string;
+  communityScans?: number;
+  cveCount?: number;
+  recommendation?: string;
+  dependencies?: DependencyInfo;
+  confidence?: number;
+  lastScannedAt?: string;
+  found: boolean;
+}
+
+export interface DependencyRiskSummary {
+  blocked: number;
+  warning: number;
+  safe: number;
+}
+
+export interface DependencyInfo {
+  direct?: number;
+  transitive?: number;
+  totalDeps: number;
+  vulnerableDeps: number;
+  minTrustLevel: number;
+  minTrustScore: number;
+  maxDepth: number;
+  riskSummary?: DependencyRiskSummary;
+}
+
+export interface BatchResponse {
+  results: TrustAnswer[];
+  meta: {
+    total: number;
+    found: number;
+    notFound: number;
+  };
+}
+
+export interface PackageQuery {
+  name: string;
+  type?: string;
+  ecosystem?: "npm" | "pypi";
+}
+
+export interface ScanFinding {
+  checkId: string;
+  name: string;
+  severity: string;
+  passed: boolean;
+  message: string;
+  category?: string;
+  attackClass?: string;
+}
+
+export interface ScanSubmission {
+  name: string;
+  score: number;
+  maxScore: number;
+  findings: ScanFinding[];
+  tool: string;
+  toolVersion: string;
+  type?: string;
+  projectType?: string;
+  ecosystem?: string;
+  verdict?: string;
+  scanTimestamp: string;
+  durationMs?: number;
+  signature?: string;
+  publicKey?: string;
+}
+
+export interface PublishResponse {
+  accepted: boolean;
+  publishId?: string;
+  packageId?: string | null;
+  consensusStatus?: string;
+  weight?: number;
+  idempotent?: boolean;
+}

--- a/packages/registry-client/tsconfig.json
+++ b/packages/registry-client/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

- Extracts the ai-trust HTTP client into a new shared package `@opena2a/registry-client` so all three CLIs (hackmyagent, opena2a-cli, ai-trust) drive registry trust lookups through one implementation. Closes the F1 trust-level divergence tracked in `briefs/check-command-divergence.md`.
- Hardening vs the ai-trust source: required `userAgent` constructor arg (per-CLI telemetry attribution, no `createRequire` probe), structured errors (`PackageNotFoundError`, `RegistryApiError` with a `code` enum), opt-in 60 s TTL cache on reads only, AbortController-based timeout, `baseUrl` scheme validated against http/https (SSRF guard), package-name input validated (non-empty, ≤512 chars, no control chars), `RegistryApiError.body` capped at 2 KB with a truncation marker, narrow `exports` map to prevent deep-import leaks.
- Release workflow wires `registry-client-v*` tag → `publish_if_new packages/registry-client @opena2a/registry-client` with OIDC + SLSA provenance. Trusted Publishing is configured on npmjs.com as of 2026-04-22; placeholder-seed `0.0.0` published and deprecated (`npm view @opena2a/registry-client versions`).

## Scope

- Day-1 of the CA-034 M1 2-day release train. Day-2 migrates the three CLIs onto `@opena2a/registry-client@0.1.0` via a separate session — pickup queued at `opena2a-org/todo/2026-04-22-cli-consolidation-m1-day2-pickup.md`.
- F1 parity fixture (`check-registered-ai`) deferred to Day-2: the harness needs a package-name fixture kind (it currently only supports directory scans) and goldens can only be captured from migrated CLIs.
- No CLI files touched in this PR. `hackmyagent`, `ai-trust`, and `opena2a/packages/cli` continue to use their inline trust-query code until Day-2.

## Design constraints (enforced in code + tests)

- **Server-only trust levels.** The client never computes `trustLevel` or backfills from score. Test: `passes server-computed trustLevel through unchanged (no client math)`.
- **Minimal knobs.** `{baseUrl, userAgent}` required; `{timeoutMs, cache, cacheTtlMs, fetch}` optional with opinionated defaults (10 s, cache on, 60 s TTL, global `fetch`).
- **Zero runtime deps.** Dev-only: `@types/node`, `typescript`, `vitest`. Uses Node 18+ globals (`fetch`, `URLSearchParams`, `AbortController`, `URL`).
- **Exact pins** when consumers adopt (no caret), per `feedback_single_source_of_truth_scan.md`.

## Test plan

- [x] 42/42 unit tests green (`npm test --workspace=packages/registry-client`): URL construction, NULL-UUID + missing-packageId → found=false, server-level passthrough, all error code paths (400/401/403/404/429/5xx/network/timeout/invalid_response), cache hit/miss/clear/disabled, publish never cached, SSRF baseUrl rejection, input validation (empty/>512/control chars), error body truncation, cache-key canonicalization.
- [x] `npm run build --workspace=packages/registry-client` green
- [x] `npm run typecheck --workspace=packages/registry-client` green
- [x] `npx turbo run build` green across the monorepo (7 packages)
- [x] `npx hackmyagent secure --ci` → Library 95/100 (1 MEDIUM for missing sub-package .gitignore; monorepo root has one — non-blocker)
- [x] `npm view @opena2a/registry-client` resolves (0.0.0 seed live, deprecated)
- [ ] **Merge → tag `registry-client-v0.1.0` → workflow publishes 0.1.0 with SLSA v1 attestations → verify `npm view @opena2a/registry-client dist.attestations --json` returns non-empty with `predicateType` matching SLSA v1.**
- [ ] Parity CI (auto-triggered by `packages/registry-client/**` path filter) green on the current fixture set (`secure-dirty-skill`, ai-trust correctly skipped).

## Chief decisions (this session)

- **[CHIEF-CA] DECISION:** `@opena2a/registry-client@0.1.0` surface = `{checkTrust, batchQuery, publishScan}` mirroring ai-trust's existing API, plus the hardening listed above. No client-side trust-level math. Structured errors with codes; CLIs render prose. Opt-in TTL cache on reads, never on writes. ALTERNATIVES REJECTED: client-side level helpers (violates CA-034 "server-side only"), async stream API (overbuilt for three call patterns), baking user prose into the client (M2 `cli-ui` territory). ESCALATION: none — matches `todo/2026-04-22-cli-consolidation-sequenced.md` §M1 exactly.

## Review follow-ups (slide to 0.1.1)

AI code review flagged these; non-critical to ship 0.1.0:
- M1: `publishScan` uses constructor `timeoutMs` — may want a per-call override for slow publish paths.
- M2: Pin `found=true + NULL UUID` server-contract edge case with a dedicated test.
- M3: `TtlCache` has no size cap — fine for CLI use (tens–hundreds of queries); add `maxEntries` LRU before any daemon consumer adopts.
- M6: Optional Unicode NFC normalization on `name` for cache-key stability across homoglyphs.
- L1–L6: minor test depth + classifier tweaks.

## References

- Plan: `opena2a-org/todo/2026-04-22-cli-consolidation-sequenced.md` §M1
- Parent brief: `opena2a-org/briefs/cli-consolidation.md`
- Divergence closed: `opena2a-org/briefs/check-command-divergence.md` §F1 (goldens land Day-2)
- Day-2 pickup: `opena2a-org/todo/2026-04-22-cli-consolidation-m1-day2-pickup.md`