### PR TITLE
fix(telemetry): drain in-flight events on exit (0.1.2)

### DIFF
--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/telemetry",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Tier-1 anonymous usage telemetry SDK for OpenA2A CLIs and tools. Fire-and-forget, opt-out, no content collection.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/telemetry/src/index.test.ts
+++ b/packages/telemetry/src/index.test.ts
@@ -174,3 +174,33 @@ describe("network failure tolerance", () => {
     await expect(tele.track("scan")).resolves.toBeUndefined();
   });
 });
+
+describe("flush", () => {
+  it("waits for in-flight fetches before resolving", async () => {
+    // A 1.5s slow request — process.exit() would kill it without flush().
+    let resolveFetch: (v: Response) => void = () => {};
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((r) => {
+          resolveFetch = r;
+        }),
+    );
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.8.1" });
+    tele.start(); // fire-and-forget; doesn't await internally
+    let flushDone = false;
+    const flushPromise = tele.flush().then(() => {
+      flushDone = true;
+    });
+    expect(flushDone).toBe(false);
+    resolveFetch(new Response(null, { status: 204 }));
+    await flushPromise;
+    expect(flushDone).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op with no in-flight events", async () => {
+    const tele = await freshSdk();
+    await expect(tele.flush()).resolves.toBeUndefined();
+  });
+});

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -10,6 +10,8 @@ import { loadConfig, setEnabled, configPaths, POLICY_URL } from "./config.js";
 import { sendEvent } from "./sender.js";
 import type { InitOptions, Status, TrackFields, UsageEvent } from "./types.js";
 
+export { flush } from "./sender.js";
+
 let session: { tool: string; version: string; installId: string; enabled: boolean } | null = null;
 
 function nodeMajor(): number {

--- a/packages/telemetry/src/sender.ts
+++ b/packages/telemetry/src/sender.ts
@@ -5,8 +5,27 @@ const SEND_TIMEOUT_MS = 2000;
 const DEBOUNCE_MS = 200;
 
 let lastSendAt = 0;
-let inFlight = 0;
+const inFlight = new Set<Promise<void>>();
 const MAX_IN_FLIGHT = 4;
+let beforeExitInstalled = false;
+
+/**
+ * Drain in-flight events on natural process exit so short-lived CLI commands
+ * (`dvaa agents`, `hma scan`, …) don't lose events when their dispatcher
+ * calls `process.exit()` immediately after `tele.track()`. Each request is
+ * already capped at 2s by SEND_TIMEOUT_MS, so the worst-case extra latency
+ * is bounded.
+ *
+ * Installed lazily on first send to avoid attaching to import-only consumers
+ * that never fire an event.
+ */
+function installBeforeExitDrain(): void {
+  if (beforeExitInstalled || typeof process === "undefined") return;
+  beforeExitInstalled = true;
+  process.on("beforeExit", async () => {
+    if (inFlight.size > 0) await flush();
+  });
+}
 
 /**
  * Fire-and-forget send.
@@ -15,29 +34,44 @@ const MAX_IN_FLIGHT = 4;
  * - Honors a 200ms debounce per process (drops events that fire faster).
  * - Resolves regardless of network outcome — never throws, never rejects.
  * - When OPENA2A_TELEMETRY_DEBUG=print, echoes the payload to stderr.
+ * - Tracks the in-flight set so `flush()` and the beforeExit drain can wait.
  */
 export async function sendEvent(event: UsageEvent): Promise<void> {
   const now = Date.now();
   if (now - lastSendAt < DEBOUNCE_MS) return;
-  if (inFlight >= MAX_IN_FLIGHT) return;
+  if (inFlight.size >= MAX_IN_FLIGHT) return;
   lastSendAt = now;
+
+  installBeforeExitDrain();
 
   if (debugPrintEnabled()) {
     process.stderr.write(`[opena2a:telemetry] ${JSON.stringify(event)}\n`);
   }
 
-  inFlight++;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), SEND_TIMEOUT_MS);
-  try {
-    await fetch(endpointURL(), {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(event),
-      signal: controller.signal,
-    }).catch(() => undefined);
-  } finally {
-    clearTimeout(timeout);
-    inFlight--;
-  }
+  const task = fetch(endpointURL(), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(event),
+    signal: controller.signal,
+  })
+    .catch(() => undefined)
+    .finally(() => {
+      clearTimeout(timeout);
+    })
+    .then(() => undefined);
+  inFlight.add(task);
+  task.finally(() => inFlight.delete(task));
+  await task;
+}
+
+/**
+ * Wait for all in-flight events to settle. Call before `process.exit()` in a
+ * short-lived script if you can't rely on Node's natural exit hook (e.g.
+ * after manual `process.exit(N)`). The beforeExit handler covers natural
+ * exits automatically.
+ */
+export async function flush(): Promise<void> {
+  await Promise.allSettled([...inFlight]);
 }


### PR DESCRIPTION
## Summary

Fixes silent telemetry loss in short-lived CLI commands like `dvaa agents`. Discovered during PR #37's prod verification: probe via curl landed in the Registry, but `dvaa agents` (which constructs the same payload — debug-print confirms) did not, because DVAA's dispatcher does `void tele.track(...)` followed by `process.exit()`. Node kills the process before `fetch()` flushes the request body.

## Fix

- Track each in-flight fetch in a Set.
- Install `process.on('beforeExit')` handler on first send to drain naturally (covers commands that exit by running to completion).
- Export `flush()` for consumers that call `process.exit(N)` explicitly.

Per-event 2s timeout unchanged — `flush()` can't hang longer than that even against an unreachable endpoint.

## Test plan

- [x] 31/31 tests pass (29 prior + 2 regression tests for flush + no-op-empty case)
- [ ] Followup DVAA bump: `await tele.flush()` before `process.exit()` in `src/cli/router.js` (separate PR, ships as DVAA 0.8.2)