### PR TITLE
feat(help): two-bucket telemetry disclosure on --help

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -83,6 +83,10 @@ Smart Features:
   $ opena2a find secrets         Natural language command matching
   $ opena2a detect credentials   Natural language command matching
 
+Telemetry:
+  Anonymous usage telemetry is on. Disable: OPENA2A_TELEMETRY=off
+  Local scans may contribute to the OpenA2A Registry. Disable: --no-contribute
+
 Learn more: https://opena2a.org/docs`);
 
   // Register all adapter-backed commands


### PR DESCRIPTION
## Summary

Closes the only remaining acceptance criterion in `briefs/scan-result-telemetry-policy.md` §10 for opena2a-cli: a Telemetry section appended to the existing `--help` block that surfaces both consent rails (invocation telemetry, scan-result contribution) without making the user read the privacy policy.

Brief reference: §7 disclosure form (locked under [CHIEF-CSR-014] + [CHIEF-CPO-021] on 2026-04-27).

## Diff

```
+Telemetry:
+  Anonymous usage telemetry is on. Disable: OPENA2A_TELEMETRY=off
+  Local scans may contribute to the OpenA2A Registry. Disable: --no-contribute
+
```

4 lines appended to the existing `addHelpText('after', ...)` block in `packages/cli/src/index.ts`.

## Note on disclosure form

Unlike HMA + ai-trust, opena2a-cli does NOT have a `telemetry` subcommand of its own. The scan-result disable maps to `--no-contribute` on `opena2a check` (which forwards to HMA's same flag via spawn delegation). Adding a `telemetry` subcommand to opena2a-cli is intentionally out of scope here — would change the brand model and isn't required by the brief.

## Verification

```
$ node dist/index.js --help | grep -A 3 ^Telemetry:
Telemetry:
  Anonymous usage telemetry is on. Disable: OPENA2A_TELEMETRY=off
  Local scans may contribute to the OpenA2A Registry. Disable: --no-contribute
```

## Test plan

- [x] `npm run build` (in `packages/cli/`) — clean
- [x] `npm test` — 891/891 pass
- [x] `--help` renders the disclosure verbatim
- [x] No detection logic / scanner / scoring changes (Phase 4.5 skip)

## Companion PRs

- hackmyagent #132 — same disclosure on HMA (with `hackmyagent telemetry off` reference)
- ai-trust #N+1 — same disclosure on ai-trust