### PR TITLE
feat(cli-ui): renderCheckBlock + renderNotFoundBlock + renderNextSteps (0.3.0)

### DIFF
--- a/packages/cli-ui/CHANGELOG.md
+++ b/packages/cli-ui/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog — @opena2a/cli-ui
+
+## 0.3.0
+
+### Added
+- `renderCheckBlock(input)` — canonical `check <pkg>` output block. Emits header (name + meta), verdict line, Trust meter (gated on `scanStatus`), trust-level legend, and optional Publisher / Permissions / Revocation / Community scans / Last scan rows. Missing optional fields are hidden, never faked (closes brief `check-command-divergence.md` §F5).
+- `renderNotFoundBlock(input)` — unified package-not-found output: ecosystem-aware header, optional error hint (for translated git-style misses, §F3), Did-you-mean suggestions list, optional skill-fallback CTA. Closes §F5 shape divergence across HMA / opena2a-cli / ai-trust.
+- `renderNextSteps(input)` — Next-Steps CTAs with primary-vs-default bullet styling and tone signals. Each CLI passes its own commands; labels stay consistent across CLIs (closes §F7).
+
+### Behaviour
+- Trust meter is suppressed when `scanStatus !== 'completed' | 'warnings'` (closes §F6 — "a number implies measurement").
+- Registry-canonical `trustScore` on the 0-1 scale is accepted and scaled to 0-100 for the meter; callers passing 0-100 work unchanged.
+- No new runtime dependencies; primitives return structured `{ label, value, tone }` data so CLIs apply their own chalk palette.
+
+## 0.2.0
+
+### Added
+- `renderObservationsBlock` + `buildCategorySummaries` + `buildVerdict` — Surfaces / Checks / Categories / Verdict block for scan output, consumed by HMA / opena2a-cli / ai-trust after CA-030.
+- `analyst-render` helpers for description / threat-level / confidence normalization.
+
+## 0.1.0
+
+### Added
+- Initial release: `scoreMeter`, `miniMeter`, `divider`, `normalizeVerdict`, `verdictColor`, `trustLevelLabel`, `trustLevelColor`, `trustLevelLegend`, `scoreColor`, `formatScanAge`.

--- a/packages/cli-ui/README.md
+++ b/packages/cli-ui/README.md
@@ -12,6 +12,10 @@ One place to update score meters, dividers, trust level legends, and verdict col
 - `verdictColor(verdict)` / `normalizeVerdict(verdict)` — collapse registry verdict variants and get a chalk color
 - `trustLevelLabel(0-4)` / `trustLevelColor(0-4)` / `trustLevelLegend(current)` — render the 5-level trust ladder
 - `formatScanAge(timestamp)` — "3 days ago" or "120 days ago (stale)"
+- `renderObservationsBlock(input)` — Surfaces / Checks / Categories / Verdict block for scan output (0.2.0)
+- `renderCheckBlock(input)` — canonical `check <pkg>` block: header, verdict, trust level, meter (gated on scanStatus), optional publisher / permissions / revocation / community scans / last-scan rows (0.3.0)
+- `renderNotFoundBlock(input)` — "package not found" block with did-you-mean suggestions, optional error hint, optional skill-fallback CTA (0.3.0)
+- `renderNextSteps(input)` — Next-Steps CTAs with primary/default bullet styling (0.3.0)
 
 ## Usage
 

