### PR TITLE
feat(telemetry): add @opena2a/telemetry SDK + cli-ui helpers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
       - 'ai-classifier-v*'
       - 'registry-client-v*'
       - 'check-core-v*'
+      - 'telemetry-v*'
 
 permissions:
   contents: write
@@ -70,6 +71,7 @@ jobs:
           publish_if_new packages/aim-core @opena2a/aim-core
           publish_if_new packages/registry-client @opena2a/registry-client
           publish_if_new packages/check-core @opena2a/check-core
+          publish_if_new packages/telemetry @opena2a/telemetry
           echo "=== Published this run ==="
           cat /tmp/published.txt
           echo "=== Skipped (version already on npm) ==="

--- a/package-lock.json
+++ b/package-lock.json
@@ -928,6 +928,10 @@
       "resolved": "packages/shared",
       "link": true
     },
+    "node_modules/@opena2a/telemetry": {
+      "resolved": "packages/telemetry",
+      "link": true
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
@@ -3987,6 +3991,29 @@
       "devDependencies": {
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
+      }
+    },
+    "packages/telemetry": {
+      "name": "@opena2a/telemetry",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/telemetry/node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     }
   }

--- a/packages/cli-ui/CHANGELOG.md
+++ b/packages/cli-ui/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — @opena2a/cli-ui
 
