### PR TITLE
fix(shield): gate findings by scan target (closes #109 sub-item 1)

### DIFF
--- a/packages/cli/__tests__/shield/findings-path-scoping.test.ts
+++ b/packages/cli/__tests__/shield/findings-path-scoping.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+
+import type { ShieldEvent } from '../../src/shield/types.js';
+import { filterEventsToTarget } from '../../src/shield/findings.js';
+
+function makeEvent(overrides: Partial<ShieldEvent> = {}): ShieldEvent {
+  return {
+    id: 'test-id',
+    timestamp: '2026-03-01T00:00:00.000Z',
+    version: 1,
+    source: 'configguard',
+    category: 'config.tampered',
+    severity: 'critical',
+    agent: null,
+    sessionId: null,
+    action: 'guard.verify',
+    target: '/Users/foo/projectA',
+    outcome: 'blocked',
+    detail: {},
+    prevHash: 'abc',
+    eventHash: 'def',
+    orgId: null,
+    managed: false,
+    agentId: null,
+    ...overrides,
+  };
+}
+
+describe('filterEventsToTarget', () => {
+  it('drops absolute-path events outside the scan target', () => {
+    const events = [
+      makeEvent({ target: '/Users/foo/projectA' }),
+      makeEvent({ target: '/Users/foo/projectB' }),
+      makeEvent({ target: '/tmp/other' }),
+    ];
+    const filtered = filterEventsToTarget(events, '/Users/foo/projectA');
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]!.target).toBe('/Users/foo/projectA');
+  });
+
+  it('keeps events whose path is nested under the scan target', () => {
+    const events = [
+      makeEvent({ target: '/Users/foo/projectA/.env' }),
+      makeEvent({ target: '/Users/foo/projectA/sub/dir/config.yaml' }),
+    ];
+    const filtered = filterEventsToTarget(events, '/Users/foo/projectA');
+    expect(filtered).toHaveLength(2);
+  });
+
+  it('keeps events whose path equals the scan target exactly', () => {
+    const events = [makeEvent({ target: '/Users/foo/projectA' })];
+    const filtered = filterEventsToTarget(events, '/Users/foo/projectA');
+    expect(filtered).toHaveLength(1);
+  });
+
+  it('does not match by lexical prefix (projectA vs project)', () => {
+    const events = [
+      makeEvent({ target: '/Users/foo/projectA' }),
+      makeEvent({ target: '/Users/foo/projectAlpha/config' }),
+    ];
+    const filtered = filterEventsToTarget(events, '/Users/foo/project');
+    expect(filtered).toHaveLength(0);
+  });
+
+  it('keeps events whose target is empty or non-path (URLs, package names, action ids)', () => {
+    const events = [
+      makeEvent({ source: 'arp', target: '' }),
+      makeEvent({ source: 'arp', target: 'curl' }),
+      makeEvent({ source: 'registry', target: 'left-pad' }),
+      makeEvent({ source: 'arp', target: 'https://malicious.example.com' }),
+      makeEvent({ source: 'shield', target: 'shield.posture' }),
+    ];
+    const filtered = filterEventsToTarget(events, '/Users/foo/projectA');
+    expect(filtered).toHaveLength(5);
+  });
+
+  it('normalizes the scan target so trailing slashes and . segments do not change the result', () => {
+    const events = [
+      makeEvent({ target: '/Users/foo/projectA/.env' }),
+    ];
+    expect(filterEventsToTarget(events, '/Users/foo/projectA/').length).toBe(1);
+    expect(filterEventsToTarget(events, '/Users/foo/projectA/./').length).toBe(1);
+    expect(filterEventsToTarget(events, '/Users/foo/projectA/sub/..').length).toBe(1);
+  });
+
+  it('returns an empty array when no events match', () => {
+    const events = [makeEvent({ target: '/Users/foo/projectB' })];
+    expect(filterEventsToTarget(events, '/tmp/empty')).toEqual([]);
+  });
+
+  it('returns the input unchanged when every event is in scope', () => {
+    const events = [
+      makeEvent({ target: '/Users/foo/projectA' }),
+      makeEvent({ target: '/Users/foo/projectA/.env' }),
+    ];
+    const filtered = filterEventsToTarget(events, '/Users/foo/projectA');
+    expect(filtered).toHaveLength(2);
+  });
+
+  it('handles a relative scan target by resolving against cwd', () => {
+    const events = [
+      makeEvent({ target: path.resolve('.') }),
+      makeEvent({ target: '/some/other/place' }),
+    ];
+    const filtered = filterEventsToTarget(events, '.');
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]!.target).toBe(path.resolve('.'));
+  });
+
+  it('issue #109 sub-item 1 reproducer: empty test dir surfaces 0 cross-target tamper events', () => {
+    const events: ShieldEvent[] = Array.from({ length: 288 }, (_, i) =>
+      makeEvent({
+        id: `evt-${i}`,
+        target: '/Users/foo/projectA',
+        action: 'guard.verify',
+        outcome: 'blocked',
+      }),
+    );
+    const filtered = filterEventsToTarget(events, '/tmp/empty-test-dir');
+    expect(filtered).toHaveLength(0);
+  });
+});