--- a/packages/cli-ui/package.json
+++ b/packages/cli-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opena2a/cli-ui",
-  "version": "0.2.0",
-  "description": "Shared terminal UI primitives for OpenA2A CLIs (score meter, trust level legend, verdict colors, observations + verdict block, analyst-render)",
+  "version": "0.3.0",
+  "description": "Shared terminal UI primitives for OpenA2A CLIs (score meter, trust level legend, verdict colors, observations + verdict block, analyst-render, check block, not-found block, next-steps)",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli-ui/src/check-block.test.ts
+++ b/packages/cli-ui/src/check-block.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from "vitest";
+import { renderCheckBlock, type CheckBlockInput } from "./check-block.js";
+
+function base(over: Partial<CheckBlockInput> = {}): CheckBlockInput {
+  return {
+    name: "example",
+    trustLevel: 3,
+    trustScore: 0.82,
+    verdict: "passed",
+    scanStatus: "completed",
+    ...over,
+  };
+}
+
+describe("renderCheckBlock — header", () => {
+  it("passes the name through and includes version + type when present", () => {
+    const out = renderCheckBlock(base({ version: "1.2.3", packageType: "mcp_server" }));
+    expect(out.header.name).toBe("example");
+    expect(out.header.meta).toEqual(["v1.2.3", "mcp server"]);
+  });
+
+  it("omits version and type when absent", () => {
+    const out = renderCheckBlock(base());
+    expect(out.header.meta).toEqual([]);
+  });
+});
+
+describe("renderCheckBlock — verdict", () => {
+  it.each([
+    ["passed", "good", "No known issues"],
+    ["safe", "good", "No known issues"],
+    ["warning", "warning", "Warning — review before installing"],
+    ["warnings", "warning", "Warning — review before installing"],
+    ["blocked", "critical", "Blocked by registry"],
+    ["failed", "critical", "Blocked by registry"],
+    ["listed", "default", "Listed — limited signal"],
+  ])("verdict %s → tone %s", (verdict, expectedTone, expectedText) => {
+    const out = renderCheckBlock(base({ verdict }));
+    expect(out.verdict.tone).toBe(expectedTone);
+    expect(out.verdict.text).toBe(expectedText);
+  });
+
+  it("renders an unknown verdict as dim", () => {
+    const out = renderCheckBlock(base({ verdict: "gibberish" }));
+    expect(out.verdict.tone).toBe("dim");
+    expect(out.verdict.text).toBe("Unknown verdict");
+  });
+});
+
+describe("renderCheckBlock — meter gating (F6)", () => {
+  it("shows the Trust meter when scanStatus is completed", () => {
+    const out = renderCheckBlock(base({ scanStatus: "completed" }));
+    expect(out.meterShown).toBe(true);
+    const trust = out.lines.find((l) => l.label === "Trust")!;
+    expect(trust).toBeDefined();
+    // Meter string includes the score digits somewhere in the chalk-wrapped payload.
+    expect(trust.value).toMatch(/82/);
+    expect(trust.tone).toBe("good");
+  });
+
+  it("shows the Trust meter when scanStatus is warnings", () => {
+    const out = renderCheckBlock(base({ scanStatus: "warnings" }));
+    expect(out.meterShown).toBe(true);
+  });
+
+  it("hides the Trust meter when scanStatus is pending", () => {
+    const out = renderCheckBlock(base({ scanStatus: "pending" }));
+    expect(out.meterShown).toBe(false);
+    const trust = out.lines.find((l) => l.label === "Trust")!;
+    expect(trust.value).toContain("not scanned");
+    expect(trust.tone).toBe("dim");
+  });
+
+  it("hides the Trust meter when scanStatus is undefined", () => {
+    const out = renderCheckBlock(base({ scanStatus: undefined }));
+    expect(out.meterShown).toBe(false);
+  });
+
+  it("hides the Trust meter for any unrecognized scanStatus", () => {
+    const out = renderCheckBlock(base({ scanStatus: "weird-new-state" }));
+    expect(out.meterShown).toBe(false);
+  });
+});
+
+describe("renderCheckBlock — score normalization", () => {
+  it("accepts 0-1 scores (Registry canonical scale) and scales to 0-100", () => {
+    const out = renderCheckBlock(base({ trustScore: 0.35 }));
+    const trust = out.lines.find((l) => l.label === "Trust")!;
+    expect(trust.value).toMatch(/35/);
+    expect(trust.tone).toBe("critical");
+  });
+
+  it("accepts 0-100 scores as-is for callers that pre-scale", () => {
+    const out = renderCheckBlock(base({ trustScore: 45 }));
+    const trust = out.lines.find((l) => l.label === "Trust")!;
+    expect(trust.value).toMatch(/45/);
+    expect(trust.tone).toBe("warning");
+  });
+});
+
+describe("renderCheckBlock — trust level", () => {
+  it("always emits a Level line even when meter is hidden", () => {
+    const out = renderCheckBlock(base({ scanStatus: undefined }));
+    const level = out.lines.find((l) => l.label === "Level")!;
+    expect(level).toBeDefined();
+    expect(level.value).toContain("Scanned");
+  });
+
+  it.each([
+    [0, "critical"],
+    [1, "warning"],
+    [2, "warning"],
+    [3, "good"],
+    [4, "good"],
+  ])("trustLevel %d → tone %s", (lvl, expectedTone) => {
+    const out = renderCheckBlock(base({ trustLevel: lvl }));
+    const level = out.lines.find((l) => l.label === "Level")!;
+    expect(level.tone).toBe(expectedTone);
+  });
+});
+
+describe("renderCheckBlock — optional fields", () => {
+  it("hides Publisher when not provided (F5 missing=hidden)", () => {
+    const out = renderCheckBlock(base());
+    expect(out.lines.find((l) => l.label === "Publisher")).toBeUndefined();
+  });
+
+  it("shows Publisher with verified marker", () => {
+    const out = renderCheckBlock(base({ publisher: { name: "Anthropic", verified: true } }));
+    const pub = out.lines.find((l) => l.label === "Publisher")!;
+    expect(pub.value).toBe("Anthropic · verified");
+    expect(pub.tone).toBe("good");
+  });
+
+  it("shows Publisher with unverified marker", () => {
+    const out = renderCheckBlock(base({ publisher: { name: "Someone", verified: false } }));
+    const pub = out.lines.find((l) => l.label === "Publisher")!;
+    expect(pub.value).toBe("Someone · unverified");
+    expect(pub.tone).toBe("warning");
+  });
+
+  it("shows Publisher with no verification suffix when verified is undefined", () => {
+    const out = renderCheckBlock(base({ publisher: { name: "Someone" } }));
+    const pub = out.lines.find((l) => l.label === "Publisher")!;
+    expect(pub.value).toBe("Someone");
+    expect(pub.tone).toBe("default");
+  });
+
+  it("hides Permissions when empty or undefined", () => {
+    expect(renderCheckBlock(base()).lines.find((l) => l.label === "Permissions")).toBeUndefined();
+    expect(
+      renderCheckBlock(base({ permissions: [] })).lines.find((l) => l.label === "Permissions"),
+    ).toBeUndefined();
+  });
+
+  it("shows Permissions joined with comma-space", () => {
+    const out = renderCheckBlock(base({ permissions: ["fs-write", "net-egress"] }));
+    const perms = out.lines.find((l) => l.label === "Permissions")!;
+    expect(perms.value).toBe("fs-write, net-egress");
+  });
+
+  it("renders Revocation listed as critical", () => {
+    const out = renderCheckBlock(base({ revocation: { listed: true } }));
+    const rev = out.lines.find((l) => l.label === "Revocation")!;
+    expect(rev.value).toBe("on blocklist — do not install");
+    expect(rev.tone).toBe("critical");
+  });
+
+  it("renders Revocation not-listed as good", () => {
+    const out = renderCheckBlock(base({ revocation: { listed: false } }));
+    const rev = out.lines.find((l) => l.label === "Revocation")!;
+    expect(rev.value).toBe("not on blocklist");
+    expect(rev.tone).toBe("good");
+  });
+
+  it("hides Revocation when undefined", () => {
+    const out = renderCheckBlock(base());
+    expect(out.lines.find((l) => l.label === "Revocation")).toBeUndefined();
+  });
+
+  it("hides Scans when 0 or undefined", () => {
+    expect(renderCheckBlock(base()).lines.find((l) => l.label === "Scans")).toBeUndefined();
+    expect(
+      renderCheckBlock(base({ communityScans: 0 })).lines.find((l) => l.label === "Scans"),
+    ).toBeUndefined();
+  });
+
+  it("pluralizes community scans correctly", () => {
+    expect(
+      renderCheckBlock(base({ communityScans: 1 })).lines.find((l) => l.label === "Scans")!.value,
+    ).toBe("1 community scan");
+    expect(
+      renderCheckBlock(base({ communityScans: 7 })).lines.find((l) => l.label === "Scans")!.value,
+    ).toBe("7 community scans");
+  });
+
+  it("renders Last scan as warning when stale (>90 days)", () => {
+    const ancient = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString();
+    const out = renderCheckBlock(base({ lastScannedAt: ancient }));
+    const last = out.lines.find((l) => l.label === "Last scan")!;
+    expect(last.value).toContain("stale");
+    expect(last.tone).toBe("warning");
+  });
+
+  it("renders Last scan as default when recent", () => {
+    const recent = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+    const out = renderCheckBlock(base({ lastScannedAt: recent }));
+    const last = out.lines.find((l) => l.label === "Last scan")!;
+    expect(last.value).toBe("2 days ago");
+    expect(last.tone).toBe("default");
+  });
+
+  it("hides Last scan when lastScannedAt is missing", () => {
+    const out = renderCheckBlock(base());
+    expect(out.lines.find((l) => l.label === "Last scan")).toBeUndefined();
+  });
+});
+
+describe("renderCheckBlock — line ordering (F5 canonical schema)", () => {
+  it("emits Trust, then Level, then optional rows in a stable order", () => {
+    const out = renderCheckBlock(
+      base({
+        publisher: { name: "Anthropic", verified: true },
+        permissions: ["fs"],
+        revocation: { listed: false },
+        communityScans: 3,
+        lastScannedAt: new Date().toISOString(),
+      }),
+    );
+    const labels = out.lines.map((l) => l.label);
+    expect(labels).toEqual([
+      "Trust",
+      "Level",
+      "Publisher",
+      "Permissions",
+      "Revocation",
+      "Scans",
+      "Last scan",
+    ]);
+  });
+});