+## 0.4.0
+
+### Added
+- `versionLine({ tool, version, telemetry })` — multi-line `--version` output for OpenA2A CLIs. Appends a "Telemetry: on/off (opt-out: ...)" line when a status object is supplied. Structurally typed against `@opena2a/telemetry`'s `status()` so cli-ui takes no hard dep on the telemetry package.
+- `runTelemetryCommand(action, input)` — handler for `<tool> telemetry [on|off|status]` subcommands. Returns the string to print; consumers wire it into commander/yargs/etc. in three lines. Default action is `status`; unknown actions return a friendly error.
+
+### Behaviour
+- Telemetry-aware helpers are opt-in: tools that haven't integrated `@opena2a/telemetry` yet can call `versionLine({ tool, version })` with no second arg and get just the head line.
+- Both helpers print the canonical `opena2a.org/telemetry` policy URL so the per-run banner is unnecessary (matches the spec's disclosure-surfaces amendment).
+
 ## 0.3.0
 
 ### Added

--- a/packages/cli-ui/src/index.ts
+++ b/packages/cli-ui/src/index.ts
@@ -69,3 +69,13 @@ export {
   type RenderedNextSteps,
   type NextStepsTone,
 } from "./next-steps.js";
+export {
+  versionLine,
+  type TelemetryStatusLike,
+  type VersionLineInput,
+} from "./version-line.js";
+export {
+  runTelemetryCommand,
+  type TelemetryAction,
+  type TelemetryCommandInput,
+} from "./telemetry-command.js";

--- a/packages/cli-ui/src/telemetry-command.test.ts
+++ b/packages/cli-ui/src/telemetry-command.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import chalk from "chalk";
+import { runTelemetryCommand } from "./telemetry-command.js";
+
+beforeEach(() => {
+  chalk.level = 0;
+});
+
+function makeInput(overrides: { enabled?: boolean } = {}) {
+  let enabled = overrides.enabled ?? true;
+  return {
+    tool: "dvaa",
+    setOptOut: vi.fn((v: boolean) => {
+      enabled = v;
+    }),
+    getStatus: () => ({
+      enabled,
+      policyURL: "https://opena2a.org/telemetry",
+      configPath: "/home/user/.config/opena2a/telemetry.json",
+      installId: "abc-123",
+    }),
+  };
+}
+
+describe("runTelemetryCommand", () => {
+  it("status (no action) prints current state and toggle hint", () => {
+    const input = makeInput();
+    const out = runTelemetryCommand(undefined, input);
+    expect(out).toContain("dvaa telemetry");
+    expect(out).toContain("state:");
+    expect(out).toContain("on");
+    expect(out).toContain("install_id:");
+    expect(out).toContain("abc-123");
+    expect(out).toContain("policy:");
+    expect(out).toContain("opena2a.org/telemetry");
+    expect(out).toContain("OPENA2A_TELEMETRY=off");
+    expect(input.setOptOut).not.toHaveBeenCalled();
+  });
+
+  it("'status' action behaves the same as no action", () => {
+    const a = runTelemetryCommand(undefined, makeInput());
+    const b = runTelemetryCommand("status", makeInput());
+    expect(a).toBe(b);
+  });
+
+  it("'on' action calls setOptOut(true) and prints enabled framing", () => {
+    const input = makeInput({ enabled: false });
+    const out = runTelemetryCommand("on", input);
+    expect(input.setOptOut).toHaveBeenCalledWith(true);
+    expect(out).toContain("Telemetry enabled for dvaa.");
+  });
+
+  it("'off' action calls setOptOut(false) and prints disabled framing", () => {
+    const input = makeInput({ enabled: true });
+    const out = runTelemetryCommand("off", input);
+    expect(input.setOptOut).toHaveBeenCalledWith(false);
+    expect(out).toContain("Telemetry disabled for dvaa.");
+  });
+
+  it("unknown action returns an error string and does not toggle", () => {
+    const input = makeInput();
+    // @ts-expect-error — testing the runtime guard
+    const out = runTelemetryCommand("nuke", input);
+    expect(out).toContain("Unknown action 'nuke'");
+    expect(out).toContain("[on|off|status]");
+    expect(input.setOptOut).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli-ui/src/telemetry-command.ts
+++ b/packages/cli-ui/src/telemetry-command.ts
@@ -1,0 +1,73 @@
+import chalk from "chalk";
+import type { TelemetryStatusLike } from "./version-line.js";
+
+export type TelemetryAction = "on" | "off" | "status" | undefined;
+
+export interface TelemetryCommandInput {
+  /** Tool name — only used in the printed output. */
+  tool: string;
+  /** Returns the current telemetry status. Typically `tele.status`. */
+  getStatus: () => TelemetryStatusLike & { configPath: string; installId: string };
+  /** Persists the new opt-out state. Typically `tele.setOptOut`. */
+  setOptOut: (enabled: boolean) => unknown;
+}
+
+/**
+ * Run a `<tool> telemetry [on|off|status]` subcommand.
+ *
+ * Returns the string to print. CLIs wire this in three lines:
+ *
+ *   program.command("telemetry [action]").action((action) => {
+ *     console.log(runTelemetryCommand(action, { tool: "dvaa", getStatus: tele.status, setOptOut: tele.setOptOut }));
+ *   });
+ *
+ * Default action (no args) is `status`.
+ */
+export function runTelemetryCommand(
+  action: TelemetryAction,
+  input: TelemetryCommandInput,
+): string {
+  switch (action) {
+    case "on":
+      input.setOptOut(true);
+      return renderStatus("enabled", input);
+    case "off":
+      input.setOptOut(false);
+      return renderStatus("disabled", input);
+    case "status":
+    case undefined:
+      return renderStatus("current", input);
+    default:
+      return chalk.red(
+        `Unknown action '${action}'. Try '${input.tool} telemetry [on|off|status]'.`,
+      );
+  }
+}
+
+function renderStatus(
+  framing: "enabled" | "disabled" | "current",
+  input: TelemetryCommandInput,
+): string {
+  const status = input.getStatus();
+  const stateWord = status.enabled ? chalk.green("on") : chalk.dim("off");
+  const header =
+    framing === "enabled"
+      ? chalk.green(`Telemetry enabled for ${input.tool}.`)
+      : framing === "disabled"
+        ? chalk.dim(`Telemetry disabled for ${input.tool}.`)
+        : chalk.bold(`${input.tool} telemetry`);
+  const lines = [
+    header,
+    `  state:       ${stateWord}`,
+    `  install_id:  ${chalk.dim(status.installId)}`,
+    `  config:      ${chalk.dim(status.configPath)}`,
+    `  policy:      ${chalk.cyan(status.policyURL)}`,
+  ];
+  if (framing === "current") {
+    lines.push(
+      "",
+      chalk.dim(`  toggle: '${input.tool} telemetry off'  or  OPENA2A_TELEMETRY=off`),
+    );
+  }
+  return lines.join("\n");
+}

--- a/packages/cli-ui/src/version-line.test.ts
+++ b/packages/cli-ui/src/version-line.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import chalk from "chalk";
+import { versionLine } from "./version-line.js";
+
+beforeEach(() => {
+  // Force chalk to emit ANSI codes deterministically for matching, then strip
+  // them in assertions where we only care about the text content.
+  chalk.level = 0;
+});
+
+describe("versionLine", () => {
+  it("returns just the head line when telemetry omitted", () => {
+    expect(versionLine({ tool: "dvaa", version: "0.8.1" })).toBe("dvaa 0.8.1");
+  });
+
+  it("appends 'on' line when telemetry enabled", () => {
+    const out = versionLine({
+      tool: "dvaa",
+      version: "0.8.1",
+      telemetry: { enabled: true, policyURL: "https://opena2a.org/telemetry" },
+    });
+    expect(out).toContain("dvaa 0.8.1");
+    expect(out).toContain("Telemetry: on");
+    expect(out).toContain("opena2a.org/telemetry");
+    expect(out).toContain("OPENA2A_TELEMETRY=off");
+  });
+
+  it("appends 'off' line when telemetry disabled", () => {
+    const out = versionLine({
+      tool: "hma",
+      version: "0.18.0",
+      telemetry: { enabled: false, policyURL: "https://opena2a.org/telemetry" },
+    });
+    expect(out).toContain("Telemetry: off");
+  });
+
+  it("strips the URL scheme so the line stays compact", () => {
+    const out = versionLine({
+      tool: "ai-trust",
+      version: "0.3.0",
+      telemetry: { enabled: true, policyURL: "https://opena2a.org/telemetry" },
+    });
+    expect(out).not.toContain("https://");
+    expect(out).toContain("opena2a.org/telemetry");
+  });
+});

--- a/packages/cli-ui/src/version-line.ts
+++ b/packages/cli-ui/src/version-line.ts
@@ -1,0 +1,43 @@
+import chalk from "chalk";
+
+/**
+ * Status shape compatible with `@opena2a/telemetry`'s `status()` return.
+ *
+ * Declared structurally so cli-ui doesn't take a hard dep on the telemetry
+ * package — consumers pass in `tele.status()`.
+ */
+export interface TelemetryStatusLike {
+  enabled: boolean;
+  policyURL: string;
+}
+
+export interface VersionLineInput {
+  tool: string;
+  version: string;
+  /** Optional. When omitted, no telemetry line is appended. */
+  telemetry?: TelemetryStatusLike;
+}
+
+/**
+ * Build the multi-line `--version` output for a CLI.
+ *
+ * Returns:
+ *   <tool> 0.8.1
+ *   Telemetry: on (opt-out: OPENA2A_TELEMETRY=off  •  details: opena2a.org/telemetry)
+ *
+ * The telemetry line is only appended when `telemetry` is provided. Tools that
+ * opted out of integrating telemetry can call `versionLine({ tool, version })`
+ * with no second arg and get just the first line.
+ */
+export function versionLine(input: VersionLineInput): string {
+  const head = `${input.tool} ${input.version}`;
+  if (!input.telemetry) return head;
+  const state = input.telemetry.enabled ? chalk.green("on") : chalk.dim("off");
+  const policy = input.telemetry.policyURL.replace(/^https?:\/\//, "");
+  const tail = chalk.dim(
+    `Telemetry: ${state}${chalk.dim(
+      ` (opt-out: OPENA2A_TELEMETRY=off  •  details: ${policy})`,
+    )}`,
+  );
+  return `${head}\n${tail}`;
+}

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -1,0 +1,80 @@
+# @opena2a/telemetry
+
+Tier-1 anonymous usage telemetry SDK for OpenA2A CLIs and tools.
+
+Fires anonymous events (tool name, version, command name, success, duration, platform, node major) to the OpenA2A Registry. **No content collection** — no file paths, no scanned content, no prompts, no responses, no env vars, no IP storage. Schema and rationale: [`opena2a.org/telemetry`](https://opena2a.org/telemetry) (canonical disclosure) + `opena2a-registry/docs/telemetry-spec.md` (engineering spec).
+
+## Install
+
+```bash
+npm install @opena2a/telemetry
+```
+
+## Usage
+
+```ts
+import * as tele from "@opena2a/telemetry";
+
+await tele.init({ tool: "dvaa", version: "0.8.1" });
+tele.start();
+await tele.track("scan", { success: true, durationMs: 312 });
+tele.error("scan", "HMA_TIMEOUT");
+```
+
+- `init()` loads opt-out config from `~/.config/opena2a/telemetry.json` and `OPENA2A_TELEMETRY` env var. **No first-run banner is emitted** (deliberate — see disclosure surfaces below).
+- `start()` fires a `start` event.
+- `track(name, fields?)` fires a `command` event with the command name and optional `success` / `durationMs`.
+- `error(name, code)` fires an `error` event with the failure code.
+- `status()` returns `{ enabled, configPath, policyURL, installId }` for tools to build their own `--version` line and `telemetry` subcommand (see `@opena2a/cli-ui` helpers).
+
+All methods are fire-and-forget. Network failures, rate-limiting (429), and timeouts are swallowed. Telemetry never blocks the calling tool.
+
+## Disclosure surfaces
+
+Per the spec, this SDK does not emit a per-run CLI banner. Disclosure is discoverable via four other surfaces:
+
+1. **Policy page** — [`opena2a.org/telemetry`](https://opena2a.org/telemetry).
+2. **README section** — every consuming tool's README has a `## Telemetry` section.
+3. **`<tool> --version` line** — appended by `@opena2a/cli-ui`'s `versionLine()` helper.
+4. **`<tool> telemetry [on|off|status]`** — added by `@opena2a/cli-ui`'s `registerTelemetryCommand()` helper.
+
+## Opt-out
+
+Three ways to disable, in precedence order:
+
+1. **Per-invocation** — `OPENA2A_TELEMETRY=off` (also `0`, `false`, `no`).
+2. **Persistent** — `<tool> telemetry off` (writes to `~/.config/opena2a/telemetry.json`).
+3. **Direct edit** — `~/.config/opena2a/telemetry.json` → `{"enabled": false}`.
+
+## Audit
+
+Runtime audit of every payload:
+
+```bash
+OPENA2A_TELEMETRY_DEBUG=print dvaa scan ./agent
+```
+
+Each event is echoed to stderr in JSON before sending.
+
+## What's collected
+
+Only these fields, exactly:
+
+| Field        | Example                     | Purpose                          |
+|--------------|-----------------------------|----------------------------------|
+| `tool`       | `"dvaa"`                    | Which tool fired the event       |
+| `version`    | `"0.8.1"`                   | Version distribution             |
+| `installId`  | `<random UUID>`             | Unique-installs aggregate (DAU)  |
+| `event`      | `"install" \| "start" \| "command" \| "error"` | Event class |
+| `name`       | `"scan"` (command events)   | Command-use heatmap              |
+| `success`    | `true` (command events)     | Success rate per command         |
+| `durationMs` | `312` (command events)      | Latency aggregate per command    |
+| `platform`   | `"darwin"`                  | Platform distribution            |
+| `nodeMajor`  | `24`                        | Node-version-support planning    |
+| `countryCode` | derived server-side from CF-IPCountry | Country distribution (no IP stored) |
+
+**Never collected:** file paths, scanned content, attack payloads, prompts, responses, env vars, argv beyond command name, user identifiers, raw IP.
+
+## License
+
+Apache-2.0

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@opena2a/cli-ui",
-  "version": "0.4.0",
-  "description": "Shared terminal UI primitives for OpenA2A CLIs (score meter, trust level legend, verdict colors, observations + verdict block, analyst-render, check block, not-found block, next-steps, version-line, telemetry-command)",
+  "name": "@opena2a/telemetry",
+  "version": "0.1.0",
+  "description": "Tier-1 anonymous usage telemetry SDK for OpenA2A CLIs and tools. Fire-and-forget, opt-out, no content collection.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -17,9 +17,6 @@
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },
-  "dependencies": {
-    "chalk": "^5.3.0"
-  },
   "files": [
     "dist",
     "README.md"
@@ -27,8 +24,11 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/opena2a-org/opena2a.git",
-    "directory": "packages/cli-ui"
+    "directory": "packages/telemetry"
   },
-  "homepage": "https://github.com/opena2a-org/opena2a/tree/main/packages/cli-ui",
-  "license": "Apache-2.0"
+  "homepage": "https://github.com/opena2a-org/opena2a/tree/main/packages/telemetry",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=18.0.0"
+  }
 }

--- a/packages/telemetry/src/config.test.ts
+++ b/packages/telemetry/src/config.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadConfig, setEnabled, configPaths, endpointURL, debugPrintEnabled, DEFAULT_ENDPOINT } from "./config.js";
+
+let tmpHome: string;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "opena2a-telem-"));
+  process.env.XDG_CONFIG_HOME = tmpHome;
+  delete process.env.OPENA2A_TELEMETRY;
+  delete process.env.OPENA2A_TELEMETRY_URL;
+  delete process.env.OPENA2A_TELEMETRY_DEBUG;
+});
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+  delete process.env.XDG_CONFIG_HOME;
+});
+
+describe("configPaths", () => {
+  it("uses XDG_CONFIG_HOME when set", () => {
+    const { dir, file } = configPaths();
+    expect(dir).toBe(join(tmpHome, "opena2a"));
+    expect(file).toBe(join(tmpHome, "opena2a", "telemetry.json"));
+  });
+});
+
+describe("loadConfig", () => {
+  it("defaults to enabled on first run and persists install_id", () => {
+    const { config, paths } = loadConfig();
+    expect(config.enabled).toBe(true);
+    expect(config.installId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-8[0-9a-f]{3}-[0-9a-f]{12}$/);
+    expect(existsSync(paths.file)).toBe(true);
+    const persisted = JSON.parse(readFileSync(paths.file, "utf8"));
+    expect(persisted.installId).toBe(config.installId);
+  });
+
+  it("reuses install_id across calls", () => {
+    const a = loadConfig().config.installId;
+    const b = loadConfig().config.installId;
+    expect(a).toBe(b);
+  });
+
+  it("env OPENA2A_TELEMETRY=off forces disabled even if file says enabled", () => {
+    loadConfig(); // seed file with enabled=true
+    process.env.OPENA2A_TELEMETRY = "off";
+    expect(loadConfig().config.enabled).toBe(false);
+  });
+
+  it.each([["off"], ["false"], ["0"], ["no"], ["OFF"], ["False"]])(
+    "env value %s disables",
+    (val) => {
+      process.env.OPENA2A_TELEMETRY = val;
+      expect(loadConfig().config.enabled).toBe(false);
+    },
+  );
+
+  it("file enabled=false is honored when env is unset", () => {
+    setEnabled(false);
+    expect(loadConfig().config.enabled).toBe(false);
+  });
+
+  it("file enabled=false with env=on still off (env can only force off, not on)", () => {
+    setEnabled(false);
+    process.env.OPENA2A_TELEMETRY = "on";
+    // 'on' isn't in the disable list, so env doesn't force off; file says false → off
+    expect(loadConfig().config.enabled).toBe(false);
+  });
+
+  it("recovers from a corrupt config file", () => {
+    const { dir, file } = configPaths();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(file, "{not json");
+    const result = loadConfig();
+    expect(result.config.enabled).toBe(true);
+    expect(result.config.installId).toBeTruthy();
+  });
+});
+
+describe("setEnabled", () => {
+  it("flips the flag and preserves install_id", () => {
+    const original = loadConfig().config.installId;
+    const flipped = setEnabled(false);
+    expect(flipped.enabled).toBe(false);
+    expect(flipped.installId).toBe(original);
+    expect(loadConfig().config.installId).toBe(original);
+  });
+});
+
+describe("endpointURL", () => {
+  it("defaults to api.oa2a.org Registry route", () => {
+    expect(endpointURL()).toBe(DEFAULT_ENDPOINT);
+    expect(DEFAULT_ENDPOINT).toContain("/api/v1/registry/telemetry/v1/event");
+  });
+
+  it("env OPENA2A_TELEMETRY_URL overrides", () => {
+    process.env.OPENA2A_TELEMETRY_URL = "http://localhost:8088/api/v1/registry/telemetry/v1/event";
+    expect(endpointURL()).toBe("http://localhost:8088/api/v1/registry/telemetry/v1/event");
+  });
+});
+
+describe("debugPrintEnabled", () => {
+  it("only true when env=print", () => {
+    expect(debugPrintEnabled()).toBe(false);
+    process.env.OPENA2A_TELEMETRY_DEBUG = "print";
+    expect(debugPrintEnabled()).toBe(true);
+    process.env.OPENA2A_TELEMETRY_DEBUG = "PRINT";
+    expect(debugPrintEnabled()).toBe(true);
+    process.env.OPENA2A_TELEMETRY_DEBUG = "verbose";
+    expect(debugPrintEnabled()).toBe(false);
+  });
+});