--- a/packages/cli/__tests__/shield/findings-path-scoping.test.ts
+++ b/packages/cli/__tests__/shield/findings-path-scoping.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import path from 'node:path';
 
-import type { ShieldEvent } from '../../src/shield/types.js';
-import { filterEventsToTarget } from '../../src/shield/findings.js';
+import type { ShieldEvent, ShieldEventSource } from '../../src/shield/types.js';
+import {
+  classifyEvents,
+  filterEventsToTarget,
+} from '../../src/shield/findings.js';
 
 function makeEvent(overrides: Partial<ShieldEvent> = {}): ShieldEvent {
-  return {
+  const base: ShieldEvent = {
     id: 'test-id',
     timestamp: '2026-03-01T00:00:00.000Z',
     version: 1,
@@ -23,12 +26,12 @@ function makeEvent(overrides: Partial<ShieldEvent> = {}): ShieldEvent {
     orgId: null,
     managed: false,
     agentId: null,
-    ...overrides,
   };
+  return { ...base, ...overrides };
 }
 
-describe('filterEventsToTarget', () => {
-  it('drops absolute-path events outside the scan target', () => {
+describe('filterEventsToTarget — configguard scoping', () => {
+  it('drops absolute-path configguard events outside the scan target', () => {
     const events = [
       makeEvent({ target: '/Users/foo/projectA' }),
       makeEvent({ target: '/Users/foo/projectB' }),
@@ -39,7 +42,7 @@ describe('filterEventsToTarget', () => {
     expect(filtered[0]!.target).toBe('/Users/foo/projectA');
   });
 
-  it('keeps events whose path is nested under the scan target', () => {
+  it('keeps configguard events whose path is nested under the scan target', () => {
     const events = [
       makeEvent({ target: '/Users/foo/projectA/.env' }),
       makeEvent({ target: '/Users/foo/projectA/sub/dir/config.yaml' }),
@@ -48,7 +51,7 @@ describe('filterEventsToTarget', () => {
     expect(filtered).toHaveLength(2);
   });
 
-  it('keeps events whose path equals the scan target exactly', () => {
+  it('keeps configguard events whose path equals the scan target exactly', () => {
     const events = [makeEvent({ target: '/Users/foo/projectA' })];
     const filtered = filterEventsToTarget(events, '/Users/foo/projectA');
     expect(filtered).toHaveLength(1);
@@ -63,39 +66,33 @@ describe('filterEventsToTarget', () => {
     expect(filtered).toHaveLength(0);
   });
 
-  it('keeps events whose target is empty or non-path (URLs, package names, action ids)', () => {
+  it('does not drop a child whose name happens to begin with "..bytes" (unusual but valid)', () => {
+    // path.relative('/Users/foo', '/Users/foo/..badname') === '..badname'.
+    // The check must use ('..' + sep) so it doesn't false-trip on names
+    // that merely start with two dots without being parent traversal.
+    const events = [makeEvent({ target: '/Users/foo/..badname' })];
+    const filtered = filterEventsToTarget(events, '/Users/foo');
+    expect(filtered).toHaveLength(1);
+  });
+
+  it('keeps configguard events whose target is empty or relative (guard watch case)', () => {
+    // guard.ts:493,522 emits target: sig.filePath (relative, e.g. "package.json").
+    // We can't reliably scope these without writer-side changes, so they
+    // pass through. Documented as residual in the helper docstring.
     const events = [
-      makeEvent({ source: 'arp', target: '' }),
-      makeEvent({ source: 'arp', target: 'curl' }),
-      makeEvent({ source: 'registry', target: 'left-pad' }),
-      makeEvent({ source: 'arp', target: 'https://malicious.example.com' }),
-      makeEvent({ source: 'shield', target: 'shield.posture' }),
+      makeEvent({ target: '' }),
+      makeEvent({ target: 'package.json' }),
+      makeEvent({ target: '.opena2a/config.yaml' }),
     ];
     const filtered = filterEventsToTarget(events, '/Users/foo/projectA');
-    expect(filtered).toHaveLength(5);
+    expect(filtered).toHaveLength(3);
   });
 
   it('normalizes the scan target so trailing slashes and . segments do not change the result', () => {
-    const events = [
-      makeEvent({ target: '/Users/foo/projectA/.env' }),
-    ];
+    const events = [makeEvent({ target: '/Users/foo/projectA/.env' })];
     expect(filterEventsToTarget(events, '/Users/foo/projectA/').length).toBe(1);
     expect(filterEventsToTarget(events, '/Users/foo/projectA/./').length).toBe(1);
     expect(filterEventsToTarget(events, '/Users/foo/projectA/sub/..').length).toBe(1);
-  });
-
-  it('returns an empty array when no events match', () => {
-    const events = [makeEvent({ target: '/Users/foo/projectB' })];
-    expect(filterEventsToTarget(events, '/tmp/empty')).toEqual([]);
-  });
-
-  it('returns the input unchanged when every event is in scope', () => {
-    const events = [
-      makeEvent({ target: '/Users/foo/projectA' }),
-      makeEvent({ target: '/Users/foo/projectA/.env' }),
-    ];
-    const filtered = filterEventsToTarget(events, '/Users/foo/projectA');
-    expect(filtered).toHaveLength(2);
   });
 
   it('handles a relative scan target by resolving against cwd', () => {
@@ -108,7 +105,7 @@ describe('filterEventsToTarget', () => {
     expect(filtered[0]!.target).toBe(path.resolve('.'));
   });
 
-  it('issue #109 sub-item 1 reproducer: empty test dir surfaces 0 cross-target tamper events', () => {
+  it('issue #109 reproducer: empty scan dir surfaces 0 cross-target tamper events', () => {
     const events: ShieldEvent[] = Array.from({ length: 288 }, (_, i) =>
       makeEvent({
         id: `evt-${i}`,
@@ -119,5 +116,102 @@ describe('filterEventsToTarget', () => {
     );
     const filtered = filterEventsToTarget(events, '/tmp/empty-test-dir');
     expect(filtered).toHaveLength(0);
+  });
+});
+
+describe('filterEventsToTarget — non-configguard sources are NOT scoped', () => {
+  // Critical safety property: only configguard events use `target` as the
+  // scope indicator. Other sources use `target` for the affected entity
+  // (binary, package, action, finding id), which has nothing to do with
+  // whether the event is in scope. Filtering them by path would suppress
+  // legitimate findings — e.g. a malicious agent shelling out to
+  // /usr/bin/curl from inside the scan target.
+  const otherSources: ShieldEventSource[] = [
+    'arp', 'registry', 'secretless', 'shield', 'browser-guard', 'hma',
+  ];
+
+  for (const source of otherSources) {
+    it(`passes through ${source} events even when target is an absolute system path outside the scan dir`, () => {
+      const events = [
+        makeEvent({ source, target: '/usr/bin/curl' }),
+        makeEvent({ source, target: '/etc/passwd' }),
+        makeEvent({ source, target: '/var/log/system.log' }),
+      ];
+      const filtered = filterEventsToTarget(events, '/Users/foo/projectA');
+      expect(filtered).toHaveLength(3);
+    });
+
+    it(`passes through ${source} events with non-path targets`, () => {
+      const events = [
+        makeEvent({ source, target: 'left-pad' }),
+        makeEvent({ source, target: 'https://evil.example.com' }),
+        makeEvent({ source, target: 'pid:12345' }),
+        makeEvent({ source, target: '' }),
+      ];
+      const filtered = filterEventsToTarget(events, '/Users/foo/projectA');
+      expect(filtered).toHaveLength(4);
+    });
+  }
+});
+
+describe('filterEventsToTarget — heterogeneous stream + classification integration', () => {
+  it('mixed stream: drops only out-of-scope configguard events; preserves the rest', () => {
+    const events: ShieldEvent[] = [
+      // Out-of-scope configguard tamper from another project — should be dropped
+      makeEvent({ id: 'cg-out-1', target: '/Users/foo/projectB' }),
+      makeEvent({ id: 'cg-out-2', target: '/tmp/random' }),
+      // In-scope configguard tamper — should survive
+      makeEvent({ id: 'cg-in-1', target: '/Users/foo/projectA' }),
+      // ARP event with absolute system binary path — should survive (not configguard)
+      makeEvent({ id: 'arp-1', source: 'arp', category: 'process.spawn', target: '/usr/bin/curl' }),
+      // Registry event for a package — should survive
+      makeEvent({ id: 'reg-1', source: 'registry', category: 'supply-chain.advisory', target: 'left-pad' }),
+      // Secretless credential finding — should survive
+      makeEvent({ id: 'sec-1', source: 'secretless', category: 'credential-finding', target: 'anthropic' }),
+    ];
+    const filtered = filterEventsToTarget(events, '/Users/foo/projectA');
+    const survivedIds = filtered.map(e => e.id).sort();
+    expect(survivedIds).toEqual(['arp-1', 'cg-in-1', 'reg-1', 'sec-1']);
+  });
+
+  it('positive integration: in-scope ConfigGuard tamper still classifies to SHIELD-INT-001', () => {
+    const events: ShieldEvent[] = [
+      makeEvent({
+        id: 'in-scope-tamper',
+        source: 'configguard',
+        target: '/Users/foo/projectA',
+        outcome: 'blocked',
+      }),
+      // Drown the in-scope event in cross-project noise to prove it survives.
+      ...Array.from({ length: 100 }, (_, i) => makeEvent({
+        id: `noise-${i}`, target: '/Users/foo/projectB',
+      })),
+    ];
+    const filtered = filterEventsToTarget(events, '/Users/foo/projectA');
+    const classified = classifyEvents(filtered);
+    const shieldInt001 = classified.find(c => c.finding.id === 'SHIELD-INT-001');
+    expect(shieldInt001).toBeDefined();
+    expect(shieldInt001!.count).toBe(1);
+  });
+
+  it('positive integration: ARP process-spawn surfaces as SHIELD-PROC-001 even with system-binary target', () => {
+    // Regression guard for the adversarial-review H1 finding: an earlier
+    // version of this filter dropped ARP events whose target was an
+    // absolute path (e.g. /usr/bin/curl), suppressing real attacks.
+    const events: ShieldEvent[] = [
+      makeEvent({
+        id: 'arp-curl',
+        source: 'arp',
+        category: 'process.spawn',
+        severity: 'high',
+        target: '/usr/bin/curl',
+        outcome: 'blocked',
+      }),
+    ];
+    const filtered = filterEventsToTarget(events, '/Users/foo/projectA');
+    const classified = classifyEvents(filtered);
+    const shieldProc = classified.find(c => c.finding.id === 'SHIELD-PROC-001');
+    expect(shieldProc).toBeDefined();
+    expect(shieldProc!.count).toBe(1);
   });
 });

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -38,7 +38,7 @@ import { quickCredentialScan, type CredentialMatch } from '../util/credential-pa
 import { checkAdvisories, type AdvisoryCheck } from '../util/advisories.js';
 import { getShieldStatus } from '../shield/status.js';
 import { readEvents } from '../shield/events.js';
-import { classifyEvents, type ClassifiedFinding } from '../shield/findings.js';
+import { classifyEvents, filterEventsToTarget, type ClassifiedFinding } from '../shield/findings.js';
 import { getARPStats, type ARPStats } from '../shield/arp-bridge.js';
 import { verifyConfigIntegrity, type ConfigIntegritySummary } from './guard.js';
 import { calculateGovernanceScore } from '../util/governance-scoring.js';
@@ -645,7 +645,8 @@ function runShieldPhase(targetDir: string): ShieldPhaseData {
     events = [] as ReturnType<typeof readEvents>;
   }
 
-  const classifiedFindings = classifyEvents(events);
+  const scopedEvents = filterEventsToTarget(events, targetDir);
+  const classifiedFindings = classifyEvents(scopedEvents);
 
   let arpStats: ARPStats;
   try {
@@ -674,7 +675,7 @@ function runShieldPhase(targetDir: string): ShieldPhaseData {
   postureScore = Math.max(0, Math.min(100, postureScore));
 
   return {
-    eventCount: events.length,
+    eventCount: scopedEvents.length,
     classifiedFindings,
     arpStats,
     postureScore,

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -675,7 +675,7 @@ function runShieldPhase(targetDir: string): ShieldPhaseData {
   postureScore = Math.max(0, Math.min(100, postureScore));
 
   return {
-    eventCount: scopedEvents.length,
+    eventCount: events.length,
     classifiedFindings,
     arpStats,
     postureScore,

--- a/packages/cli/src/shield/findings.ts
+++ b/packages/cli/src/shield/findings.ts
@@ -12,6 +12,8 @@
  *               INT (integrity), SUP (supply chain), BAS (behavioral)
  */
 
+import path from 'node:path';
+
 import type { ShieldEvent, EventSeverity, PolicyViolation } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -275,6 +277,53 @@ export function classifyEvent(event: ShieldEvent): FindingDefinition | null {
   }
 
   return null;
+}
+
+/**
+ * Drop events whose absolute-path target is outside `targetDir`.
+ *
+ * The global event log at `~/.opena2a/shield/events.jsonl` accumulates
+ * events from every `opena2a guard`/scan invocation across the user's
+ * machine. When `opena2a review` runs against a directory, only events
+ * whose subject lives inside that directory should surface — otherwise
+ * unrelated cross-project events (e.g. SHIELD-INT-001 from a tampered
+ * config in `/Users/foo/projectA`) bleed into a scan of an unrelated
+ * `/tmp/projectB` and the report appears broken (issue #109).
+ *
+ * Containment rules:
+ * - If `event.target` looks like an absolute path (starts with `/` on
+ *   POSIX or matches a Windows drive letter), keep the event only if
+ *   the path resolves under `targetDir`. Equality counts as inside.
+ * - If `event.target` is empty or doesn't look like a path (URLs,
+ *   package names, action identifiers, hostnames), keep the event —
+ *   we can't prove it's out of scope, so we don't drop it.
+ *
+ * Pure function. No I/O.
+ */
+export function filterEventsToTarget(
+  events: ShieldEvent[],
+  targetDir: string,
+): ShieldEvent[] {
+  const normalizedTarget = path.resolve(targetDir);
+  return events.filter(event => {
+    const target = event.target ?? '';
+    if (!isAbsolutePathLike(target)) return true;
+    const normalizedEventTarget = path.resolve(target);
+    if (normalizedEventTarget === normalizedTarget) return true;
+    const rel = path.relative(normalizedTarget, normalizedEventTarget);
+    if (rel === '' ) return true;
+    if (rel.startsWith('..')) return false;
+    if (path.isAbsolute(rel)) return false;
+    return true;
+  });
+}
+
+function isAbsolutePathLike(value: string): boolean {
+  if (value.length === 0) return false;
+  if (value.startsWith('/')) return true;
+  // Windows drive letter (C:\, D:/, etc.)
+  if (/^[A-Za-z]:[\\/]/.test(value)) return true;
+  return false;
 }
 
 /**

--- a/packages/cli/src/shield/findings.ts
+++ b/packages/cli/src/shield/findings.ts
@@ -280,25 +280,34 @@ export function classifyEvent(event: ShieldEvent): FindingDefinition | null {
 }
 
 /**
- * Drop events whose absolute-path target is outside `targetDir`.
+ * Drop ConfigGuard events whose absolute-path target is outside `targetDir`.
  *
  * The global event log at `~/.opena2a/shield/events.jsonl` accumulates
- * events from every `opena2a guard`/scan invocation across the user's
- * machine. When `opena2a review` runs against a directory, only events
- * whose subject lives inside that directory should surface — otherwise
- * unrelated cross-project events (e.g. SHIELD-INT-001 from a tampered
- * config in `/Users/foo/projectA`) bleed into a scan of an unrelated
- * `/tmp/projectB` and the report appears broken (issue #109).
+ * events from every `opena2a guard verify` invocation across the user's
+ * machine. When `opena2a review` runs against a directory, ConfigGuard
+ * verify events from unrelated directories should not surface as
+ * SHIELD-INT-001 critical findings — otherwise an empty test dir
+ * inherits 288 cross-project tamper events and the report looks broken
+ * (issue #109 sub-item 1).
  *
- * Containment rules:
- * - If `event.target` looks like an absolute path (starts with `/` on
- *   POSIX or matches a Windows drive letter), keep the event only if
- *   the path resolves under `targetDir`. Equality counts as inside.
- * - If `event.target` is empty or doesn't look like a path (URLs,
- *   package names, action identifiers, hostnames), keep the event —
- *   we can't prove it's out of scope, so we don't drop it.
+ * Scope of this filter (intentionally narrow):
+ * - Only `event.source === 'configguard'` events with an absolute-path
+ *   `target` are subject to scoping. Those events use `target` as the
+ *   directory whose configs were verified (set at guard.ts:310,
+ *   guard-policy.ts, guard-snapshots.ts:247).
+ * - All other event sources (arp, registry, secretless, shield) are
+ *   passed through untouched. Their `target` field is the affected
+ *   entity (binary, package, finding id, action) — NOT a scope
+ *   indicator. Filtering those by path would suppress legitimate
+ *   cross-cutting findings (e.g. an ARP event for `/usr/bin/curl`
+ *   spawned inside the scan target).
+ * - ConfigGuard events with a non-absolute `target` (`guard watch`
+ *   emits relative paths like `package.json`) are kept. They cannot
+ *   be reliably scoped without writer-side changes; that's tracked
+ *   as a residual issue separate from this PR.
  *
- * Pure function. No I/O.
+ * No filesystem I/O — `path.resolve` only consults `process.cwd()`
+ * when `targetDir` is relative.
  */
 export function filterEventsToTarget(
   events: ShieldEvent[],
@@ -306,13 +315,14 @@ export function filterEventsToTarget(
 ): ShieldEvent[] {
   const normalizedTarget = path.resolve(targetDir);
   return events.filter(event => {
+    if (event.source !== 'configguard') return true;
     const target = event.target ?? '';
     if (!isAbsolutePathLike(target)) return true;
     const normalizedEventTarget = path.resolve(target);
     if (normalizedEventTarget === normalizedTarget) return true;
     const rel = path.relative(normalizedTarget, normalizedEventTarget);
-    if (rel === '' ) return true;
-    if (rel.startsWith('..')) return false;
+    if (rel === '') return true;
+    if (rel === '..' || rel.startsWith('..' + path.sep)) return false;
     if (path.isAbsolute(rel)) return false;
     return true;
   });
@@ -321,7 +331,6 @@ export function filterEventsToTarget(
 function isAbsolutePathLike(value: string): boolean {
   if (value.length === 0) return false;
   if (value.startsWith('/')) return true;
-  // Windows drive letter (C:\, D:/, etc.)
   if (/^[A-Za-z]:[\\/]/.test(value)) return true;
   return false;
 }


### PR DESCRIPTION
## Closes opena2a-org/opena2a#109 sub-item 1 (of 7)

Each sub-item of #109 lands as an independent PR per the issue's "Suggested order" section. This is the highest-leverage one: the 288-count on an empty test directory was the smoking gun that the entire `opena2a review` report looked broken.

## Root cause

`runShieldPhase` in `packages/cli/src/commands/review.ts:643` reads from the global Shield event log at `~/.opena2a/shield/events.jsonl` with no path filter. That log accumulates events from every `opena2a guard verify` invocation across every project on the user's machine. The `classifyEvents` helper then maps each event to a `SHIELD-*` finding — including SHIELD-INT-001 (config tampered, **critical**) — regardless of whether the tampered file is anywhere near the directory the user is currently scanning.

Concretely: a user who runs `opena2a guard verify /Users/foo/projectA`, then later runs `opena2a review /tmp/empty-test`, sees every historical tamper event from projectA surface as a critical finding in the empty-test review. With 288 such events accumulated in the global log, the composite score collapses to 27/100 and the report appears broken.

## Fix

New helper `filterEventsToTarget(events, targetDir)` in `packages/cli/src/shield/findings.ts`. Drops `event.source === 'configguard'` events whose absolute-path `target` resolves outside `targetDir`. Wired into `runShieldPhase()` between `readEvents()` and `classifyEvents()`.

The filter is **intentionally narrow** — it only touches ConfigGuard events:
- ConfigGuard is the single event source whose `target` field is the scope indicator (the resolved directory passed to `guard verify` / `guard sign` / `guard resign`, set at `guard.ts:310`, `guard-policy.ts`, `guard-snapshots.ts:247`).
- Other event sources (`arp`, `registry`, `secretless`, `shield`, `browser-guard`, `hma`) use `target` for the affected entity (binary, package, finding id, action) — NOT a scope indicator. Filtering those by path would suppress legitimate cross-cutting findings (e.g. a SHIELD-PROC-001 ARP event for `/usr/bin/curl` spawned inside the scan target would otherwise be dropped).

`eventCount` is kept at `events.length` (global, unchanged semantics) to preserve the existing meaning of the "X events, Y findings" summary line. The "what does eventCount mean" question is separately tracked as #109 sub-item 3.

## User-visible impact

| Scan target | Before | After |
|---|---|---|
| `mktemp -d` (empty) | Score 27/100, **288 SHIELD-INT-001 critical** | Score 72/100, 0 SHIELD-INT-001 |
| Real project with in-scope ConfigGuard tamper | Surfaces SHIELD-INT-001 | Surfaces SHIELD-INT-001 (unchanged) |
| Real project with in-scope ARP `/usr/bin/curl` spawn | Surfaces SHIELD-PROC-001 | Surfaces SHIELD-PROC-001 (unchanged) |

## Tests

`packages/cli/__tests__/shield/findings-path-scoping.test.ts` — 24 deterministic unit tests, no spawn, no corpus. Per `feedback_spawn_only_tests_silently_skip_in_ci.md`, this is the layer that gates merges in CI.

Coverage:
- 6 negative tests for ConfigGuard cross-target events (incl. lexical-prefix, exact-match, nesting, normalization, traversal-segment edge cases)
- The literal #109 reproducer (288 cross-target events on an empty target → 0 surviving)
- 12 pass-through tests for non-ConfigGuard sources (`arp`, `registry`, `secretless`, `shield`, `browser-guard`, `hma`) with both absolute-system-path and non-path targets
- Mixed heterogeneous-stream test
- **Positive integration**: in-scope ConfigGuard tamper still classifies to SHIELD-INT-001 even when buried in 100 cross-target noise events
- **Positive integration / regression guard for adversarial-review H1**: ARP `/usr/bin/curl` event still classifies to SHIELD-PROC-001 (an earlier broader version of this filter dropped it)

Full suite: 915/915 pass (was 901; 14 net new from this PR).

## Adversarial review

The first commit (`3c42391`) was rejected by adversarial self-review with FAIL — the broader filter dropped legitimate ARP findings and silently changed `eventCount` semantics. The second commit (`4267ac0`) narrowed the filter to ConfigGuard only, reverted `eventCount`, tightened the parent-traversal predicate, and added the regression guards above. The second-pass adversarial review returned **PASS-WITH-CAVEAT**, with two MEDIUM residuals filed as separate issues:

- #110 — `guard watch` emits relative-path targets that this filter cannot scope (writer-side fix; no user-visible impact in default config)
- #111 — Symmetric scoping for relative configguard targets (event-log injection hardening, local-attacker scenario)

Neither is a blocker for this PR.

## Out of scope

- #109 sub-items 2 (cross-phase dedupe), 3 (Shield posture incoherence), 4 (hygiene math wording), 5 (Shadow AI governance split), 6 (gitignore fix command), 7 (Shield code explainer registry) — each independent PR.
- HMA #138 (attackClass population) — separate active branch.
- Pre-existing P2/P3 from the 0.9.1 release-test (`check` no-arg, `trust` NaN, SEM-CRED-002 prose Fix, runtime --help global flags).

## Test plan

- [x] 24 deterministic unit tests in `findings-path-scoping.test.ts` pass in CI
- [x] Full opena2a-cli suite 915/915
- [x] Lint clean
- [x] HMA self-scan introduces 0 new findings on touched files
- [x] `opena2a review` on a fresh `mktemp -d`: 0 SHIELD-INT-001, score 72/100
- [x] `opena2a review` on a real project with no ConfigGuard history: behavior unchanged from main
- [x] `opena2a review /does/not/exist`: clean error path
- [x] Adversarial second-pass review PASS-WITH-CAVEAT