--- a/packages/cli-ui/src/check-block.ts
+++ b/packages/cli-ui/src/check-block.ts
@@ -1,0 +1,244 @@
+/**
+ * Check block — unified output schema for the `check <pkg>` command.
+ *
+ * Shared across hackmyagent, opena2a-cli (via hma delegation), and ai-trust.
+ * Closes F5/F6 from briefs/check-command-divergence.md:
+ *   - F5: one canonical output schema, conditional sections, missing = hidden
+ *   - F6: trust/security meter suppressed when `scanStatus !== completed|warnings`
+ *         ("a number implies measurement")
+ *
+ * Returns structured lines. The CLI applies its own chalk palette so the
+ * package stays a rendering library, not a color library. Values that
+ * require the shared meter / legend helpers are pre-rendered by those
+ * helpers (which own their own chalk) and passed through as `value`.
+ */
+
+import { scoreMeter } from "./meters.js";
+import { trustLevelLabel, trustLevelLegend } from "./trust-level.js";
+import { formatScanAge } from "./scan-age.js";
+import { normalizeVerdict } from "./verdict.js";
+
+export type CheckTone = "default" | "good" | "warning" | "critical" | "dim";
+
+/**
+ * Input shape for `renderCheckBlock`.
+ *
+ * Required fields mirror what `@opena2a/registry-client`'s `TrustAnswer`
+ * always populates for a registered package. Optional fields cover the
+ * extended surface described in F5 — publisher, permissions, revocation.
+ * These are stubs for v0.3.0: the caller passes them when available
+ * (e.g. agent / skill paths), otherwise the renderer hides the row.
+ */
+export interface CheckBlockInput {
+  /** Package name as the user typed it (used in the header). */
+  name: string;
+  /** Package type from the registry — "mcp_server", "ai_tool", "library", "skill", etc. */
+  packageType?: string;
+  /** Optional package version, shown in header meta when present. */
+  version?: string;
+  /** Trust level 0-4. Always shown. */
+  trustLevel: number;
+  /** Trust score 0-1 (the registry's canonical scale). Rendered 0-100 for the meter. */
+  trustScore: number;
+  /** Registry verdict string: "passed" | "warning" | "warnings" | "blocked" | "listed" | ... */
+  verdict: string;
+  /**
+   * Scan status from the registry — controls whether the Trust meter is rendered.
+   * Meter shown iff `completed` or `warnings`. Other values (`pending`, `unscanned`,
+   * undefined) hide the meter and emit a "not scanned" line instead.
+   */
+  scanStatus?: string;
+  /** Count of independent community scans backing the score. */
+  communityScans?: number;
+  /** ISO timestamp of the most recent scan. Rendered via `formatScanAge`. */
+  lastScannedAt?: string;
+  /**
+   * Publisher identity. Stub for v0.3.0 — most call sites won't populate this yet.
+   * When `undefined`, the row is hidden. M3 expands the registry surface to
+   * provide verified-publisher data consistently.
+   */
+  publisher?: { name: string; verified?: boolean };
+  /**
+   * Permissions declared by the artifact (agents / skills only).
+   * When `undefined` or empty, the row is hidden. Libraries don't have
+   * permissions; this block is only emitted for agent-shaped artifacts.
+   */
+  permissions?: string[];
+  /**
+   * Revocation signal. `listed: true` means "on the blocklist" (critical).
+   * `listed: false` is rendered as a positive "not on blocklist" signal.
+   * When `undefined`, the row is hidden (unknown state, don't fake it).
+   */
+  revocation?: { listed: boolean };
+}
+
+/** One rendered line in the check block. */
+export interface CheckBlockLine {
+  label: string;
+  /**
+   * Pre-composed value string. May contain chalk ANSI for the Trust meter
+   * and trust-level legend, which own their own color internally. The CLI
+   * applies its own chalk only to the `label` and to plain values.
+   */
+  value: string;
+  tone: CheckTone;
+}
+
+/** Rendered check block — the shape `check` commands consume. */
+export interface RenderedCheck {
+  /** Header line components. CLI composes `<name>  <meta.join(' · ')>`. */
+  header: { name: string; meta: string[] };
+  /** Plain-English verdict ("No known issues", "Warning — review...", "Blocked by registry"). */
+  verdict: { text: string; tone: CheckTone };
+  /** Rendering-ordered lines. Empty when a given field is undefined (F5 "missing = hidden"). */
+  lines: CheckBlockLine[];
+  /**
+   * True when the Trust meter line was emitted. Useful for callers
+   * that want a structural assertion in parity tests (F6 regression).
+   */
+  meterShown: boolean;
+}
+
+/** Normalize a score from the registry's 0-1 scale to the meter's 0-100 scale. */
+function normalizeScore(raw: number): number {
+  if (raw <= 1) return Math.round(raw * 100);
+  return Math.round(raw);
+}
+
+/** Decide whether the Trust meter should render based on scan status. */
+function shouldShowMeter(scanStatus?: string): boolean {
+  if (!scanStatus) return false;
+  return scanStatus === "completed" || scanStatus === "warnings";
+}
+
+/** Build the verdict line from the registry verdict string. */
+function buildVerdict(verdict: string): { text: string; tone: CheckTone } {
+  const normalized = normalizeVerdict(verdict);
+  switch (normalized) {
+    case "safe":
+      return { text: "No known issues", tone: "good" };
+    case "warning":
+      return { text: "Warning — review before installing", tone: "warning" };
+    case "blocked":
+      return { text: "Blocked by registry", tone: "critical" };
+    case "listed":
+      return { text: "Listed — limited signal", tone: "default" };
+    default:
+      return { text: "Unknown verdict", tone: "dim" };
+  }
+}
+
+export function renderCheckBlock(input: CheckBlockInput): RenderedCheck {
+  const {
+    name,
+    packageType,
+    version,
+    trustLevel,
+    trustScore,
+    verdict,
+    scanStatus,
+    communityScans,
+    lastScannedAt,
+    publisher,
+    permissions,
+    revocation,
+  } = input;
+
+  // --- Header ----------------------------------------------------------------
+  const meta: string[] = [];
+  if (version) meta.push(`v${version}`);
+  if (packageType) meta.push(packageType.replace(/_/g, " "));
+
+  // --- Verdict ---------------------------------------------------------------
+  const verdictLine = buildVerdict(verdict);
+
+  // --- Lines -----------------------------------------------------------------
+  const lines: CheckBlockLine[] = [];
+
+  // Trust meter — governed by scanStatus (F6).
+  const meterShown = shouldShowMeter(scanStatus);
+  if (meterShown) {
+    const score = normalizeScore(trustScore);
+    lines.push({
+      label: "Trust",
+      value: scoreMeter(score, 100),
+      tone: score >= 70 ? "good" : score >= 40 ? "warning" : "critical",
+    });
+  } else {
+    lines.push({
+      label: "Trust",
+      value: "not scanned — request a scan to see a score",
+      tone: "dim",
+    });
+  }
+
+  // Trust level is always shown (matches F5 schema: "Level always present; one truth").
+  lines.push({
+    label: "Level",
+    value: `${trustLevelLabel(trustLevel)}  ${trustLevelLegend(trustLevel)}`,
+    tone: trustLevel >= 3 ? "good" : trustLevel >= 1 ? "warning" : "critical",
+  });
+
+  // Publisher — shown only when known (F5 "missing = hidden").
+  if (publisher && publisher.name) {
+    const verifiedSuffix =
+      publisher.verified === true
+        ? " · verified"
+        : publisher.verified === false
+          ? " · unverified"
+          : "";
+    lines.push({
+      label: "Publisher",
+      value: `${publisher.name}${verifiedSuffix}`,
+      tone: publisher.verified === true ? "good" : publisher.verified === false ? "warning" : "default",
+    });
+  }
+
+  // Permissions — agents/skills only.
+  if (permissions && permissions.length > 0) {
+    lines.push({
+      label: "Permissions",
+      value: permissions.join(", "),
+      tone: "default",
+    });
+  }
+
+  // Revocation — shown when we have a definitive answer.
+  if (revocation) {
+    if (revocation.listed) {
+      lines.push({
+        label: "Revocation",
+        value: "on blocklist — do not install",
+        tone: "critical",
+      });
+    } else {
+      lines.push({
+        label: "Revocation",
+        value: "not on blocklist",
+        tone: "good",
+      });
+    }
+  }
+
+  // Community scans — shown when > 0.
+  if (typeof communityScans === "number" && communityScans > 0) {
+    lines.push({
+      label: "Scans",
+      value: `${communityScans} community scan${communityScans === 1 ? "" : "s"}`,
+      tone: "default",
+    });
+  }
+
+  // Last scanned — shown when known.
+  const age = formatScanAge(lastScannedAt);
+  if (age) {
+    const isStale = age.includes("stale");
+    lines.push({
+      label: "Last scan",
+      value: age,
+      tone: isStale ? "warning" : "default",
+    });
+  }
+
+  return { header: { name, meta }, verdict: verdictLine, lines, meterShown };
+}