--- a/packages/telemetry/src/config.ts
+++ b/packages/telemetry/src/config.ts
@@ -1,0 +1,137 @@
+import { homedir, platform as osPlatform } from "node:os";
+import { join } from "node:path";
+import { mkdirSync, readFileSync, writeFileSync, existsSync, statSync } from "node:fs";
+import { randomUUID, createHash } from "node:crypto";
+
+export const POLICY_URL = "https://opena2a.org/telemetry";
+export const DEFAULT_ENDPOINT = "https://api.oa2a.org/api/v1/registry/telemetry/v1/event";
+const ENV_OPT_OUT = "OPENA2A_TELEMETRY";
+const ENV_ENDPOINT = "OPENA2A_TELEMETRY_URL";
+const ENV_DEBUG = "OPENA2A_TELEMETRY_DEBUG";
+
+export interface TelemetryConfig {
+  enabled: boolean;
+  installId: string;
+}
+
+export interface ConfigPaths {
+  dir: string;
+  file: string;
+}
+
+export function configPaths(): ConfigPaths {
+  const xdg = process.env.XDG_CONFIG_HOME;
+  const dir = xdg
+    ? join(xdg, "opena2a")
+    : join(homedir(), ".config", "opena2a");
+  return { dir, file: join(dir, "telemetry.json") };
+}
+
+function readConfigFile(file: string): Partial<TelemetryConfig> | null {
+  if (!existsSync(file)) return null;
+  try {
+    const raw = readFileSync(file, "utf8");
+    const parsed = JSON.parse(raw) as Partial<TelemetryConfig>;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeConfigFile(paths: ConfigPaths, cfg: TelemetryConfig): void {
+  if (!existsSync(paths.dir)) {
+    mkdirSync(paths.dir, { recursive: true, mode: 0o700 });
+  }
+  writeFileSync(paths.file, JSON.stringify(cfg, null, 2) + "\n", {
+    mode: 0o600,
+  });
+}
+
+/**
+ * Stable-per-machine install ID.
+ *
+ * Persisted in the config file. If absent, derived from a hash of
+ * platform + node-major + npm-cache-dir mtime so npx invocations on
+ * the same machine produce the same ID for ~30 days, then rotate.
+ * Falls back to a fresh UUID if the cache stat is unavailable.
+ */
+function deriveInstallId(): string {
+  try {
+    const cacheDir = process.env.npm_config_cache
+      ?? join(homedir(), ".npm");
+    if (existsSync(cacheDir)) {
+      const mtimeBucket = Math.floor(
+        statSync(cacheDir).mtimeMs / (1000 * 60 * 60 * 24 * 30),
+      );
+      const seed = `${osPlatform()}:${process.versions.node.split(".")[0]}:${cacheDir}:${mtimeBucket}`;
+      const hash = createHash("sha256").update(seed).digest("hex");
+      return [
+        hash.slice(0, 8),
+        hash.slice(8, 12),
+        "4" + hash.slice(13, 16),
+        "8" + hash.slice(17, 20),
+        hash.slice(20, 32),
+      ].join("-");
+    }
+  } catch {
+    // fall through
+  }
+  return randomUUID();
+}
+
+function envOptOut(env: NodeJS.ProcessEnv): boolean {
+  const v = env[ENV_OPT_OUT];
+  if (v === undefined) return false;
+  const lower = v.toLowerCase();
+  return lower === "off" || lower === "0" || lower === "false" || lower === "no";
+}
+
+/**
+ * Load (and lazily create) the telemetry config.
+ *
+ * Precedence for `enabled`:
+ *   1. OPENA2A_TELEMETRY env var (always wins, per-invocation)
+ *   2. config file `enabled` field
+ *   3. default ON (matches spec)
+ *
+ * The install_id is always persisted on first call so subsequent runs
+ * (and subsequent tools on the same machine) report the same ID.
+ */
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): {
+  config: TelemetryConfig;
+  paths: ConfigPaths;
+} {
+  const paths = configPaths();
+  const file = readConfigFile(paths.file);
+  const installId = file?.installId ?? deriveInstallId();
+  const fileEnabled = file?.enabled ?? true;
+  const envDisabled = envOptOut(env);
+  const enabled = !envDisabled && fileEnabled;
+
+  if (!file || !file.installId || file.enabled === undefined) {
+    try {
+      writeConfigFile(paths, { enabled: fileEnabled, installId });
+    } catch {
+      // best-effort persistence; running in a sandbox without HOME is fine.
+    }
+  }
+
+  return { config: { enabled, installId }, paths };
+}
+
+export function setEnabled(enabled: boolean): TelemetryConfig {
+  const paths = configPaths();
+  const existing = readConfigFile(paths.file);
+  const installId = existing?.installId ?? deriveInstallId();
+  const cfg: TelemetryConfig = { enabled, installId };
+  writeConfigFile(paths, cfg);
+  return cfg;
+}
+
+export function endpointURL(env: NodeJS.ProcessEnv = process.env): string {
+  return env[ENV_ENDPOINT] ?? DEFAULT_ENDPOINT;
+}
+
+export function debugPrintEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[ENV_DEBUG]?.toLowerCase() === "print";
+}

