### PR TITLE
feat(check-core): extract @opena2a/check-core 0.1.0 (CA-034 M3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
       - 'aim-core-v*'
       - 'ai-classifier-v*'
       - 'registry-client-v*'
+      - 'check-core-v*'
 
 permissions:
   contents: write
@@ -68,6 +69,7 @@ jobs:
           publish_if_new packages/ai-classifier @opena2a/ai-classifier
           publish_if_new packages/aim-core @opena2a/aim-core
           publish_if_new packages/registry-client @opena2a/registry-client
+          publish_if_new packages/check-core @opena2a/check-core
           echo "=== Published this run ==="
           cat /tmp/published.txt
           echo "=== Skipped (version already on npm) ==="

--- a/package-lock.json
+++ b/package-lock.json
@@ -908,6 +908,10 @@
       "resolved": "packages/aim-core",
       "link": true
     },
+    "node_modules/@opena2a/check-core": {
+      "resolved": "packages/check-core",
+      "link": true
+    },
     "node_modules/@opena2a/cli-ui": {
       "resolved": "packages/cli-ui",
       "link": true
@@ -3838,6 +3842,32 @@
         "undici-types": "~6.21.0"
       }
     },
+    "packages/check-core": {
+      "name": "@opena2a/check-core",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opena2a/registry-client": "0.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/check-core/node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "packages/cli": {
       "name": "opena2a-cli",
       "version": "0.8.25",
@@ -3870,7 +3900,7 @@
     },
     "packages/cli-ui": {
       "name": "@opena2a/cli-ui",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0"

--- a/packages/check-core/CHANGELOG.md
+++ b/packages/check-core/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to `@opena2a/check-core`.
+
+## 0.1.0 — 2026-04-24
+
+Initial release. Extracted from `hackmyagent/src/check-render.ts` and
+`ai-trust/src/output/formatter.ts` to provide one implementation of the
+`check` flow's data layer across OpenA2A CLIs.
+
+### Added
+- `parseCheckInput(raw)` — ecosystem classifier (npm / pypi / github / local / url).
+- `translateDownloadError(name, message)` — `code 128` + not-found hint builder.
+- `mapScanStatusForMeter(status)` — maps registry scanStatus to the cli-ui meter gate.
+- `buildCheckOutput(input)` — canonical `CheckOutput` JSON shape. Emission order matches hackmyagent@0.18.3 for byte-equality parity.
+- `buildNotFoundOutput(input)` — canonical `NotFoundOutput` JSON shape.
+- `checkPackage(input)` — registry-first, scan-on-miss orchestrator with pluggable `registry` / `scan` / `skillFallback` adapters.
+- Types: `CheckInput`, `CheckOutput`, `NotFoundOutput`, `ScanResult`, `SkillResult`, `TrustData`, `ParsedCheckInput`, `ScanAdapter`, `SkillAdapter`, `RegistryAdapter`, `TranslatedError`.
+
+### Unblocks
+- F2, F3, F4 of `briefs/check-command-divergence.md` (not-found shape, git exit code leak, skill fallback).
+- `[CA-034]` M3 milestone in `todo/2026-04-22-cli-consolidation-sequenced.md`.

--- a/packages/check-core/README.md
+++ b/packages/check-core/README.md
@@ -1,0 +1,80 @@
+# @opena2a/check-core
+
+Data-shape and orchestration primitives for the `check` command across
+OpenA2A CLIs (`hackmyagent`, `opena2a`, `ai-trust`).
+
+One implementation of:
+- input classification (npm / pypi / github / local / url)
+- download-error translation
+- registry-status → meter-gate mapping
+- canonical `CheckOutput` + `NotFoundOutput` JSON shape
+- registry-first, scan-on-miss orchestrator (pluggable adapters)
+
+Rendering stays in [`@opena2a/cli-ui`](../cli-ui). This package is data only.
+
+## Why
+
+Three CLIs emit `check --json`. Before 0.18.3 their outputs disagreed on
+five load-bearing fields (trustLevel, verdict, packageType, scanStatus,
+name). M2 closed that by convention; M3 closes it by construction — there
+is exactly one implementation, and every CLI imports it.
+
+Parent design: [`briefs/cli-consolidation.md`](https://github.com/opena2a-org/opena2a-org-public/blob/main/briefs/cli-consolidation.md).
+Milestone: [CA-034] M3.
+
+## API
+
+```ts
+import {
+  checkPackage,
+  buildCheckOutput,
+  buildNotFoundOutput,
+  translateDownloadError,
+  mapScanStatusForMeter,
+  parseCheckInput,
+} from "@opena2a/check-core";
+```
+
+### Orchestrator (registry-first, scan-on-miss)
+
+```ts
+const res = await checkPackage({
+  target: "@modelcontextprotocol/server-filesystem",
+  mode: "scan-on-miss",
+  registry: (name, type) => client.checkTrust(name, type),
+  scan: (name) => runLocalScan(name),
+  skillFallback: (name) => resolveSkill(name),
+});
+
+if (res.kind === "found") {
+  console.log(JSON.stringify(res.output, null, 2));
+} else {
+  console.log(JSON.stringify(res.output, null, 2));
+  process.exitCode = 2;
+}
+```
+
+### Pure helpers (for CLIs that keep their own flow)
+
+```ts
+const output = buildCheckOutput({
+  name: "express",
+  type: "npm-package",
+  scan: { score: 100, maxScore: 100, findings: [] },
+  registry: trustAnswer,
+});
+
+const hint = translateDownloadError("anthropic/code-review", "code 128");
+// { errorHint: "Looks like a git-style name. npm packages use ...", suggestions: [...] }
+```
+
+## Contract
+
+The emission order of `buildCheckOutput` is load-bearing: the
+`opena2a-parity` harness compares JSON byte-for-byte across CLIs. Do not
+reorder fields without bumping to a new minor — consumers rely on stable
+shape.
+
+## License
+
+Apache-2.0

--- a/packages/check-core/package.json
+++ b/packages/check-core/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@opena2a/check-core",
+  "version": "0.1.0",
+  "description": "Data-shape and orchestration primitives for the `check` command across OpenA2A CLIs. One implementation of input classification, registry → scan-on-miss flow, download-error translation, and canonical CheckOutput schema — consumed by hackmyagent, opena2a-cli, and ai-trust.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run --passWithNoTests",
+    "lint": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@opena2a/registry-client": "0.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opena2a-org/opena2a.git",
+    "directory": "packages/check-core"
+  },
+  "homepage": "https://github.com/opena2a-org/opena2a/tree/main/packages/check-core",
+  "license": "Apache-2.0"
+}

--- a/packages/check-core/src/check-package.test.ts
+++ b/packages/check-core/src/check-package.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from "vitest";
+import { checkPackage } from "./check-package.js";
+import type { ScanResult, TrustData } from "./types.js";
+
+const foundRegistry: TrustData = {
+  found: true,
+  name: "@modelcontextprotocol/server-filesystem",
+  trustScore: 0.82,
+  trustLevel: 3,
+  verdict: "warnings",
+  scanStatus: "passed",
+  packageType: "mcp_server",
+};
+
+const missingRegistry: TrustData = {
+  found: false,
+  name: "ghost",
+  trustScore: 0,
+  trustLevel: 0,
+  verdict: "unknown",
+};
+
+const okScan: ScanResult = {
+  projectType: "mcp-server",
+  score: 100,
+  maxScore: 100,
+  findings: [],
+};
+
+describe("checkPackage — orchestrator", () => {
+  it("returns found when registry has data", async () => {
+    const res = await checkPackage({
+      target: "@modelcontextprotocol/server-filesystem",
+      mode: "scan-on-miss",
+      registry: async () => foundRegistry,
+    });
+    expect(res.kind).toBe("found");
+    if (res.kind === "found") {
+      expect(res.output.source).toBe("registry");
+      expect(res.output.trustLevel).toBe(3);
+      expect(res.output.name).toBe(foundRegistry.name);
+    }
+  });
+
+  it("registry-only mode → not-found when registry misses", async () => {
+    const res = await checkPackage({
+      target: "ghost",
+      mode: "registry-only",
+      registry: async () => missingRegistry,
+    });
+    expect(res.kind).toBe("not-found");
+    if (res.kind === "not-found") {
+      expect(res.output.name).toBe("ghost");
+      expect(res.output.ecosystem).toBe("npm");
+    }
+  });
+
+  it("scan-on-miss mode → runs scan on registry miss and returns source=local-scan", async () => {
+    const scan = vi.fn(async () => okScan);
+    const res = await checkPackage({
+      target: "ghost",
+      mode: "scan-on-miss",
+      registry: async () => missingRegistry,
+      scan,
+    });
+    expect(scan).toHaveBeenCalledWith("ghost");
+    expect(res.kind).toBe("found");
+    if (res.kind === "found") {
+      expect(res.output.source).toBe("local-scan");
+      expect(res.output.score).toBe(100);
+    }
+  });
+
+  it("scan error with git-style name + code 128 → translated not-found", async () => {
+    const scan = vi.fn(async () => {
+      throw new Error("npm ERR! code 128 git clone failed");
+    });
+    const res = await checkPackage({
+      target: "anthropic/code-review",
+      mode: "scan-on-miss",
+      registry: async () => missingRegistry,
+      scan,
+    });
+    expect(res.kind).toBe("not-found");
+    if (res.kind === "not-found") {
+      expect(res.output.errorHint).toContain("@anthropic/code-review");
+      expect(res.output.suggestions).toEqual(["@anthropic/code-review"]);
+    }
+  });
+
+  it("registry error does not abort — scan adapter still runs in scan-on-miss mode", async () => {
+    const scan = vi.fn(async () => okScan);
+    const res = await checkPackage({
+      target: "express",
+      mode: "scan-on-miss",
+      registry: async () => {
+        throw new Error("HTTP 500 from registry");
+      },
+      scan,
+    });
+    expect(scan).toHaveBeenCalled();
+    expect(res.kind).toBe("found");
+  });
+
+  it("skill fallback used when no scan adapter and registry misses", async () => {
+    const skillFallback = vi.fn(async () => ({
+      name: "@anthropic/code-review",
+    }));
+    const res = await checkPackage({
+      target: "@anthropic/code-review",
+      mode: "scan-on-miss",
+      registry: async () => missingRegistry,
+      skillFallback,
+    });
+    expect(skillFallback).toHaveBeenCalled();
+    expect(res.kind).toBe("found");
+    if (res.kind === "found") {
+      expect(res.output.source).toBe("skill");
+      expect(res.output.type).toBe("skill");
+    }
+  });
+
+  it("skill fallback returning null yields not-found", async () => {
+    const skillFallback = vi.fn(async () => null);
+    const res = await checkPackage({
+      target: "nothing",
+      mode: "scan-on-miss",
+      registry: async () => missingRegistry,
+      skillFallback,
+    });
+    expect(res.kind).toBe("not-found");
+  });
+
+  it("registry-only mode never calls the scan adapter even if present", async () => {
+    const scan = vi.fn(async () => okScan);
+    await checkPackage({
+      target: "ghost",
+      mode: "registry-only",
+      registry: async () => missingRegistry,
+      scan,
+    });
+    expect(scan).not.toHaveBeenCalled();
+  });
+
+  it("passes the type filter through to the registry adapter", async () => {
+    const registry = vi.fn(async () => foundRegistry);
+    await checkPackage({
+      target: "@modelcontextprotocol/server-filesystem",
+      mode: "registry-only",
+      type: "mcp_server",
+      registry,
+    });
+    expect(registry).toHaveBeenCalledWith(
+      "@modelcontextprotocol/server-filesystem",
+      "mcp_server",
+    );
+  });
+
+  it("parses pip: prefix and hands registry the stripped name", async () => {
+    const registry = vi.fn(async () => foundRegistry);
+    await checkPackage({
+      target: "pip:requests",
+      mode: "registry-only",
+      registry,
+    });
+    expect(registry).toHaveBeenCalledWith("requests", undefined);
+  });
+});

--- a/packages/check-core/src/check-package.ts
+++ b/packages/check-core/src/check-package.ts
@@ -1,0 +1,140 @@
+import { buildCheckOutput, buildNotFoundOutput } from "./output.js";
+import { parseCheckInput, ecosystemToTargetType } from "./input.js";
+import { translateDownloadError } from "./translate-error.js";
+import type {
+  CheckInput,
+  CheckOutput,
+  NotFoundOutput,
+  PackageEcosystem,
+  PackageTarget,
+} from "./types.js";
+
+/**
+ * Result type from the orchestrator — a tagged union so callers can pick
+ * the JSON shape branch without reading the `found` key.
+ */
+export type CheckPackageResult =
+  | { kind: "found"; output: CheckOutput }
+  | { kind: "not-found"; output: NotFoundOutput };
+
+/**
+ * Registry-first, scan-on-miss orchestrator for `check <target>`.
+ *
+ * This is the shared flow ai-trust uses by default, and that opena2a-cli
+ * uses when not spawn-delegating to hackmyagent. hackmyagent itself
+ * keeps its scan-first flow and calls `buildCheckOutput` directly on
+ * the merged (scan + registry) data; it doesn't need this orchestrator.
+ *
+ * Flow:
+ *   1. Query the registry.
+ *   2. Registry found → build CheckOutput from trust data (source=registry).
+ *   3. Registry miss + mode=registry-only → NotFoundOutput.
+ *   4. Registry miss + mode=scan-on-miss + scan adapter set → run scan.
+ *      - Scan OK → build CheckOutput from scan data (source=local-scan).
+ *      - Scan error → translateDownloadError, NotFoundOutput.
+ *   5. Registry miss + mode=scan-on-miss + skillFallback set → try skill.
+ *      - Skill match → CheckOutput with source=skill.
+ *      - Skill miss  → NotFoundOutput.
+ *   6. Otherwise → NotFoundOutput with default hint.
+ */
+export async function checkPackage(input: CheckInput): Promise<CheckPackageResult> {
+  const parsed = parseCheckInput(input.target);
+  const ecosystem: PackageEcosystem = parsed.ecosystem;
+  const type: PackageTarget =
+    ecosystemToTargetType(ecosystem) ?? "npm-package";
+
+  // 1. Registry lookup
+  let registryError: Error | null = null;
+  try {
+    const trust = await input.registry(parsed.normalizedName, input.type);
+    if (trust.found) {
+      return {
+        kind: "found",
+        output: buildCheckOutput({
+          name: trust.name ?? parsed.normalizedName,
+          type,
+          registry: trust,
+        }),
+      };
+    }
+  } catch (err) {
+    registryError = err instanceof Error ? err : new Error(String(err));
+  }
+
+  // 2. registry-only mode → bail with a not-found
+  if (input.mode === "registry-only") {
+    return {
+      kind: "not-found",
+      output: buildNotFoundOutput({
+        name: parsed.normalizedName,
+        ecosystem,
+        error: registryError?.message,
+      }),
+    };
+  }
+
+  // 3. scan-on-miss: try the scan adapter first
+  if (input.scan) {
+    try {
+      const scan = await input.scan(parsed.normalizedName);
+      return {
+        kind: "found",
+        output: buildCheckOutput({
+          name: parsed.normalizedName,
+          type,
+          scan,
+        }),
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const translated = translateDownloadError(parsed.normalizedName, message);
+      if (translated !== undefined) {
+        return {
+          kind: "not-found",
+          output: buildNotFoundOutput({
+            name: parsed.normalizedName,
+            ecosystem,
+            errorHint: translated.errorHint,
+            suggestions: translated.suggestions,
+            error: message,
+          }),
+        };
+      }
+      return {
+        kind: "not-found",
+        output: buildNotFoundOutput({
+          name: parsed.normalizedName,
+          ecosystem,
+          error: message,
+        }),
+      };
+    }
+  }
+
+  // 4. skill fallback (HMA-only in 0.1.0)
+  if (input.skillFallback) {
+    try {
+      const skill = await input.skillFallback(parsed.normalizedName);
+      if (skill) {
+        return {
+          kind: "found",
+          output: {
+            name: skill.name,
+            type: "skill",
+            source: "skill",
+          },
+        };
+      }
+    } catch {
+      // fall through to generic not-found
+    }
+  }
+
+  return {
+    kind: "not-found",
+    output: buildNotFoundOutput({
+      name: parsed.normalizedName,
+      ecosystem,
+    }),
+  };
+}

--- a/packages/check-core/src/index.ts
+++ b/packages/check-core/src/index.ts
@@ -1,0 +1,51 @@
+/**
+ * @opena2a/check-core — Data-shape and orchestration primitives for the
+ * `check` command across OpenA2A CLIs.
+ *
+ * One implementation of:
+ *   - input classification (npm / pypi / github / local / url)
+ *   - download-error translation
+ *   - registry-status → meter-gate mapping
+ *   - canonical CheckOutput + NotFoundOutput JSON shape
+ *   - registry-first, scan-on-miss orchestrator (with pluggable adapters)
+ *
+ * Rendering stays in `@opena2a/cli-ui` (renderCheckBlock /
+ * renderNotFoundBlock / renderNextSteps) — this package is data only.
+ */
+
+export {
+  parseCheckInput,
+  ecosystemToTargetType,
+} from "./input.js";
+
+export { translateDownloadError } from "./translate-error.js";
+
+export { mapScanStatusForMeter } from "./scan-status.js";
+
+export {
+  buildCheckOutput,
+  buildNotFoundOutput,
+  type BuildCheckOutputInput,
+  type BuildNotFoundInput,
+} from "./output.js";
+
+export {
+  checkPackage,
+  type CheckPackageResult,
+} from "./check-package.js";
+
+export type {
+  CheckInput,
+  CheckOutput,
+  NotFoundOutput,
+  PackageEcosystem,
+  PackageTarget,
+  ParsedCheckInput,
+  RegistryAdapter,
+  ScanAdapter,
+  ScanResult,
+  SkillAdapter,
+  SkillResult,
+  TranslatedError,
+  TrustData,
+} from "./types.js";

--- a/packages/check-core/src/input.test.ts
+++ b/packages/check-core/src/input.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { parseCheckInput, ecosystemToTargetType } from "./input.js";
+
+describe("parseCheckInput", () => {
+  it("classifies a scoped npm name", () => {
+    const r = parseCheckInput("@modelcontextprotocol/server-filesystem");
+    expect(r.ecosystem).toBe("npm");
+    expect(r.normalizedName).toBe("@modelcontextprotocol/server-filesystem");
+    expect(r.isScoped).toBe(true);
+    expect(r.isGitShorthand).toBe(false);
+  });
+
+  it("classifies a bare npm name", () => {
+    const r = parseCheckInput("express");
+    expect(r.ecosystem).toBe("npm");
+    expect(r.normalizedName).toBe("express");
+    expect(r.isScoped).toBe(false);
+    expect(r.isGitShorthand).toBe(false);
+  });
+
+  it("classifies a github shorthand as github", () => {
+    const r = parseCheckInput("anthropic/code-review");
+    expect(r.ecosystem).toBe("github");
+    expect(r.normalizedName).toBe("anthropic/code-review");
+    expect(r.isGitShorthand).toBe(true);
+    expect(r.isScoped).toBe(false);
+  });
+
+  it("classifies a pip: prefixed name", () => {
+    const r = parseCheckInput("pip:requests");
+    expect(r.ecosystem).toBe("pypi");
+    expect(r.normalizedName).toBe("requests");
+    expect(r.isScoped).toBe(false);
+  });
+
+  it("classifies a local path (.)", () => {
+    const r = parseCheckInput("./my-project");
+    expect(r.ecosystem).toBe("local");
+    expect(r.normalizedName).toBe("./my-project");
+  });
+
+  it("classifies an absolute local path (/)", () => {
+    const r = parseCheckInput("/tmp/my-project");
+    expect(r.ecosystem).toBe("local");
+    expect(r.normalizedName).toBe("/tmp/my-project");
+  });
+
+  it("classifies a URL", () => {
+    const r = parseCheckInput("https://github.com/a/b");
+    expect(r.ecosystem).toBe("url");
+    expect(r.normalizedName).toBe("https://github.com/a/b");
+  });
+
+  it("trims whitespace", () => {
+    const r = parseCheckInput("  express  ");
+    expect(r.ecosystem).toBe("npm");
+    expect(r.normalizedName).toBe("express");
+    // raw preserves the original
+    expect(r.raw).toBe("  express  ");
+  });
+
+  it("is not scoped when name contains @ mid-string", () => {
+    const r = parseCheckInput("foo@bar");
+    expect(r.isScoped).toBe(false);
+  });
+
+  it("classifies totally malformed input as unknown", () => {
+    const r = parseCheckInput("!!$$");
+    expect(r.ecosystem).toBe("unknown");
+  });
+});
+
+describe("ecosystemToTargetType", () => {
+  it("maps npm → npm-package", () => {
+    expect(ecosystemToTargetType("npm")).toBe("npm-package");
+  });
+  it("maps pypi → pypi-package", () => {
+    expect(ecosystemToTargetType("pypi")).toBe("pypi-package");
+  });
+  it("maps github → github-repo", () => {
+    expect(ecosystemToTargetType("github")).toBe("github-repo");
+  });
+  it("leaves local/url/unknown undefined", () => {
+    expect(ecosystemToTargetType("local")).toBeUndefined();
+    expect(ecosystemToTargetType("url")).toBeUndefined();
+    expect(ecosystemToTargetType("unknown")).toBeUndefined();
+  });
+});

--- a/packages/check-core/src/input.ts
+++ b/packages/check-core/src/input.ts
@@ -1,0 +1,91 @@
+import type { ParsedCheckInput, PackageEcosystem } from "./types.js";
+
+const NPM_NAME_RE = /^[@A-Za-z0-9_][A-Za-z0-9_.\-/]*$/;
+const GIT_SHORTHAND_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const URL_RE = /^https?:\/\//i;
+const LOCAL_PATH_RE = /^(\.\.?\/|\/)/;
+
+/**
+ * Classify a raw `check <target>` string into its ecosystem and normalized
+ * form. The classifier is intentionally permissive — it does not reject
+ * malformed names; the registry / downloader layers surface the real error.
+ */
+export function parseCheckInput(raw: string): ParsedCheckInput {
+  const trimmed = raw.trim();
+
+  if (URL_RE.test(trimmed)) {
+    return {
+      raw,
+      ecosystem: "url",
+      normalizedName: trimmed,
+      isGitShorthand: false,
+      isScoped: false,
+    };
+  }
+
+  if (LOCAL_PATH_RE.test(trimmed)) {
+    return {
+      raw,
+      ecosystem: "local",
+      normalizedName: trimmed,
+      isGitShorthand: false,
+      isScoped: false,
+    };
+  }
+
+  if (trimmed.startsWith("pip:")) {
+    return {
+      raw,
+      ecosystem: "pypi",
+      normalizedName: trimmed.slice(4),
+      isGitShorthand: false,
+      isScoped: false,
+    };
+  }
+
+  const isScoped = trimmed.startsWith("@");
+  const isGitShorthand =
+    !isScoped && GIT_SHORTHAND_RE.test(trimmed);
+
+  // Git-shorthand like `user/repo` (no `@` scope) is ambiguous — it could be
+  // a typo for `@user/repo` on npm or an intentional GitHub reference. The
+  // downloader will try npm first; translateDownloadError handles the
+  // "code 128" fallback case. We tag ecosystem as `github` so the caller
+  // can short-circuit if desired, but `normalizedName` is left as the raw
+  // form so the registry lookup happens against the same literal.
+  if (isGitShorthand) {
+    return {
+      raw,
+      ecosystem: "github",
+      normalizedName: trimmed,
+      isGitShorthand: true,
+      isScoped: false,
+    };
+  }
+
+  if (NPM_NAME_RE.test(trimmed)) {
+    return {
+      raw,
+      ecosystem: "npm",
+      normalizedName: trimmed,
+      isGitShorthand: false,
+      isScoped,
+    };
+  }
+
+  return {
+    raw,
+    ecosystem: "unknown",
+    normalizedName: trimmed,
+    isGitShorthand: false,
+    isScoped: false,
+  };
+}
+
+/** Map an ecosystem to the corresponding `CheckOutput.type` value. */
+export function ecosystemToTargetType(eco: PackageEcosystem): "npm-package" | "github-repo" | "pypi-package" | undefined {
+  if (eco === "npm") return "npm-package";
+  if (eco === "github") return "github-repo";
+  if (eco === "pypi") return "pypi-package";
+  return undefined;
+}

--- a/packages/check-core/src/output.test.ts
+++ b/packages/check-core/src/output.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import { buildCheckOutput, buildNotFoundOutput } from "./output.js";
+import type { ScanResult, TrustData } from "./types.js";
+
+describe("buildCheckOutput", () => {
+  const baseScan: ScanResult = {
+    projectType: "mcp-server",
+    score: 100,
+    maxScore: 100,
+    findings: [],
+  };
+
+  const baseRegistry: TrustData = {
+    found: true,
+    name: "@modelcontextprotocol/server-filesystem",
+    trustScore: 0.82,
+    trustLevel: 3,
+    verdict: "warnings",
+    scanStatus: "passed",
+    packageType: "mcp_server",
+    lastScannedAt: "2026-03-02T10:00:00.000Z",
+    communityScans: 12,
+    cveCount: 0,
+  };
+
+  it("emits scan-only output with source=local-scan", () => {
+    const out = buildCheckOutput({
+      name: "express",
+      type: "npm-package",
+      scan: baseScan,
+    });
+    expect(out).toEqual({
+      name: "express",
+      type: "npm-package",
+      source: "local-scan",
+      projectType: "mcp-server",
+      score: 100,
+      maxScore: 100,
+      findings: [],
+    });
+  });
+
+  it("emits registry-only output with source=registry", () => {
+    const out = buildCheckOutput({
+      name: baseRegistry.name,
+      type: "npm-package",
+      registry: baseRegistry,
+    });
+    expect(out).toEqual({
+      name: baseRegistry.name,
+      type: "npm-package",
+      source: "registry",
+      trustLevel: 3,
+      trustScore: 0.82,
+      verdict: "warnings",
+      scanStatus: "passed",
+      packageType: "mcp_server",
+      lastScannedAt: "2026-03-02T10:00:00.000Z",
+      communityScans: 12,
+      cveCount: 0,
+    });
+  });
+
+  it("merges scan + registry with source=local-scan (HMA's scan-first path)", () => {
+    const out = buildCheckOutput({
+      name: "express",
+      type: "npm-package",
+      scan: baseScan,
+      registry: baseRegistry,
+    });
+    expect(out.source).toBe("local-scan");
+    expect(out.score).toBe(100);
+    expect(out.trustLevel).toBe(3);
+  });
+
+  it("key order matches hackmyagent@0.18.3 buildCheckJsonOutput (byte-equality contract)", () => {
+    // The parity harness compares JSON output byte-for-byte. Key order must
+    // match the legacy emitter exactly so `hackmyagent check --json` does
+    // not drift after migration.
+    const out = buildCheckOutput({
+      name: "express",
+      type: "npm-package",
+      scan: { ...baseScan, version: "4.18.2", analystFindings: [{ id: "x" }] },
+      registry: baseRegistry,
+    });
+    const keys = Object.keys(out);
+    expect(keys).toEqual([
+      "name",
+      "type",
+      "source",
+      "projectType",
+      "score",
+      "maxScore",
+      "findings",
+      "version",
+      "trustLevel",
+      "trustScore",
+      "verdict",
+      "scanStatus",
+      "packageType",
+      "lastScannedAt",
+      "communityScans",
+      "cveCount",
+      "analystFindings",
+    ]);
+  });
+
+  it("omits analystFindings when empty", () => {
+    const out = buildCheckOutput({
+      name: "express",
+      type: "npm-package",
+      scan: { ...baseScan, analystFindings: [] },
+    });
+    expect(out.analystFindings).toBeUndefined();
+  });
+
+  it("does not merge registry when found=false", () => {
+    const out = buildCheckOutput({
+      name: "ghost",
+      type: "npm-package",
+      scan: baseScan,
+      registry: { ...baseRegistry, found: false },
+    });
+    expect(out.trustLevel).toBeUndefined();
+    expect(out.verdict).toBeUndefined();
+    expect(out.source).toBe("local-scan");
+  });
+
+  it("omits optional scan fields when absent", () => {
+    const minimalScan: ScanResult = { score: 95, maxScore: 100, findings: [] };
+    const out = buildCheckOutput({
+      name: "minimal",
+      type: "npm-package",
+      scan: minimalScan,
+    });
+    expect(out.projectType).toBeUndefined();
+    expect(out.version).toBeUndefined();
+  });
+
+  it("omits optional registry fields when undefined", () => {
+    const minimalReg: TrustData = {
+      found: true,
+      name: "bare",
+      trustScore: 0.5,
+      trustLevel: 2,
+      verdict: "pass",
+    };
+    const out = buildCheckOutput({
+      name: "bare",
+      type: "npm-package",
+      registry: minimalReg,
+    });
+    expect(out.scanStatus).toBeUndefined();
+    expect(out.packageType).toBeUndefined();
+    expect(out.lastScannedAt).toBeUndefined();
+  });
+});
+
+describe("buildNotFoundOutput", () => {
+  it("emits minimal not-found shape", () => {
+    const out = buildNotFoundOutput({ name: "ghost" });
+    expect(out).toEqual({ name: "ghost", found: false });
+  });
+
+  it("includes errorHint and suggestions when present", () => {
+    const out = buildNotFoundOutput({
+      name: "anthropic/code-review",
+      errorHint: "did you mean scoped?",
+      suggestions: ["@anthropic/code-review"],
+    });
+    expect(out.errorHint).toBe("did you mean scoped?");
+    expect(out.suggestions).toEqual(["@anthropic/code-review"]);
+  });
+
+  it("omits empty suggestions array", () => {
+    const out = buildNotFoundOutput({ name: "ghost", suggestions: [] });
+    expect(out.suggestions).toBeUndefined();
+  });
+
+  it("includes ecosystem when provided", () => {
+    const out = buildNotFoundOutput({ name: "ghost", ecosystem: "npm" });
+    expect(out.ecosystem).toBe("npm");
+  });
+});

--- a/packages/check-core/src/output.ts
+++ b/packages/check-core/src/output.ts
@@ -1,0 +1,95 @@
+import type {
+  CheckOutput,
+  NotFoundOutput,
+  PackageEcosystem,
+  PackageTarget,
+  ScanResult,
+  TrustData,
+} from "./types.js";
+
+/**
+ * Input to `buildCheckOutput`. At least one of `scan` or `registry`
+ * (with `found === true`) should be present; both together means the
+ * local-scan finished and the registry also has trust data to merge.
+ */
+export interface BuildCheckOutputInput {
+  name: string;
+  type: PackageTarget;
+  scan?: ScanResult;
+  registry?: TrustData | null;
+}
+
+/**
+ * Build the canonical `check` output object.
+ *
+ * Key order is load-bearing — the opena2a-parity harness compares the
+ * byte shape across CLIs, and changing the emission order would break
+ * `hackmyagent check --json` outputs consumers rely on. Order matches
+ * hackmyagent@0.18.3's legacy `buildCheckJsonOutput`:
+ *
+ *   name, type, source,
+ *   projectType, score, maxScore, findings, version,     (scan path)
+ *   trustLevel, trustScore, verdict, scanStatus,          (registry)
+ *   packageType, lastScannedAt, communityScans, cveCount,
+ *   analystFindings
+ */
+export function buildCheckOutput(input: BuildCheckOutputInput): CheckOutput {
+  const { name, type, scan, registry } = input;
+  const out: CheckOutput = {
+    name,
+    type,
+    source: scan ? "local-scan" : "registry",
+  };
+
+  if (scan) {
+    if (scan.projectType !== undefined) out.projectType = scan.projectType;
+    out.score = scan.score;
+    out.maxScore = scan.maxScore;
+    out.findings = scan.findings;
+    if (scan.version !== undefined) out.version = scan.version;
+  }
+
+  if (registry?.found) {
+    out.trustLevel = registry.trustLevel;
+    out.trustScore = registry.trustScore;
+    out.verdict = registry.verdict;
+    if (registry.scanStatus !== undefined) out.scanStatus = registry.scanStatus;
+    if (registry.packageType !== undefined) out.packageType = registry.packageType;
+    if (registry.lastScannedAt !== undefined) out.lastScannedAt = registry.lastScannedAt;
+    if (registry.communityScans !== undefined) out.communityScans = registry.communityScans;
+    if (registry.cveCount !== undefined) out.cveCount = registry.cveCount;
+  }
+
+  if (scan?.analystFindings && scan.analystFindings.length) {
+    out.analystFindings = scan.analystFindings;
+  }
+
+  return out;
+}
+
+export interface BuildNotFoundInput {
+  name: string;
+  ecosystem?: PackageEcosystem;
+  errorHint?: string;
+  suggestions?: string[];
+  error?: string;
+  nextSteps?: string[];
+}
+
+/**
+ * Build the canonical not-found JSON shape. Closes F2 (three different
+ * not-found shapes) by giving all consumers a single builder.
+ */
+export function buildNotFoundOutput(input: BuildNotFoundInput): NotFoundOutput {
+  const { name, ecosystem, errorHint, suggestions, error, nextSteps } = input;
+  const out: NotFoundOutput = {
+    name,
+    found: false,
+  };
+  if (error !== undefined) out.error = error;
+  if (errorHint !== undefined) out.errorHint = errorHint;
+  if (suggestions && suggestions.length) out.suggestions = suggestions;
+  if (nextSteps && nextSteps.length) out.nextSteps = nextSteps;
+  if (ecosystem !== undefined) out.ecosystem = ecosystem;
+  return out;
+}

--- a/packages/check-core/src/scan-status.test.ts
+++ b/packages/check-core/src/scan-status.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { mapScanStatusForMeter } from "./scan-status.js";
+
+describe("mapScanStatusForMeter", () => {
+  it("maps 'complete' / 'completed' / 'passed' → completed", () => {
+    expect(mapScanStatusForMeter("complete")).toBe("completed");
+    expect(mapScanStatusForMeter("completed")).toBe("completed");
+    expect(mapScanStatusForMeter("passed")).toBe("completed");
+  });
+
+  it("maps 'warnings' / 'warning' → warnings", () => {
+    expect(mapScanStatusForMeter("warnings")).toBe("warnings");
+    expect(mapScanStatusForMeter("warning")).toBe("warnings");
+  });
+
+  it("suppresses meter for pending / not_applicable / empty", () => {
+    expect(mapScanStatusForMeter("pending")).toBeUndefined();
+    expect(mapScanStatusForMeter("not_applicable")).toBeUndefined();
+    expect(mapScanStatusForMeter("")).toBeUndefined();
+  });
+
+  it("suppresses meter for error / failed", () => {
+    expect(mapScanStatusForMeter("error")).toBeUndefined();
+    expect(mapScanStatusForMeter("failed")).toBeUndefined();
+  });
+
+  it("suppresses meter for undefined and unknown states", () => {
+    expect(mapScanStatusForMeter(undefined)).toBeUndefined();
+    expect(mapScanStatusForMeter("in_progress")).toBeUndefined();
+    expect(mapScanStatusForMeter("weird-new-state")).toBeUndefined();
+  });
+
+  it("is case-insensitive and whitespace-tolerant", () => {
+    expect(mapScanStatusForMeter("  PASSED  ")).toBe("completed");
+    expect(mapScanStatusForMeter("Warning")).toBe("warnings");
+  });
+});

--- a/packages/check-core/src/scan-status.ts
+++ b/packages/check-core/src/scan-status.ts
@@ -1,0 +1,18 @@
+/**
+ * Map the registry's scanStatus vocabulary onto the meter-gate tri-state
+ * consumed by renderCheckBlock in `@opena2a/cli-ui@0.3.0`:
+ *
+ *   - `"completed"` — render the Security meter with the numeric score.
+ *   - `"warnings"`  — render the meter with a warnings chrome.
+ *   - `undefined`   — suppress the meter (F6: a number implies measurement;
+ *     don't show one for pending/failed/unknown states).
+ */
+export function mapScanStatusForMeter(status?: string): "completed" | "warnings" | undefined {
+  if (!status) return undefined;
+  const normalized = status.toLowerCase().trim();
+  if (normalized === "" || normalized === "pending" || normalized === "not_applicable") return undefined;
+  if (normalized === "error" || normalized === "failed") return undefined;
+  if (normalized === "warnings" || normalized === "warning") return "warnings";
+  if (normalized === "complete" || normalized === "completed" || normalized === "passed") return "completed";
+  return undefined;
+}

--- a/packages/check-core/src/translate-error.test.ts
+++ b/packages/check-core/src/translate-error.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { translateDownloadError } from "./translate-error.js";
+
+describe("translateDownloadError", () => {
+  // Merged cases from hackmyagent/src/check-render.ts (translateNpmPackError)
+  // + ai-trust/src/output/formatter.ts (translateDownloadError).
+
+  describe("git-style name + code 128", () => {
+    it("suggests the scoped form", () => {
+      const out = translateDownloadError("anthropic/code-review", "npm ERR! code 128");
+      expect(out).toEqual({
+        errorHint: `Looks like a git-style name. npm packages use "@scope/name" — did you mean "@anthropic/code-review"?`,
+        suggestions: ["@anthropic/code-review"],
+      });
+    });
+
+    it("handles case-insensitive code 128 phrasing", () => {
+      const out = translateDownloadError("foo/bar", "error: CODE 128 from git");
+      expect(out?.suggestions).toEqual(["@foo/bar"]);
+    });
+
+    it("handles 'code  128' with extra whitespace", () => {
+      const out = translateDownloadError("foo/bar", "died: code  128");
+      expect(out?.suggestions).toEqual(["@foo/bar"]);
+    });
+
+    it("does not trigger on an already-scoped name even with code 128", () => {
+      const out = translateDownloadError("@anthropic/code-review", "code 128");
+      // @-scoped names are legit npm — don't suggest adding another @
+      expect(out).toBeUndefined();
+    });
+
+    it("does not trigger on a bare name with code 128", () => {
+      const out = translateDownloadError("express", "code 128");
+      expect(out).toBeUndefined();
+    });
+  });
+
+  describe("clean not-found messages", () => {
+    it("returns empty hint object for 'not found on npm'", () => {
+      const out = translateDownloadError("ghost-pkg", `Package "ghost-pkg" not found on npm`);
+      expect(out).toEqual({});
+    });
+
+    it("returns empty hint object for 'not found on pypi'", () => {
+      const out = translateDownloadError("ghost-pkg", `Package "ghost-pkg" not found on PyPI`);
+      expect(out).toEqual({});
+    });
+
+    it("returns empty hint for case-insensitive pypi miss", () => {
+      const out = translateDownloadError("ghost", "Found? no — NOT FOUND ON pypi anywhere");
+      expect(out).toEqual({});
+    });
+  });
+
+  describe("unrecognized messages", () => {
+    it("returns undefined for a generic network error", () => {
+      const out = translateDownloadError("express", "ETIMEDOUT reading registry");
+      expect(out).toBeUndefined();
+    });
+
+    it("returns undefined when message is empty", () => {
+      const out = translateDownloadError("express", "");
+      expect(out).toBeUndefined();
+    });
+  });
+});

--- a/packages/check-core/src/translate-error.ts
+++ b/packages/check-core/src/translate-error.ts
@@ -1,0 +1,39 @@
+import type { TranslatedError } from "./types.js";
+
+const GIT_STYLE_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const CODE_128_RE = /code\s*128/i;
+const NPM_NOT_FOUND_RE = /not found on npm/i;
+const PYPI_NOT_FOUND_RE = /not found on pypi/i;
+
+/**
+ * Translate a raw downloader error message into a renderNotFoundBlock hint.
+ *
+ * Two recognized cases (merged from hackmyagent + ai-trust):
+ *
+ * 1. Git-style name (`anthropic/code-review`, no `@` scope) failing with
+ *    `code 128` — npm's downloader tried the git-clone fallback because
+ *    the name didn't resolve on the registry. Suggest the scoped form.
+ *
+ * 2. Clean "not found" on npm / PyPI — returns an empty hint object so the
+ *    caller renders the default not-found block (no extra suggestion line).
+ *
+ * Returns `undefined` when the error is not recognized — caller decides
+ * whether to surface it raw or translate generically.
+ */
+export function translateDownloadError(
+  name: string,
+  message: string,
+): TranslatedError | undefined {
+  const looksGitStyle = GIT_STYLE_RE.test(name) && !name.startsWith("@");
+  if (looksGitStyle && CODE_128_RE.test(message)) {
+    const scoped = `@${name}`;
+    return {
+      errorHint: `Looks like a git-style name. npm packages use "@scope/name" — did you mean "${scoped}"?`,
+      suggestions: [scoped],
+    };
+  }
+  if (NPM_NOT_FOUND_RE.test(message) || PYPI_NOT_FOUND_RE.test(message)) {
+    return {};
+  }
+  return undefined;
+}

--- a/packages/check-core/src/types.ts
+++ b/packages/check-core/src/types.ts
@@ -1,0 +1,155 @@
+/**
+ * Canonical types for the `check` flow.
+ *
+ * These are the shapes that every OpenA2A CLI agrees on when emitting a
+ * `check --json` result. Extras may be layered on top by a specific CLI
+ * (see the `may_differ` section of opena2a-parity's contracts) but the
+ * fields declared here are the cross-CLI invariant.
+ */
+
+/**
+ * Structural subset of the Registry's TrustAnswer (see
+ * `@opena2a/registry-client`). Duplicated here so check-core stays lean
+ * at the type level — consumers pass a compatible object, nothing more.
+ */
+export interface TrustData {
+  found: boolean;
+  name: string;
+  trustScore: number;
+  trustLevel: number;
+  verdict: string;
+  scanStatus?: string;
+  lastScannedAt?: string;
+  packageType?: string;
+  recommendation?: string;
+  cveCount?: number;
+  communityScans?: number;
+  dependencies?: {
+    totalDeps?: number;
+    vulnerableDeps?: number;
+    minTrustLevel?: number;
+    riskSummary?: Record<string, unknown>;
+  };
+}
+
+/**
+ * A generic local-scan result. Each CLI ships its own finding shape; the
+ * orchestrator is shape-agnostic below the top-level score/max/findings
+ * triple.
+ */
+export interface ScanResult {
+  projectType?: string;
+  score: number;
+  maxScore: number;
+  findings: unknown[];
+  analystFindings?: Array<Record<string, unknown>>;
+  version?: string;
+}
+
+/**
+ * A skill-resolver result — HMA's `@anthropic/code-review` fallback path.
+ * ai-trust and opena2a-cli do not inject a skill adapter in 0.1.0
+ * (skill handling is HMA-only per F4 of the check-command-divergence brief).
+ */
+export interface SkillResult {
+  name: string;
+  [key: string]: unknown;
+}
+
+export type ScanAdapter = (target: string) => Promise<ScanResult>;
+export type SkillAdapter = (target: string) => Promise<SkillResult | null>;
+export type RegistryAdapter = (
+  target: string,
+  type?: string,
+) => Promise<TrustData>;
+
+export type PackageEcosystem = "npm" | "pypi" | "github" | "local" | "url" | "unknown";
+export type PackageTarget = "npm-package" | "github-repo" | "pypi-package" | "skill";
+
+/**
+ * Classifier output for a raw `check <target>` argument.
+ */
+export interface ParsedCheckInput {
+  /** The original user-provided string. */
+  raw: string;
+  /** Ecosystem inferred from shape. */
+  ecosystem: PackageEcosystem;
+  /** Normalized package/resource name (e.g. `pip:requests` → `requests`). */
+  normalizedName: string;
+  /** True when the shape looks like a git shorthand (`user/repo`) that
+   * npm's downloader will try to clone (F3 of the divergence brief). */
+  isGitShorthand: boolean;
+  /** True when the raw input had the `@scope/` npm prefix. */
+  isScoped: boolean;
+}
+
+/**
+ * Input to the high-level `checkPackage` orchestrator.
+ */
+export interface CheckInput {
+  /** Raw target (e.g. `@modelcontextprotocol/server-filesystem`). */
+  target: string;
+  /** registry-only = skip scan on miss; scan-on-miss = try scan adapter if
+   * the registry says "not found". */
+  mode: "registry-only" | "scan-on-miss";
+  /** Package type filter forwarded to the registry (optional). */
+  type?: string;
+  /** Registry adapter — caller injects so the orchestrator stays HTTP-free. */
+  registry: RegistryAdapter;
+  /** Scan adapter — called on miss when mode = scan-on-miss. */
+  scan?: ScanAdapter;
+  /** Skill-fallback adapter — HMA-only in 0.1.0. */
+  skillFallback?: SkillAdapter;
+}
+
+/**
+ * Canonical `check` output. Emitted as JSON directly by each CLI's
+ * `--json` path. Matches hackmyagent's buildCheckJsonOutput order so the
+ * byte-equality parity contract holds.
+ */
+export interface CheckOutput {
+  name: string;
+  type?: PackageTarget;
+  source: "registry" | "local-scan" | "skill";
+
+  /** Scan-sourced fields (present when scan data is attached). */
+  projectType?: string;
+  score?: number;
+  maxScore?: number;
+  findings?: unknown[];
+  version?: string;
+
+  /** Registry-sourced fields (present when registry.found === true). */
+  trustLevel?: number;
+  trustScore?: number;
+  verdict?: string;
+  scanStatus?: string;
+  packageType?: string;
+  lastScannedAt?: string;
+  communityScans?: number;
+  cveCount?: number;
+
+  /** Optional analyst annotations from NanoMind. */
+  analystFindings?: Array<Record<string, unknown>>;
+}
+
+/**
+ * Canonical `check` not-found output. Emitted as JSON on misses the
+ * orchestrator couldn't recover (no skill fallback, no scan adapter,
+ * or all adapters rejected).
+ */
+export interface NotFoundOutput {
+  name: string;
+  found: false;
+  error?: string;
+  errorHint?: string;
+  suggestions?: string[];
+  nextSteps?: string[];
+  ecosystem?: PackageEcosystem;
+}
+
+/** Translator output — feeds renderNotFoundBlock. */
+export interface TranslatedError {
+  errorHint?: string;
+  suggestions?: string[];
+}

--- a/packages/check-core/tsconfig.json
+++ b/packages/check-core/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

- New workspace package `@opena2a/check-core@0.1.0` — the shared data-shape + orchestration layer for the `check` command across all three OpenA2A CLIs.
- One implementation of: input classification, download-error translation, registry-status → meter-gate mapping, canonical `CheckOutput` / `NotFoundOutput` JSON, and the registry-first / scan-on-miss orchestrator.
- Closes F2 / F3 / F4 of `briefs/check-command-divergence.md` by making three CLIs AGREE BY CONSTRUCTION (one implementation) instead of AGREE BY CONVENTION (M2's approach).

## What's in this PR

- `packages/check-core/` — 8 source files + 5 co-located test files (52 unit tests green)
- `.github/workflows/release.yml` — `check-core-v*` tag pattern + publish step wired in alongside registry-client
- `package-lock.json` — workspace link for the new package

## Public surface

```ts
export {
  parseCheckInput,        // npm / pypi / github / local / url classifier
  translateDownloadError, // merged git-style "code 128" + not-found cases
  mapScanStatusForMeter,  // registry scanStatus → cli-ui meter gate
  buildCheckOutput,       // canonical JSON shape (byte-compatible with hackmyagent@0.18.3)
  buildNotFoundOutput,    // closes F2 not-found shape divergence
  checkPackage,           // registry-first, scan-on-miss orchestrator
}
```

Rendering stays in `@opena2a/cli-ui` — this package is data only.

## Contract

`buildCheckOutput` emits keys in a load-bearing order that matches the legacy `hackmyagent@0.18.3 buildCheckJsonOutput`. The opena2a-parity harness compares JSON byte-for-byte across CLIs; reordering fields without a semver bump would break consumer output.

Exact-pin `@opena2a/registry-client: 0.1.0` per [CA-034] M1 invariant.

## Test plan

- [x] `npm run build --workspace=packages/check-core` — clean
- [x] `npm test --workspace=packages/check-core` — 52/52 tests pass
- [x] Full monorepo `npm run build` — 8/8 turbo tasks successful
- [x] Full monorepo `npm test` — 16/16 turbo tasks successful (885 opena2a-cli tests included)
- [x] Smoke test: compiled ESM package exports + orchestrator flow via `require()`

## After merge

1. Bootstrap placeholder-seed: manual publish of `@opena2a/check-core@0.0.0` then deprecate (documented flow per `feedback_drive_new_package_bootstrap_end_to_end`)
2. Configure Trusted Publishing on npmjs.com: Organization `opena2a-org`, Repository `opena2a`, Workflow `release.yml`
3. Tag `check-core-v0.1.0` → monorepo workflow publishes with SLSA v1 provenance
4. Verify: `npm view @opena2a/check-core dist.attestations --json` returns `predicateType: https://slsa.dev/provenance/v1`

Then consumer migrations proceed (separate PRs per [CA-034] M3 handoff):
- hackmyagent@0.19.0 — replaces `buildCheckJsonOutput` / `translateNpmPackError` with check-core calls
- ai-trust@0.5.0 — replaces `formatCheckResult` / `formatNotFound` / `translateDownloadError` with check-core calls
- opena2a-parity — adds F2 / F3 / F4 fixtures to lock the new shape across all three CLIs

## Related

- Parent brief: `briefs/cli-consolidation.md` (CA-034 / CPO-019 chief decisions)
- Sequenced plan: `todo/2026-04-22-cli-consolidation-sequenced.md` §M3
- M4 + R.1 sequencing: `briefs/cli-consolidation-m4-r1-sequencing.md` (M4 explicitly NOT started in this PR)