--- a/packages/cli-ui/src/index.test.ts
+++ b/packages/cli-ui/src/index.test.ts
@@ -7,6 +7,9 @@ import {
   trustLevelLabel,
   trustLevelLegend,
   formatScanAge,
+  renderCheckBlock,
+  renderNotFoundBlock,
+  renderNextSteps,
 } from "./index.js";
 
 describe("scoreMeter", () => {
@@ -100,5 +103,33 @@ describe("formatScanAge", () => {
     const out = formatScanAge(old);
     expect(out).toContain("120");
     expect(out).toContain("stale");
+  });
+});
+
+describe("renderCheckBlock (barrel export)", () => {
+  it("is exported from the package entry point", () => {
+    const out = renderCheckBlock({
+      name: "x",
+      trustLevel: 3,
+      trustScore: 0.82,
+      verdict: "passed",
+      scanStatus: "completed",
+    });
+    expect(out.header.name).toBe("x");
+    expect(out.meterShown).toBe(true);
+  });
+});
+
+describe("renderNotFoundBlock (barrel export)", () => {
+  it("is exported from the package entry point", () => {
+    const out = renderNotFoundBlock({ pkg: "x", ecosystem: "npm" });
+    expect(out.header.text).toContain("Package not found");
+  });
+});
+
+describe("renderNextSteps (barrel export)", () => {
+  it("is exported from the package entry point", () => {
+    const out = renderNextSteps({ ctas: [{ label: "go", command: "go do", primary: true }] });
+    expect(out.lines[0].bullet).toBe("→");
   });
 });