--- a/packages/telemetry/src/index.test.ts
+++ b/packages/telemetry/src/index.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+let tmpHome: string;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+async function freshSdk() {
+  vi.resetModules();
+  return await import("./index.js");
+}
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "opena2a-telem-sdk-"));
+  process.env.XDG_CONFIG_HOME = tmpHome;
+  process.env.OPENA2A_TELEMETRY_URL = "http://test.local/event";
+  delete process.env.OPENA2A_TELEMETRY;
+  delete process.env.OPENA2A_TELEMETRY_DEBUG;
+  fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+  vi.unstubAllGlobals();
+  delete process.env.XDG_CONFIG_HOME;
+  delete process.env.OPENA2A_TELEMETRY_URL;
+});
+
+describe("init + start", () => {
+  it("init() does not emit a banner to stderr", async () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.8.1" });
+    const writes = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(writes).not.toMatch(/telemetry/i);
+    expect(writes).not.toMatch(/anonymous/i);
+    stderrSpy.mockRestore();
+  });
+
+  it("start() POSTs a start event with platform + node_major", async () => {
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.8.1" });
+    tele.start();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toMatchObject({
+      tool: "dvaa",
+      version: "0.8.1",
+      event: "start",
+    });
+    expect(body.install_id).toMatch(/^[0-9a-f]{8}-/);
+    expect(body.platform).toBeTruthy();
+    expect(typeof body.node_major).toBe("number");
+  });
+});
+
+describe("track", () => {
+  it("posts a command event with name + success + duration_ms", async () => {
+    const tele = await freshSdk();
+    await tele.init({ tool: "hma", version: "0.18.0" });
+    await tele.track("scan", { success: true, durationMs: 312 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toMatchObject({
+      tool: "hma",
+      version: "0.18.0",
+      event: "command",
+      name: "scan",
+      success: true,
+      duration_ms: 312,
+    });
+  });
+
+  it("posts even with no fields", async () => {
+    const tele = await freshSdk();
+    await tele.init({ tool: "ai-trust", version: "0.3.0" });
+    await tele.track("audit");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.event).toBe("command");
+    expect(body.name).toBe("audit");
+  });
+});
+
+describe("error", () => {
+  it("encodes failure code as name suffix and sets success=false", async () => {
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.8.1" });
+    tele.error("scan", "HMA_TIMEOUT");
+    await new Promise((r) => setTimeout(r, 10));
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toMatchObject({
+      event: "error",
+      name: "scan:HMA_TIMEOUT",
+      success: false,
+    });
+  });
+
+  it("truncates name+code to 64 chars (Registry name_len constraint)", async () => {
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.8.1" });
+    tele.error("a".repeat(40), "B".repeat(40));
+    await new Promise((r) => setTimeout(r, 10));
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.name.length).toBe(64);
+  });
+});
+
+describe("opt-out", () => {
+  it("OPENA2A_TELEMETRY=off blocks all sends", async () => {
+    process.env.OPENA2A_TELEMETRY = "off";
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.8.1" });
+    tele.start();
+    await tele.track("scan");
+    tele.error("scan", "X");
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("setOptOut(false) blocks subsequent sends", async () => {
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.8.1" });
+    tele.setOptOut(false);
+    tele.start();
+    await tele.track("scan");
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("status", () => {
+  it("returns enabled+policy URL+install id even before init", async () => {
+    const tele = await freshSdk();
+    const s = tele.status();
+    expect(s.enabled).toBe(true);
+    expect(s.policyURL).toBe("https://opena2a.org/telemetry");
+    expect(s.installId).toBeTruthy();
+    expect(s.configPath).toContain("telemetry.json");
+  });
+
+  it("reflects setOptOut state", async () => {
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.8.1" });
+    expect(tele.status().enabled).toBe(true);
+    tele.setOptOut(false);
+    expect(tele.status().enabled).toBe(false);
+  });
+});
+
+describe("debug print", () => {
+  it("OPENA2A_TELEMETRY_DEBUG=print echoes payload to stderr", async () => {
+    process.env.OPENA2A_TELEMETRY_DEBUG = "print";
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.8.1" });
+    tele.start();
+    await new Promise((r) => setTimeout(r, 10));
+    const writes = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(writes).toContain("[opena2a:telemetry]");
+    expect(writes).toContain("\"event\":\"start\"");
+    stderrSpy.mockRestore();
+  });
+});
+
+describe("network failure tolerance", () => {
+  it("never throws when fetch rejects", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.8.1" });
+    await expect(tele.track("scan")).resolves.toBeUndefined();
+  });
+});

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -1,0 +1,105 @@
+/**
+ * @opena2a/telemetry — Tier-1 anonymous usage telemetry SDK.
+ *
+ * No content collection. No first-run banner. Fire-and-forget HTTP.
+ * See README.md and opena2a-registry/docs/telemetry-spec.md.
+ */
+
+import { platform as osPlatform } from "node:os";
+import { loadConfig, setEnabled, configPaths, POLICY_URL } from "./config.js";
+import { sendEvent } from "./sender.js";
+import type { InitOptions, Status, TrackFields, UsageEvent } from "./types.js";
+
+let session: { tool: string; version: string; installId: string; enabled: boolean } | null = null;
+
+function nodeMajor(): number {
+  return parseInt(process.versions.node.split(".")[0], 10);
+}
+
+/**
+ * Initialize the SDK. Loads opt-out config, persists install_id.
+ * Idempotent: calling twice with different tools is supported (the second
+ * call rebinds the session — useful in test harnesses).
+ */
+export async function init(opts: InitOptions): Promise<void> {
+  const { config } = loadConfig();
+  session = {
+    tool: opts.tool,
+    version: opts.version,
+    installId: config.installId,
+    enabled: config.enabled,
+  };
+}
+
+function buildEvent(event: UsageEvent["event"], extras: Partial<UsageEvent> = {}): UsageEvent | null {
+  if (!session || !session.enabled) return null;
+  return {
+    tool: session.tool,
+    version: session.version,
+    install_id: session.installId,
+    event,
+    platform: osPlatform(),
+    node_major: nodeMajor(),
+    ...extras,
+  };
+}
+
+export function start(): void {
+  const evt = buildEvent("start");
+  if (evt) void sendEvent(evt);
+}
+
+export async function track(name: string, fields: TrackFields = {}): Promise<void> {
+  const evt = buildEvent("command", {
+    name,
+    success: fields.success,
+    duration_ms: fields.durationMs,
+  });
+  if (evt) await sendEvent(evt);
+}
+
+export function error(name: string, code: string): void {
+  const evt = buildEvent("error", { name, success: false });
+  if (!evt) return;
+  // The Registry schema doesn't have a free-form code field at v1. Encode
+  // the failure code as the command name suffix so it groups in the dashboard
+  // without needing a schema migration. Truncated to fit the 64-char `name` cap.
+  evt.name = `${name}:${code}`.slice(0, 64);
+  void sendEvent(evt);
+}
+
+export function status(): Status {
+  if (!session) {
+    const { config, paths } = loadConfig();
+    return {
+      enabled: config.enabled,
+      configPath: paths.file,
+      policyURL: POLICY_URL,
+      installId: config.installId,
+    };
+  }
+  return {
+    enabled: session.enabled,
+    configPath: configPaths().file,
+    policyURL: POLICY_URL,
+    installId: session.installId,
+  };
+}
+
+/**
+ * Persist enabled=true|false to the config file.
+ * Used by `<tool> telemetry on|off` subcommands.
+ */
+export function setOptOut(enabled: boolean): Status {
+  const cfg = setEnabled(enabled);
+  if (session) session.enabled = enabled;
+  return {
+    enabled: cfg.enabled,
+    configPath: configPaths().file,
+    policyURL: POLICY_URL,
+    installId: cfg.installId,
+  };
+}
+
+export { POLICY_URL } from "./config.js";
+export type { InitOptions, Status, TrackFields, UsageEvent } from "./types.js";

--- a/packages/telemetry/src/sender.ts
+++ b/packages/telemetry/src/sender.ts
@@ -1,0 +1,43 @@
+import type { UsageEvent } from "./types.js";
+import { debugPrintEnabled, endpointURL } from "./config.js";
+
+const SEND_TIMEOUT_MS = 2000;
+const DEBOUNCE_MS = 200;
+
+let lastSendAt = 0;
+let inFlight = 0;
+const MAX_IN_FLIGHT = 4;
+
+/**
+ * Fire-and-forget send.
+ *
+ * - Caps in-flight requests so a stuck endpoint can't accumulate handles.
+ * - Honors a 200ms debounce per process (drops events that fire faster).
+ * - Resolves regardless of network outcome — never throws, never rejects.
+ * - When OPENA2A_TELEMETRY_DEBUG=print, echoes the payload to stderr.
+ */
+export async function sendEvent(event: UsageEvent): Promise<void> {
+  const now = Date.now();
+  if (now - lastSendAt < DEBOUNCE_MS) return;
+  if (inFlight >= MAX_IN_FLIGHT) return;
+  lastSendAt = now;
+
+  if (debugPrintEnabled()) {
+    process.stderr.write(`[opena2a:telemetry] ${JSON.stringify(event)}\n`);
+  }
+
+  inFlight++;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), SEND_TIMEOUT_MS);
+  try {
+    await fetch(endpointURL(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(event),
+      signal: controller.signal,
+    }).catch(() => undefined);
+  } finally {
+    clearTimeout(timeout);
+    inFlight--;
+  }
+}

--- a/packages/telemetry/src/types.ts
+++ b/packages/telemetry/src/types.ts
@@ -1,0 +1,36 @@
+/**
+ * Wire-format event sent to POST /api/v1/registry/telemetry/v1/event.
+ *
+ * Field names match the Registry handler's JSON binding (snake_case for
+ * install_id, node_major, duration_ms — locked by the spec).
+ */
+export interface UsageEvent {
+  tool: string;
+  version: string;
+  install_id: string;
+  event: "install" | "start" | "command" | "error";
+  name?: string;
+  success?: boolean;
+  duration_ms?: number;
+  platform?: string;
+  node_major?: number;
+}
+
+export interface InitOptions {
+  /** Tool name. Lowercase, [a-z0-9_-], 1-64 chars (enforced by Registry). */
+  tool: string;
+  /** Tool version. ≤64 chars. */
+  version: string;
+}
+
+export interface TrackFields {
+  success?: boolean;
+  durationMs?: number;
+}
+
+export interface Status {
+  enabled: boolean;
+  configPath: string;
+  policyURL: string;
+  installId: string;
+}

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Two-package change so per-tool telemetry integration becomes a one-liner:

1. **New** `@opena2a/telemetry@0.1.0` (`packages/telemetry/`) — fire-and-forget tier-1 anonymous usage telemetry SDK. Implements the contract from `opena2a-registry/docs/telemetry-spec.md` (post-amendment per opena2a-registry#203: NO per-run banner, opt-out only).
2. **Bumped** `@opena2a/cli-ui@0.4.0` — adds `versionLine()` and `runTelemetryCommand()` so each tool wires the `--version` line and `<tool> telemetry [on|off|status]` subcommand in 3 lines, with no hard dep on the SDK.

Plus `release.yml` wiring (`telemetry-v*` tag pattern + `publish_if_new` line) so the package ships via the existing Trusted Publishing workflow.

**Draft** because no per-tool integration ships in this PR — DVAA canary is the next PR per the spec. Holding for review of the SDK contract before any tool consumes it.

## API surface (locked at 0.1.0)

```ts
import * as tele from "@opena2a/telemetry";

await tele.init({ tool: "dvaa", version: "0.8.1" });   // load opt-out config
tele.start();                                          // fires 'start'
await tele.track("scan", { success: true, durationMs: 312 });
tele.error("scan", "HMA_TIMEOUT");
tele.status();      // → { enabled, configPath, policyURL, installId }
tele.setOptOut(false);   // backs `<tool> telemetry off`
```

```ts
// In each consuming CLI:
import { versionLine, runTelemetryCommand } from "@opena2a/cli-ui";
program.option("--version", () => console.log(versionLine({ tool: "dvaa", version, telemetry: tele.status() })));
program.command("telemetry [action]")
  .action((a) => console.log(runTelemetryCommand(a, { tool: "dvaa", getStatus: tele.status, setOptOut: tele.setOptOut })));
```

## Behaviour

- **Default ON.** Opt-out via `OPENA2A_TELEMETRY=off` (also `0|false|no`) or persisted `~/.config/opena2a/telemetry.json`.
- **No first-run banner.** Disclosure surfaces are README + `--version` + `telemetry` subcommand + `opena2a.org/telemetry` policy page (per the amendment).
- **2s timeout, 200ms debounce, max 4 in-flight, never throws.** Telemetry failure never blocks the calling tool.
- **`install_id` stable per machine.** Hash of `platform:node-major:npm-cache-dir:mtime-bucket` (30-day buckets) so `npx`-style invocations group correctly. Persisted on first run; falls back to fresh UUID if cache stat fails.
- **`OPENA2A_TELEMETRY_DEBUG=print`** echoes every payload to stderr — power-user audit.
- **Endpoint** defaults to `https://api.oa2a.org/api/v1/registry/telemetry/v1/event`. `OPENA2A_TELEMETRY_URL` overrides for staging/local.

## Test plan

- [x] `@opena2a/telemetry`: 29/29 tests pass — opt-out precedence, install_id stability, payload shape (snake_case wire format, platform/node_major derivation), error-event encoding (`name:CODE` truncated to 64), no-banner guarantee, debug print, network-failure tolerance.
- [x] `@opena2a/cli-ui` 0.4.0: 9 new tests (versionLine + runTelemetryCommand). Total 135/135 pass.
- [x] `npm run build` clean across the monorepo (turbo: 9/9 cached + new tasks).
- [x] `npm run test` clean across the monorepo (18/18 tasks).
- [ ] Reviewer confirms the SDK contract before per-tool integration PRs start.

## Trusted Publishing setup needed before tag/publish

Per `~/.claude/CLAUDE.md` npm publish protocol:
1. On npmjs.com → @opena2a org → telemetry package settings → Publishing access → Trusted Publisher → GitHub Actions:
   - Organization: `opena2a-org`
   - Repository: `opena2a`
   - Workflow filename: `release.yml`
   - Environment: blank
2. After this PR merges + first `telemetry-v0.1.0` tag pushed, verify with `npm view @opena2a/telemetry dist.attestations --json` (must return non-empty SLSA v1 attestations).

## Follow-ups (separate PRs, in order)

1. **DVAA canary** — wire `tele.init/start/track/error` into DVAA's CLI entry. ~30 lines (imports + init + 3 helper one-liners + README section). Bump DVAA, ship as canary.
2. **Monitor 1 week** — confirm payloads match schema, no PII leakage, opt-out honored, country derivation works end-to-end.
3. **Roll forward** — HMA → ai-trust → AIM → opena2a-cli → Secretless. Each is its own PR using the same one-liner pattern.

## Related

- Spec: `opena2a-registry/docs/telemetry-spec.md` (amended in opena2a-registry#203)
- Ingest endpoint landed in opena2a-registry#200 (merged 2026-04-27)
- Disclosure-surfaces amendment: opena2a-registry#203 (open)