### PR TITLE
feat(cli): migrate trust queries to @opena2a/registry-client@0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3846,6 +3846,7 @@
         "@inquirer/prompts": "^7.0.0",
         "@opena2a/cli-ui": "0.2.0",
         "@opena2a/contribute": "0.1.0",
+        "@opena2a/registry-client": "0.1.0",
         "@opena2a/shared": "0.1.0",
         "ai-trust": "^0.2.23",
         "commander": "^13.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,7 @@
     "@inquirer/prompts": "^7.0.0",
     "@opena2a/cli-ui": "0.2.0",
     "@opena2a/contribute": "0.1.0",
+    "@opena2a/registry-client": "0.1.0",
     "@opena2a/shared": "0.1.0",
     "ai-trust": "^0.2.23",
     "commander": "^13.1.0",

--- a/packages/cli/src/commands/mcp-audit.ts
+++ b/packages/cli/src/commands/mcp-audit.ts
@@ -3,6 +3,9 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import * as crypto from 'node:crypto';
 import { bold, dim, green, yellow, red, cyan, gray } from '../util/colors.js';
+import { getVersion } from '../util/version.js';
+
+const DEFAULT_REGISTRY_BASE = 'https://api.oa2a.org';
 
 interface McpCommandOptions {
   subcommand: string;
@@ -150,12 +153,13 @@ function computeConfigHash(entry: McpServerEntry): string {
 
 async function fetchTrustScore(serverName: string): Promise<number | null> {
   try {
-    const resp = await fetch(
-      `https://api.oa2a.org/api/v1/trust/query?name=${encodeURIComponent(serverName)}&type=mcp_server`,
-      { signal: AbortSignal.timeout(5000) },
-    );
-    if (!resp.ok) return null;
-    const data = await resp.json() as any;
+    const { RegistryClient } = await import('@opena2a/registry-client');
+    const client = new RegistryClient({
+      baseUrl: DEFAULT_REGISTRY_BASE,
+      userAgent: `opena2a-cli/${getVersion()}`,
+      timeoutMs: 5000,
+    });
+    const data = await client.checkTrust(serverName, 'mcp_server');
     // trustScore is 0-1 from the registry, convert to 0-100
     if (typeof data.trustScore === 'number') {
       return Math.round(data.trustScore * 100);

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -10,6 +10,11 @@ import { bold, green, yellow, red, dim } from '../util/colors.js';
 import { Spinner } from '../util/spinner.js';
 import { table } from '../util/format.js';
 import { validateRegistryUrl } from '../util/validate-registry-url.js';
+import { getVersion } from '../util/version.js';
+
+function clientUserAgent(): string {
+  return `opena2a-cli/${getVersion()}`;
+}
 
 // --- Types ---
 
@@ -153,22 +158,19 @@ interface OracleVerdict {
 
 async function queryTrustProfile(registryUrl: string, name: string, type?: string): Promise<TrustProfile | null> {
   try {
-    const params = new URLSearchParams({ name, includeProfile: 'true', includeDeps: 'true' });
-    if (type) params.set('type', type);
-    const url = `${registryUrl}/api/v1/trust/query?${params}`;
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: { 'Accept': 'application/json' },
-      signal: AbortSignal.timeout(10_000),
+    const { RegistryClient } = await import('@opena2a/registry-client');
+    const client = new RegistryClient({
+      baseUrl: registryUrl,
+      userAgent: clientUserAgent(),
     });
-    if (!response.ok) return null;
-
-    const data = await response.json() as any;
+    const data = await client.checkTrust(name, type);
     return {
-      trustScore: data.trustProfile?.trustScore ?? data.trustScore ?? 0,
-      verdict: data.trustProfile?.verdict ?? data.verdict ?? 'unknown',
-      lastScannedAt: data.trustProfile?.lastScannedAt ?? data.lastScannedAt ?? null,
-      dependencyRiskCount: data.dependencies?.riskCount ?? 0,
+      trustScore: data.trustScore ?? 0,
+      verdict: data.verdict ?? 'unknown',
+      lastScannedAt: data.lastScannedAt ?? null,
+      dependencyRiskCount: data.dependencies?.riskSummary
+        ? (data.dependencies.riskSummary.blocked + data.dependencies.riskSummary.warning)
+        : 0,
     };
   } catch {
     return null;
@@ -243,10 +245,16 @@ async function verifyPackage(
   let error: string | undefined;
 
   try {
+    // Hash-based tamper detection uses a registry-side parameter
+    // (`&hash=...`) not exposed by @opena2a/registry-client@0.1.0, so this
+    // call remains a direct fetch. Revisit when the client adds a hash option.
     const url = `${registryUrl}/api/v1/trust/query?name=${encodeURIComponent(packageName)}&hash=${localHash}`;
     const response = await fetch(url, {
       method: 'GET',
-      headers: { 'Accept': 'application/json' },
+      headers: {
+        'Accept': 'application/json',
+        'User-Agent': clientUserAgent(),
+      },
       signal: AbortSignal.timeout(10_000),
     });
 

--- a/packages/cli/src/util/registry-enrichment.ts
+++ b/packages/cli/src/util/registry-enrichment.ts
@@ -6,6 +6,7 @@
  * community scan counts, and verification status from the public registry.
  */
 
+import { getVersion } from './version.js';
 import { validateRegistryUrl } from './validate-registry-url.js';
 
 // ---------------------------------------------------------------------------
@@ -21,24 +22,6 @@ export interface RegistryEnrichment {
   communityScans: number;
   verified: boolean;
   scanStatus: string;
-}
-
-export interface RegistryBatchResult {
-  packageId: string;
-  name: string;
-  packageType: string;
-  trustLevel: number;
-  trustScore: number;
-  verdict: string;
-  confidence: number;
-  scanStatus: string;
-  communityScans: number;
-}
-
-export interface RegistryBatchResponse {
-  queriedAt: string;
-  results: RegistryBatchResult[];
-  total: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -75,36 +58,21 @@ export async function enrichFromRegistry(
 
   const baseUrl = (registryBaseUrl || DEFAULT_REGISTRY_BASE).replace(/\/+$/, '');
   validateRegistryUrl(baseUrl);
-  const batchUrl = `${baseUrl}/api/v1/trust/batch`;
 
   try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), REGISTRY_TIMEOUT_MS);
-
-    const body = JSON.stringify({
-      packages: assets.map((a) => ({ name: a.name, type: a.type })),
+    const { RegistryClient } = await import('@opena2a/registry-client');
+    const client = new RegistryClient({
+      baseUrl,
+      userAgent: `opena2a-cli/${getVersion()}`,
+      timeoutMs: REGISTRY_TIMEOUT_MS,
     });
 
-    const response = await fetch(batchUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body,
-      signal: controller.signal,
-    });
+    const response = await client.batchQuery(
+      assets.map((a) => ({ name: a.name, type: a.type })),
+    );
 
-    clearTimeout(timeout);
-
-    if (!response.ok) {
-      return enrichments;
-    }
-
-    const data = (await response.json()) as RegistryBatchResponse;
-
-    if (!data.results || !Array.isArray(data.results)) {
-      return enrichments;
-    }
-
-    for (const result of data.results) {
+    for (const result of response.results) {
+      if (!result.packageType) continue;
       const key = `${result.name}:${result.packageType}`;
       enrichments.set(key, {
         name: result.name,
@@ -112,9 +80,9 @@ export async function enrichFromRegistry(
         trustScore: result.trustScore,
         trustLevel: result.trustLevel,
         verdict: result.verdict,
-        communityScans: result.communityScans,
+        communityScans: result.communityScans ?? 0,
         verified: result.verdict === 'verified' || result.trustLevel >= 4,
-        scanStatus: result.scanStatus,
+        scanStatus: result.scanStatus ?? '',
       });
     }
   } catch {

--- a/packages/cli/src/util/report-submission.ts
+++ b/packages/cli/src/util/report-submission.ts
@@ -14,6 +14,7 @@
 
 import { dim, yellow, cyan } from './colors.js';
 import { validateRegistryUrl } from './validate-registry-url.js';
+import { getVersion } from './version.js';
 
 // --- Types ---
 
@@ -169,54 +170,47 @@ export async function submitScanReport(
   try {
     validateRegistryUrl(registryUrl);
 
-    // Map ScanReport to unified publish format
-    const unifiedPayload = {
-      name: report.packageName,
-      type: report.packageType,
-      score: report.overallScore,
-      maxScore: 100,
-      tool: report.scannerName || 'opena2a-cli',
-      toolVersion: report.scannerVersion || '0.1.0',
-      findings: report.findings.map(f => ({
-        checkId: f.findingId,
-        name: f.title,
-        severity: f.severity,
-        passed: false, // ScanReport only includes failed findings
-        message: f.description || f.title,
-        category: f.category,
-        attackClass: f.attackClass,
-      })),
-      scanTimestamp: new Date().toISOString(),
-      verdict: report.verdict === 'fail' ? 'fail' : report.verdict === 'warnings' ? 'warn' : 'pass',
-    };
-
-    const url = `${registryUrl}/api/v1/trust/publish`;
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-      },
-      body: JSON.stringify(unifiedPayload),
-      signal: AbortSignal.timeout(10_000),
+    const { RegistryClient, RegistryApiError } = await import('@opena2a/registry-client');
+    const client = new RegistryClient({
+      baseUrl: registryUrl,
+      userAgent: `opena2a-cli/${getVersion()}`,
+      cache: false,
     });
 
-    if (response.ok) {
-      const result = await response.json() as Record<string, unknown>;
+    try {
+      const result = await client.publishScan({
+        name: report.packageName,
+        type: report.packageType,
+        score: report.overallScore,
+        maxScore: 100,
+        tool: report.scannerName || 'opena2a-cli',
+        toolVersion: report.scannerVersion || '0.1.0',
+        findings: report.findings.map(f => ({
+          checkId: f.findingId,
+          name: f.title,
+          severity: f.severity,
+          passed: false, // ScanReport only includes failed findings
+          message: f.description || f.title,
+          category: f.category,
+          attackClass: f.attackClass,
+        })),
+        scanTimestamp: new Date().toISOString(),
+        verdict: report.verdict === 'fail' ? 'fail' : report.verdict === 'warnings' ? 'warn' : 'pass',
+      });
+
       if (verbose && result.publishId) {
-        process.stderr.write(dim(`Published to registry (${(result.publishId as string).slice(0, 8)})\n`));
+        process.stderr.write(dim(`Published to registry (${result.publishId.slice(0, 8)})\n`));
       } else if (verbose) {
         process.stderr.write(dim('Scan report shared with OpenA2A community.\n'));
       }
       return true;
+    } catch (err) {
+      // Fall back to legacy endpoint if unified endpoint returned 404
+      if (err instanceof RegistryApiError && err.statusCode === 404) {
+        return submitLegacyScanReport(registryUrl, report, verbose);
+      }
+      throw err;
     }
-
-    // Fall back to legacy endpoint on 404
-    if (response.status === 404) {
-      return submitLegacyScanReport(registryUrl, report, verbose);
-    }
-
-    return false;
   } catch {
     // Network errors are non-critical
     return false;


### PR DESCRIPTION
## Summary

- Exact pin `@opena2a/registry-client@0.1.0` per CA-034 M1 DoD.
- Call sites migrated (all via dynamic `await import(...)` to preserve CJS compatibility):
  - `util/registry-enrichment.ts` — batch trust enrichment
  - `util/report-submission.ts`   — `trust/publish` scan submission
  - `commands/verify.ts`          — trust profile lookup
  - `commands/mcp-audit.ts`       — MCP server trust score
- `verify.ts` tamper-detection fetch left as a direct call: it hits `/api/v1/trust/query?name=...&hash=...` and the hash parameter isn't exposed by `@opena2a/registry-client@0.1.0`. Documented inline; revisit when the client adds a hash option.
- `adapters/registry.ts` (ai-trust subprocess) untouched — that's M4 territory.

Release note: now powered by `@opena2a/registry-client` — identical trust output across the fleet.

Refs:
- `briefs/cli-consolidation.md`
- `todo/2026-04-22-cli-consolidation-sequenced.md` (M1 DoD)

## Test plan

- [x] `npm run build --workspace=packages/cli` — clean.
- [x] `npm run test --workspace=packages/cli` — 885/885 vitest cases pass.
- [x] `opena2a verify --format json` returns live trust data via the new client.
- [ ] Cross-CLI parity gate (`opena2a-parity#1`) runs green on this PR.