--- a/packages/cli-ui/src/index.ts
+++ b/packages/cli-ui/src/index.ts
@@ -47,3 +47,25 @@ export {
   type AnalystFindingLike,
   type FormattedDescription,
 } from "./analyst-render.js";
+export {
+  renderCheckBlock,
+  type CheckBlockInput,
+  type CheckBlockLine,
+  type RenderedCheck,
+  type CheckTone,
+} from "./check-block.js";
+export {
+  renderNotFoundBlock,
+  type NotFoundBlockInput,
+  type NotFoundBlockLine,
+  type RenderedNotFound,
+  type NotFoundTone,
+} from "./not-found-block.js";
+export {
+  renderNextSteps,
+  type NextStepsCta,
+  type NextStepsInput,
+  type NextStepsLine,
+  type RenderedNextSteps,
+  type NextStepsTone,
+} from "./next-steps.js";

--- a/packages/cli-ui/src/next-steps.test.ts
+++ b/packages/cli-ui/src/next-steps.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { renderNextSteps } from "./next-steps.js";
+
+describe("renderNextSteps — bullet style", () => {
+  it("marks the first primary CTA with → and tone good", () => {
+    const out = renderNextSteps({
+      ctas: [
+        { label: "Full scan", command: "hma secure .", primary: true },
+        { label: "Contribute", command: "hma contribute" },
+      ],
+    });
+    expect(out.lines[0].bullet).toBe("→");
+    expect(out.lines[0].tone).toBe("good");
+    expect(out.lines[1].bullet).toBe("•");
+    expect(out.lines[1].tone).toBe("default");
+  });
+
+  it("only one line gets the primary bullet when multiple are flagged", () => {
+    const out = renderNextSteps({
+      ctas: [
+        { label: "A", command: "a", primary: true },
+        { label: "B", command: "b", primary: true },
+      ],
+    });
+    expect(out.lines[0].bullet).toBe("→");
+    expect(out.lines[1].bullet).toBe("•");
+  });
+
+  it("renders all lines as default-bullet when no CTA is primary", () => {
+    const out = renderNextSteps({
+      ctas: [
+        { label: "A", command: "a" },
+        { label: "B", command: "b" },
+      ],
+    });
+    expect(out.lines.every((l) => l.bullet === "•")).toBe(true);
+    expect(out.lines.every((l) => l.tone === "default")).toBe(true);
+  });
+});
+
+describe("renderNextSteps — contents pass-through", () => {
+  it("preserves labels and commands verbatim", () => {
+    const out = renderNextSteps({
+      ctas: [
+        { label: "Full scan", command: "opena2a review ." },
+        { label: "Contribute findings", command: "opena2a contribute --enable" },
+      ],
+    });
+    expect(out.lines[0].label).toBe("Full scan");
+    expect(out.lines[0].command).toBe("opena2a review .");
+    expect(out.lines[1].label).toBe("Contribute findings");
+    expect(out.lines[1].command).toBe("opena2a contribute --enable");
+  });
+
+  it("handles an empty CTA list gracefully", () => {
+    const out = renderNextSteps({ ctas: [] });
+    expect(out.lines).toEqual([]);
+  });
+
+  it("supports a single primary CTA", () => {
+    const out = renderNextSteps({
+      ctas: [{ label: "Rescan", command: "hma check express --refresh", primary: true }],
+    });
+    expect(out.lines).toHaveLength(1);
+    expect(out.lines[0].bullet).toBe("→");
+    expect(out.lines[0].tone).toBe("good");
+  });
+});

--- a/packages/cli-ui/src/next-steps.ts
+++ b/packages/cli-ui/src/next-steps.ts
@@ -1,0 +1,61 @@
+/**
+ * Next Steps block — per-CLI CTA injection with consistent rendering.
+ *
+ * Closes F7 from briefs/check-command-divergence.md: the three CLIs today
+ * emit different (or missing) Next Steps blocks. Labels must stay identical
+ * across CLIs so users build one mental model; commands differ because each
+ * CLI binary is different (`hackmyagent secure` vs `opena2a scan`).
+ *
+ * Callers pass their own command strings. This renderer owns bullet style,
+ * alignment, and primary-CTA emphasis. No chalk — CLI applies color via tone.
+ */
+
+export type NextStepsTone = "default" | "good" | "dim";
+
+export interface NextStepsCta {
+  /** Short action label, e.g. "Full scan", "Contribute findings". */
+  label: string;
+  /** Runnable command, e.g. "hackmyagent secure .". */
+  command: string;
+  /**
+   * True for the primary recommended action. At most one should be primary;
+   * if multiple are flagged, the first wins (renderer doesn't enforce beyond
+   * that — this is just visual emphasis).
+   */
+  primary?: boolean;
+}
+
+export interface NextStepsInput {
+  ctas: NextStepsCta[];
+}
+
+export interface NextStepsLine {
+  /** `→` for primary, `•` for everything else. */
+  bullet: string;
+  label: string;
+  command: string;
+  tone: NextStepsTone;
+}
+
+export interface RenderedNextSteps {
+  lines: NextStepsLine[];
+}
+
+const PRIMARY_BULLET = "→"; // →
+const DEFAULT_BULLET = "•"; // •
+
+export function renderNextSteps(input: NextStepsInput): RenderedNextSteps {
+  const { ctas } = input;
+  let primaryClaimed = false;
+  const lines: NextStepsLine[] = ctas.map((cta) => {
+    const isPrimary = cta.primary === true && !primaryClaimed;
+    if (isPrimary) primaryClaimed = true;
+    return {
+      bullet: isPrimary ? PRIMARY_BULLET : DEFAULT_BULLET,
+      label: cta.label,
+      command: cta.command,
+      tone: isPrimary ? "good" : "default",
+    };
+  });
+  return { lines };
+}

--- a/packages/cli-ui/src/not-found-block.test.ts
+++ b/packages/cli-ui/src/not-found-block.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { renderNotFoundBlock } from "./not-found-block.js";
+
+describe("renderNotFoundBlock — header", () => {
+  it("includes ecosystem in header when provided", () => {
+    const out = renderNotFoundBlock({ pkg: "@anthropic/code-review", ecosystem: "npm" });
+    expect(out.header.text).toBe("Package not found: @anthropic/code-review (npm)");
+    expect(out.header.tone).toBe("critical");
+  });
+
+  it("omits ecosystem suffix when not provided", () => {
+    const out = renderNotFoundBlock({ pkg: "@anthropic/code-review" });
+    expect(out.header.text).toBe("Package not found: @anthropic/code-review");
+  });
+});
+
+describe("renderNotFoundBlock — suggestions", () => {
+  it("emits Did-you-mean header then one line per suggestion", () => {
+    const out = renderNotFoundBlock({
+      pkg: "code-review",
+      suggestions: ["claude-code-review", "@wuyanbin/ai-code-review"],
+    });
+    const values = out.lines.map((l) => l.value);
+    expect(values[0]).toBe("Did you mean?");
+    expect(values[1]).toBe("claude-code-review");
+    expect(values[2]).toBe("@wuyanbin/ai-code-review");
+    expect(out.lines[1].tone).toBe("good");
+  });
+
+  it("omits the Did-you-mean block when suggestions is empty", () => {
+    const out = renderNotFoundBlock({ pkg: "x", suggestions: [] });
+    expect(out.lines.find((l) => l.value === "Did you mean?")).toBeUndefined();
+  });
+
+  it("omits the Did-you-mean block when suggestions is undefined", () => {
+    const out = renderNotFoundBlock({ pkg: "x" });
+    expect(out.lines).toEqual([]);
+  });
+});
+
+describe("renderNotFoundBlock — skill fallback", () => {
+  it("renders a Try line when skillFallback is available", () => {
+    const out = renderNotFoundBlock({
+      pkg: "@anthropic/code-review",
+      skillFallback: { available: true, command: "hma check @anthropic/code-review" },
+    });
+    const tryLine = out.lines.find((l) => l.label === "Try")!;
+    expect(tryLine.value).toBe("hma check @anthropic/code-review");
+    expect(tryLine.tone).toBe("default");
+  });
+
+  it("skips the Try line when skillFallback is unavailable", () => {
+    const out = renderNotFoundBlock({
+      pkg: "@anthropic/code-review",
+      skillFallback: { available: false, command: "never-shown" },
+    });
+    expect(out.lines.find((l) => l.label === "Try")).toBeUndefined();
+  });
+});
+
+describe("renderNotFoundBlock — error hint", () => {
+  it("emits the error hint ahead of suggestions and fallback (F3 translation)", () => {
+    const out = renderNotFoundBlock({
+      pkg: "anthropic/code-review",
+      errorHint: "Looks like a git path — use @scope/name for npm packages.",
+      suggestions: ["@anthropic/code-review"],
+    });
+    expect(out.lines[0].value).toContain("git path");
+    expect(out.lines[0].tone).toBe("warning");
+    expect(out.lines[1].value).toBe("Did you mean?");
+  });
+
+  it("omits the hint line when errorHint is undefined", () => {
+    const out = renderNotFoundBlock({ pkg: "x" });
+    expect(out.lines.find((l) => l.tone === "warning")).toBeUndefined();
+  });
+});
+
+describe("renderNotFoundBlock — combined", () => {
+  it("renders everything in order: hint, suggestions header + items, fallback", () => {
+    const out = renderNotFoundBlock({
+      pkg: "anthropic/code-review",
+      ecosystem: "npm",
+      errorHint: "git-style name; try @scope/name",
+      suggestions: ["@anthropic/code-review"],
+      skillFallback: { available: true, command: "hma check @anthropic/code-review" },
+    });
+    expect(out.lines.map((l) => l.value)).toEqual([
+      "git-style name; try @scope/name",
+      "Did you mean?",
+      "@anthropic/code-review",
+      "hma check @anthropic/code-review",
+    ]);
+  });
+});

--- a/packages/cli-ui/src/not-found-block.ts
+++ b/packages/cli-ui/src/not-found-block.ts
@@ -1,0 +1,87 @@
+/**
+ * Not-found block — unified "package not found" output.
+ *
+ * Closes F5 from briefs/check-command-divergence.md: today the three CLIs
+ * emit three different shapes for the same miss. This primitive gives them
+ * one renderer.
+ *
+ * Renderer returns structured lines only — no chalk. The CLI owns color.
+ */
+
+export type NotFoundTone = "default" | "warning" | "critical" | "dim" | "good";
+
+export interface NotFoundBlockInput {
+  /** The package name the user typed (may include ecosystem prefix, e.g. "pip:requests"). */
+  pkg: string;
+  /** Ecosystem hint shown in the header, e.g. "npm", "pypi". */
+  ecosystem?: string;
+  /**
+   * "Did you mean?" alternatives. Any source may supply these — registry fuzzy
+   * match, local skill registry, on-disk package lookup. Empty / undefined and
+   * the suggestions block is skipped entirely.
+   */
+  suggestions?: string[];
+  /**
+   * Optional skill-fallback CTA. HMA and opena2a-cli can resolve some names
+   * as skills when npm misses; ai-trust cannot. When provided, renders
+   * a targeted CTA pointing to the skill-capable CLI.
+   */
+  skillFallback?: { available: boolean; command: string };
+  /**
+   * Translated error hint for cases like `anthropic/code-review` being
+   * mistaken for a git remote (F3 in the divergence brief). Passed through
+   * verbatim when provided.
+   */
+  errorHint?: string;
+}
+
+export interface NotFoundBlockLine {
+  /** Optional label column. Lines without a label render full-width. */
+  label?: string;
+  value: string;
+  tone: NotFoundTone;
+}
+
+export interface RenderedNotFound {
+  /** Header text, e.g. "Package not found: @anthropic/code-review (npm)". */
+  header: { text: string; tone: NotFoundTone };
+  /**
+   * Body lines in render order. Contents:
+   *   - optional errorHint line
+   *   - "Did you mean?" header + one line per suggestion (when any)
+   *   - skill-fallback CTA (when provided)
+   * Empty when nothing to show beyond the header (caller falls through to
+   * the generic not-found message).
+   */
+  lines: NotFoundBlockLine[];
+}
+
+export function renderNotFoundBlock(input: NotFoundBlockInput): RenderedNotFound {
+  const { pkg, ecosystem, suggestions, skillFallback, errorHint } = input;
+
+  const headerText = ecosystem ? `Package not found: ${pkg} (${ecosystem})` : `Package not found: ${pkg}`;
+  const header = { text: headerText, tone: "critical" as NotFoundTone };
+
+  const lines: NotFoundBlockLine[] = [];
+
+  if (errorHint) {
+    lines.push({ value: errorHint, tone: "warning" });
+  }
+
+  if (suggestions && suggestions.length > 0) {
+    lines.push({ value: "Did you mean?", tone: "default" });
+    for (const s of suggestions) {
+      lines.push({ value: s, tone: "good" });
+    }
+  }
+
+  if (skillFallback?.available) {
+    lines.push({
+      label: "Try",
+      value: skillFallback.command,
+      tone: "default",
+    });
+  }
+
+  return { header, lines };
+}


### PR DESCRIPTION
## Summary

CA-034 M2: three new rendering primitives in `@opena2a/cli-ui` that close F5/F6/F7 from `briefs/check-command-divergence.md`, so the `check <pkg>` command emits one canonical shape across `hackmyagent`, `opena2a-cli`, and `ai-trust`.

- **`renderCheckBlock(input)`** — header + verdict + trust-level (always) + Trust meter (gated on `scanStatus`, F6) + optional Publisher / Permissions / Revocation / Community scans / Last scan rows. Missing fields hidden, never faked (F5). Accepts `TrustAnswer`'s 0-1 `trustScore` and auto-scales to the 0-100 meter; 0-100 inputs pass through.
- **`renderNotFoundBlock(input)`** — ecosystem-aware header, optional error hint for translated git-style misses (F3), Did-you-mean list, optional skill-fallback CTA. Closes the three-shape divergence in F5.
- **`renderNextSteps(input)`** — primary/default bullet styling; callers pass their own command strings so labels stay consistent across CLIs while each binary's name flows through (F7).

Version `0.2.0 → 0.3.0`. No new runtime deps. Primitives return `{ label, value, tone }` tuples so CLIs apply their own chalk palette.

Consumer CLIs are NOT migrated in this PR. Day-2 bumps of `ai-trust`, `opena2a-cli`, and `hackmyagent` consume this release against exact pin `@opena2a/cli-ui@0.3.0` (see `todo/2026-04-23-cli-consolidation-m2-pickup.md`).

## Test plan

- [x] `npm run typecheck` / `build` / `test` clean in `packages/cli-ui` (126 tests, 54 new)
- [x] `turbo run build` / `test` / `lint` green across the monorepo (7/7, 14/14, 9/9)
- [x] HMA self-scan 95/100 (1 MEDIUM: missing sub-package `.gitignore`, expected in monorepo)
- [x] No OWASP / race / resource-leak / secret findings in AI review
- [x] `.pre-push-review-passed` marker generated
- [ ] Merge, then tag `cli-ui-v0.3.0`
- [ ] Verify SLSA v1 attestations: `npm view @opena2a/cli-ui@0.3.0 dist.attestations --json`