### PR TITLE
feat(credential-patterns): extract @opena2a/credential-patterns@0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
       - 'registry-client-v*'
       - 'check-core-v*'
       - 'telemetry-v*'
+      - 'credential-patterns-v*'
 
 permissions:
   contents: write
@@ -72,6 +73,7 @@ jobs:
           publish_if_new packages/registry-client @opena2a/registry-client
           publish_if_new packages/check-core @opena2a/check-core
           publish_if_new packages/telemetry @opena2a/telemetry
+          publish_if_new packages/credential-patterns @opena2a/credential-patterns
           echo "=== Published this run ==="
           cat /tmp/published.txt
           echo "=== Skipped (version already on npm) ==="

--- a/package-lock.json
+++ b/package-lock.json
@@ -920,6 +920,10 @@
       "resolved": "packages/contribute",
       "link": true
     },
+    "node_modules/@opena2a/credential-patterns": {
+      "resolved": "packages/credential-patterns",
+      "link": true
+    },
     "node_modules/@opena2a/registry-client": {
       "resolved": "packages/registry-client",
       "link": true
@@ -3917,7 +3921,7 @@
     },
     "packages/cli": {
       "name": "opena2a-cli",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
@@ -3994,6 +3998,26 @@
       "devDependencies": {
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
+      }
+    },
+    "packages/credential-patterns": {
+      "name": "@opena2a/credential-patterns",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "packages/credential-patterns/node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "packages/registry-client": {

--- a/packages/credential-patterns/CHANGELOG.md
+++ b/packages/credential-patterns/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to `@opena2a/credential-patterns` will be documented in this file.
+
+## 0.1.0 — 2026-04-29
+
+Initial release. Pure relocation of the credential pattern catalog from `secretless-ai` (`src/patterns.ts` and `findRealMatch` / `isKnownExample` from `src/scan.ts`). No regex changes, no semantic changes — every input that matched in `secretless-ai 0.16.2` continues to match here.
+
+### Exports
+
+- `CREDENTIAL_PATTERNS` — 56 patterns across ai-ml, cloud, communication, developer, payment, database, auth, and monitoring categories.
+- `CREDENTIAL_PREFIX_QUICK_CHECK` — auto-generated prefilter regex.
+- `KNOWN_EXAMPLE_KEYS`, `PLACEHOLDER_INDICATORS` — allowlist data.
+- `SECRET_FILE_PATTERNS`, `CONFIG_FILES`, `SOURCE_FILE_EXTENSIONS`, `SOURCE_SKIP_DIRS` — file-system scan rules.
+- `findRealMatch`, `isKnownExample` — match-with-allowlist helpers.
+- `CredentialPattern` — pattern interface type.
+
+### Provenance
+
+`0.1.0` is a manual one-shot bootstrap publish (`npm publish --access public`). From `0.1.1` onward the package publishes via npm Trusted Publishing through `.github/workflows/release.yml`, which attaches SLSA v1 attestations.
+
+### Consumers (planned)
+
+- `secretless-ai 0.17.0` (PR 2) — replaces local `src/patterns.ts` with this package.
+- `hackmyagent` (PR 3) — replaces `src/plugins/credvault.ts`'s parallel pattern copy and switches `src/plugins/secretless.ts` from runtime `import('secretless-ai')` to a compile-time dep on this package.

--- a/packages/credential-patterns/README.md
+++ b/packages/credential-patterns/README.md
@@ -12,12 +12,17 @@ npm install @opena2a/credential-patterns
 
 Pin exactly. Per OpenA2A convention across the CLI consolidation, depend with `"@opena2a/credential-patterns": "0.1.0"`, not `^0.1.0`. Trades dependency-update PR volume for supply-chain tightness; removes transitive surprise.
 
+This package is **ESM-only** (`"type": "module"`, no CJS build).
+
+- ESM consumers (`"type": "module"`, or `.mjs` / `.mts` files): use a static `import { ... } from '@opena2a/credential-patterns'` as shown below.
+- CommonJS consumers (`"type": "commonjs"`, including any `.ts` file under a CJS `tsconfig` with `module: "Node16"`): use a dynamic `await import('@opena2a/credential-patterns')` inside an async function. A static `import` will fail with TypeScript `TS1479` ("CommonJS module ... cannot be imported with `require`"). This is the path `secretless-ai` uses today for `@opena2a/cli-ui` and is the same path PR 2 will use here.
+
 ## Exports
 
 ```ts
 import {
   CREDENTIAL_PATTERNS,           // CredentialPattern[] — ordered, prefix-specific first
-  CREDENTIAL_PREFIX_QUICK_CHECK, // RegExp — fast prefilter built from pattern prefixes
+  CREDENTIAL_PREFIX_QUICK_CHECK, // RegExp (no /g flag — safe to call .test() repeatedly)
   KNOWN_EXAMPLE_KEYS,            // Set<string> — exact public example keys to allowlist
   PLACEHOLDER_INDICATORS,        // string[] — case-insensitive placeholder substrings
   SECRET_FILE_PATTERNS,          // string[] — file globs that must never reach AI tools

--- a/packages/credential-patterns/README.md
+++ b/packages/credential-patterns/README.md
@@ -1,0 +1,73 @@
+# @opena2a/credential-patterns
+
+Canonical credential regex catalog and match-with-allowlist helpers for OpenA2A security tools.
+
+One place to update credential detection so `secretless-ai`, `hackmyagent`, and any downstream OpenA2A scanner share the same patterns and the same known-example allowlist. Add new patterns here, not in tools — duplicate catalogs are how detection drifts.
+
+## Install
+
+```bash
+npm install @opena2a/credential-patterns
+```
+
+Pin exactly. Per OpenA2A convention across the CLI consolidation, depend with `"@opena2a/credential-patterns": "0.1.0"`, not `^0.1.0`. Trades dependency-update PR volume for supply-chain tightness; removes transitive surprise.
+
+## Exports
+
+```ts
+import {
+  CREDENTIAL_PATTERNS,           // CredentialPattern[] — ordered, prefix-specific first
+  CREDENTIAL_PREFIX_QUICK_CHECK, // RegExp — fast prefilter built from pattern prefixes
+  KNOWN_EXAMPLE_KEYS,            // Set<string> — exact public example keys to allowlist
+  PLACEHOLDER_INDICATORS,        // string[] — case-insensitive placeholder substrings
+  SECRET_FILE_PATTERNS,          // string[] — file globs that must never reach AI tools
+  CONFIG_FILES,                  // string[] — config files that may carry hardcoded secrets
+  SOURCE_FILE_EXTENSIONS,        // Set<string> — extensions to scan for inline credentials
+  SOURCE_SKIP_DIRS,              // Set<string> — directory names to skip when walking
+  findRealMatch,                 // (line, pattern) => RegExpMatchArray | null
+  isKnownExample,                // (line, match) => boolean
+  type CredentialPattern,        // { id, name, regex, envPrefix, category? }
+} from '@opena2a/credential-patterns';
+```
+
+## Pattern shape
+
+```ts
+interface CredentialPattern {
+  id: string;        // stable identifier — e.g. "anthropic", "aws-access"
+  name: string;      // human-readable — "Anthropic API Key"
+  regex: RegExp;     // detection pattern; non-global is fine, findRealMatch promotes
+  envPrefix: string; // suggested env var name — "ANTHROPIC_API_KEY"
+  category?: string; // ai-ml | cloud | communication | developer | payment | database | auth | monitoring
+}
+```
+
+## Ordering
+
+The order of `CREDENTIAL_PATTERNS` is load-bearing: more specific prefixes (e.g. `sk-ant-`, `sk-proj-`, `sk-or-v1-`) precede catch-all patterns (e.g. `openai-legacy` `sk-[a-zA-Z0-9]{48,}`) because scanners iterate the array and break on first match.
+
+## Allowlist semantics
+
+`isKnownExample(line, match)` returns true if the matched value should be excluded from results. Three rules in order:
+
+1. The matched value is in `KNOWN_EXAMPLE_KEYS` (e.g. `AKIAIOSFODNN7EXAMPLE`).
+2. The matched value contains any `PLACEHOLDER_INDICATORS` substring (case-insensitive).
+3. The line carries a comment marker (`//` or `#`) AND mentions `example`, `placeholder`, or `fake`.
+
+`findRealMatch(line, pattern)` walks every match on the line (promoting non-`/g` regexes to `/g`) and returns the first one that passes `isKnownExample`. Returns null if every match is allowlisted.
+
+## Consumers
+
+- `secretless-ai` — primary consumer (PR 2 will migrate from local `src/patterns.ts`).
+- `hackmyagent` — PR 3 replaces `src/plugins/credvault.ts`'s parallel inferior copy.
+
+## Versioning
+
+- Patches (`0.1.x`): bug fixes, new patterns, allowlist additions.
+- Minors (`0.x.0`): breaking pattern semantics (regex narrowing/widening, schema changes), new exports.
+
+Detection-logic changes go through Phase 4.5 adversarial review per `~/workspace/claude-skills/skills/pre-push-review/SKILL.md`.
+
+## License
+
+Apache-2.0.

--- a/packages/credential-patterns/package.json
+++ b/packages/credential-patterns/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@opena2a/credential-patterns",
+  "version": "0.1.0",
+  "description": "Canonical credential regex catalog and match-with-allowlist helpers for OpenA2A security tools (secretless-ai, hackmyagent).",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run --passWithNoTests",
+    "lint": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opena2a-org/opena2a.git",
+    "directory": "packages/credential-patterns"
+  },
+  "homepage": "https://github.com/opena2a-org/opena2a/tree/main/packages/credential-patterns",
+  "license": "Apache-2.0"
+}

--- a/packages/credential-patterns/src/index.ts
+++ b/packages/credential-patterns/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @opena2a/credential-patterns — canonical credential regex catalog and
+ * match-with-allowlist helpers for OpenA2A security tools.
+ *
+ * One source of truth so secretless-ai, hackmyagent, and downstream consumers
+ * share the same patterns and the same known-example allowlist. Add new
+ * patterns here, not in tools — duplicate catalogs are how detection drifts.
+ */
+
+export {
+  CREDENTIAL_PATTERNS,
+  CREDENTIAL_PREFIX_QUICK_CHECK,
+  KNOWN_EXAMPLE_KEYS,
+  PLACEHOLDER_INDICATORS,
+  SECRET_FILE_PATTERNS,
+  CONFIG_FILES,
+  SOURCE_FILE_EXTENSIONS,
+  SOURCE_SKIP_DIRS,
+  type CredentialPattern,
+} from './patterns.js';
+
+export { findRealMatch, isKnownExample } from './match.js';

--- a/packages/credential-patterns/src/match.test.ts
+++ b/packages/credential-patterns/src/match.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { isKnownExample, findRealMatch } from './match.js';
+import { CREDENTIAL_PATTERNS } from './patterns.js';
+
+function patternByName(name: string) {
+  const p = CREDENTIAL_PATTERNS.find(p => p.name === name);
+  if (!p) throw new Error(`pattern ${name} not found`);
+  return p;
+}
+
+describe('isKnownExample (issue #50 — comment-marker precedence)', () => {
+  it('does NOT treat a line with # but no "example" as a known example', () => {
+    // Python comment line with a credential-shaped value but no "example" marker.
+    // Previous buggy precedence `(A && B) || C` would enter the inner block on any
+    // line containing `#`. Regression guard: must return false here.
+    const line = '# TODO: rotate AKIAREALKEY1234567890 next sprint';
+    const match = line.match(/AKIA[0-9A-Z]{16}/)!;
+    expect(match).not.toBeNull();
+    expect(isKnownExample(line, match)).toBe(false);
+  });
+
+  it('DOES treat a line with "example //" as a known example', () => {
+    const line = 'const key = "AKIASOMEOTHERKEY12345"; // example placeholder';
+    const match = line.match(/AKIA[0-9A-Z]{16}/)!;
+    expect(match).not.toBeNull();
+    expect(isKnownExample(line, match)).toBe(true);
+  });
+
+  it('treats the AKIAIOSFODNN7EXAMPLE public example as a known example', () => {
+    const line = 'See AKIAIOSFODNN7EXAMPLE in the AWS docs.';
+    const match = line.match(/AKIA[0-9A-Z]{16}/)!;
+    expect(isKnownExample(line, match)).toBe(true);
+  });
+});
+
+describe('findRealMatch (issue #51 — known-example shadowing)', () => {
+  it('mixed-pattern line: AWS example + real GitHub PAT returns the PAT', () => {
+    // Intentionally NO `//` or `#` markers — we're testing that the KNOWN_EXAMPLE_KEYS
+    // match for AKIAIOSFODNN7EXAMPLE does not shadow the real GitHub PAT later on
+    // the same line. (Lines with comment+example context are an orthogonal case
+    // handled by isKnownExample directly.)
+    const line = 'const old = "AKIAIOSFODNN7EXAMPLE"; const new_ = "ghp_abcdefghijklmnopqrstuvwxyz1234567890";';
+    const awsPattern = patternByName('AWS Access Key');
+    const ghPattern = patternByName('GitHub Token');
+
+    // AWS pattern: only match is the public example -> no real match
+    expect(findRealMatch(line, awsPattern)).toBeNull();
+    // GitHub pattern: match is real
+    const ghMatch = findRealMatch(line, ghPattern);
+    expect(ghMatch).not.toBeNull();
+    expect(ghMatch![0]).toBe('ghp_abcdefghijklmnopqrstuvwxyz1234567890');
+  });
+
+  it('multi-match same-pattern line: example AKIAIOSFODNN7EXAMPLE before real AKIA key returns the real one', () => {
+    // AWS Access Key pattern ships without /g; findRealMatch must still iterate
+    // every match on the line and skip the example to find the real key.
+    const line = 'const keys = ["AKIAIOSFODNN7EXAMPLE", "AKIAREALKEY1234567890"];';
+    const awsPattern = patternByName('AWS Access Key');
+    const match = findRealMatch(line, awsPattern);
+    expect(match).not.toBeNull();
+    // AWS regex is AKIA[0-9A-Z]{16} — match is exactly 20 chars, trailing digits truncated.
+    expect(match![0]).toBe('AKIAREALKEY123456789');
+  });
+
+  it('returns null when every match on the line is a known example', () => {
+    const line = '// examples: AKIAIOSFODNN7EXAMPLE';
+    const awsPattern = patternByName('AWS Access Key');
+    expect(findRealMatch(line, awsPattern)).toBeNull();
+  });
+});

--- a/packages/credential-patterns/src/match.ts
+++ b/packages/credential-patterns/src/match.ts
@@ -1,0 +1,53 @@
+/**
+ * Match-with-allowlist helpers. Lifted from secretless/src/scan.ts so the
+ * canonical "skip known-example credentials, keep real ones" contract lives
+ * with the patterns themselves. PR 2 + PR 3 stop reimplementing this.
+ */
+
+import { KNOWN_EXAMPLE_KEYS, PLACEHOLDER_INDICATORS, type CredentialPattern } from './patterns.js';
+
+/**
+ * Check if a matched credential is a known example or placeholder.
+ * Returns true if the match should be excluded from results.
+ *
+ * Exported so any scanner can apply the same allowlist. Prevents scanners
+ * from blocking docs that legitimately reference public example keys like
+ * AKIAIOSFODNN7EXAMPLE.
+ */
+export function isKnownExample(line: string, match: RegExpMatchArray): boolean {
+  const value = match[0];
+  // Check exact known example keys
+  if (KNOWN_EXAMPLE_KEYS.has(value)) return true;
+  // Check placeholder indicators (case-insensitive)
+  const lower = value.toLowerCase();
+  if (PLACEHOLDER_INDICATORS.some(p => lower.includes(p))) return true;
+  // Check if the line contains a comment marking it as an example
+  const lineLC = line.toLowerCase();
+  if (lineLC.includes('example') && (lineLC.includes('//') || lineLC.includes('#'))) {
+    if (lineLC.includes('example') || lineLC.includes('placeholder') || lineLC.includes('fake')) return true;
+  }
+  return false;
+}
+
+/**
+ * Return the first match in `line` for `pattern.regex` that is NOT a known
+ * example, or null if every match is an example (or there are no matches).
+ *
+ * For /g regexes this iterates all matches via matchAll so that a known
+ * example of a given pattern on a line does not shadow a real credential
+ * of the same pattern later on that line. Non-global regexes fall back to
+ * a single match check.
+ */
+export function findRealMatch(line: string, pattern: CredentialPattern): RegExpMatchArray | null {
+  // matchAll requires /g. Promote non-/g patterns so we iterate EVERY match on
+  // the line — otherwise a known-example match at position 0 would shadow a
+  // real credential of the same pattern later on the same line.
+  const globalRegex = pattern.regex.flags.includes('g')
+    ? pattern.regex
+    : new RegExp(pattern.regex.source, pattern.regex.flags + 'g');
+  globalRegex.lastIndex = 0;
+  for (const m of line.matchAll(globalRegex)) {
+    if (!isKnownExample(line, m)) return m;
+  }
+  return null;
+}

--- a/packages/credential-patterns/src/patterns.test.ts
+++ b/packages/credential-patterns/src/patterns.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect } from 'vitest';
+import { CREDENTIAL_PATTERNS, CREDENTIAL_PREFIX_QUICK_CHECK } from './patterns.js';
+
+/**
+ * Test data for each pattern: valid strings that MUST match, invalid strings that MUST NOT.
+ *
+ * Strings here are synthetic (mostly `'a'.repeat(n)` shape fixtures) — they exercise
+ * regex shape, not real credentials. Tokens that look credential-shaped are built
+ * dynamically to avoid triggering GitHub Push Protection on this file itself.
+ */
+// Build test tokens dynamically to avoid triggering GitHub Push Protection
+const slackTestToken = ['xox', 'b-1234567890-1234567890-', 'abcdefghijklmnopqrstuvwx'].join('');
+const discordBotToken = ['MTIzNDU2Nzg5MDEyMzQ1Njc4OQ', '.GabcDE.', 'abcdefghijklmnopqrstuvwxyz01234'].join('');
+
+const PATTERN_TEST_CASES: Record<string, { valid: string[]; invalid: string[] }> = {
+  // AI/ML
+  'anthropic': {
+    valid: ['sk-ant-api03-abc123def456abc123def456abc123'],
+    invalid: ['sk-ant-wrong', 'sk-ant-api-tooshort'],
+  },
+  'openai-proj': {
+    valid: ['sk-proj-Qm50BIe8JjiH5tDZHMIuf7HsH6C91Ye'],
+    invalid: ['sk-proj-short', 'sk-proj-'],
+  },
+  'openrouter': {
+    valid: ['sk-or-v1-' + 'a'.repeat(48)],
+    invalid: ['sk-or-v1-short', 'sk-or-v2-' + 'a'.repeat(48)],
+  },
+  'openai-legacy': {
+    valid: ['sk-' + 'a'.repeat(48)],
+    invalid: ['sk-' + 'a'.repeat(10), 'sk-short'],
+  },
+  'groq': {
+    valid: ['gsk_abc123def456abc123def456'],
+    invalid: ['gsk_short', 'gsk_'],
+  },
+  'replicate': {
+    valid: ['r8_abcdef1234567890abcdef'],
+    invalid: ['r8_short', 'r8_'],
+  },
+  'huggingface': {
+    valid: ['hf_abcdef1234567890abcdef'],
+    invalid: ['hf_short', 'hf_'],
+  },
+  'perplexity': {
+    valid: ['pplx-' + 'a'.repeat(48)],
+    invalid: ['pplx-short', 'pplx-' + 'a'.repeat(10)],
+  },
+  'fireworks': {
+    valid: ['fw_abcdef1234567890abcdef'],
+    invalid: ['fw_short', 'fw_'],
+  },
+
+  // Cloud
+  'aws-access': {
+    valid: ['AKIAIOSFODNN7EXAMPLE'],
+    invalid: ['AKIA123', 'BKIAIOSFODNN7EXAMPLE'],
+  },
+  'aws-sts': {
+    valid: ['ASIAIOSFODNN7EXAMPLE'],
+    invalid: ['ASIA123', 'BSIAIOSFODNN7EXAMPLE'],
+  },
+  'gcp-service-account': {
+    valid: ['"type": "service_account"', '"type":"service_account"'],
+    invalid: ['"type": "user_account"', '"type":"oauth"'],
+  },
+  'digitalocean': {
+    valid: ['dop_v1_' + 'a'.repeat(64)],
+    invalid: ['dop_v1_short', 'dop_v2_' + 'a'.repeat(64)],
+  },
+  'heroku': {
+    valid: ['HRKU-' + 'a'.repeat(30)],
+    invalid: ['HRKU-short', 'HRKU-' + 'a'.repeat(5)],
+  },
+  'fly-io': {
+    valid: ['fo1_' + 'a'.repeat(20)],
+    invalid: ['fo1_short', 'fo1_'],
+  },
+  'netlify': {
+    valid: ['nfp_' + 'a'.repeat(40)],
+    invalid: ['nfp_short', 'nfp_' + 'a'.repeat(5)],
+  },
+  'azure': {
+    valid: ['AccountKey=' + 'a'.repeat(43) + '=', 'SharedAccessKey = ' + 'B'.repeat(43) + '='],
+    invalid: ['AccountKey=short', 'RandomKey=' + 'a'.repeat(43) + '='],
+  },
+  'supabase': {
+    valid: ['eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' + 'a'.repeat(50)],
+    invalid: ['eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.short'],
+  },
+
+  // Communication
+  'slack': {
+    valid: [slackTestToken],
+    invalid: ['xoxb-short', 'xoxz-1234567890-1234567890-abcdefghijklmnopqrstuvwx'],
+  },
+  'slack-webhook': {
+    valid: ['hooks.slack.com/services/T01234567/B01234567/abcdefghijklmnopqrstuvwx'],
+    invalid: ['hooks.slack.com/services/T012/B012/abc', 'hooks.slack.com/other'],
+  },
+  'slack-app': {
+    valid: ['xapp-1-A01234567-12345-abcdef0123456789'],
+    invalid: ['xapp-nope'],
+  },
+  'telegram-bot': {
+    valid: ['123456789:ABCDefgh_ijklmnopQRSTuvwxyz012345678'],
+    invalid: ['12345:short', '1234567:AB'],
+  },
+  'discord-bot': {
+    valid: [discordBotToken],
+    invalid: ['short.ab.cd', 'Xshort.abcdef.short'],
+  },
+  'discord-webhook': {
+    valid: ['discord.com/api/webhooks/123456789/abcdef_GHIJKL-mnop'],
+    invalid: ['discord.com/api/other/123', 'discord.com/webhooks/123/abc'],
+  },
+  'twilio': {
+    valid: ['SK' + 'a'.repeat(32)],
+    invalid: ['SK' + 'a'.repeat(10), 'SKshort'],
+  },
+  'sendgrid': {
+    valid: ['SG.' + 'a'.repeat(22) + '.' + 'b'.repeat(43)],
+    invalid: ['SG.short.short', 'SG.abc'],
+  },
+
+  // Developer
+  'github-pat': {
+    valid: ['ghp_abcdefghijklmnopqrstuvwxyz0123456789'],
+    invalid: ['ghp_short', 'ghp_'],
+  },
+  'github-fine': {
+    valid: ['github_pat_' + 'a'.repeat(22) + '_' + 'b'.repeat(59)],
+    invalid: ['github_pat_short_short', 'github_pat_' + 'a'.repeat(5) + '_' + 'b'.repeat(5)],
+  },
+  'github-oauth': {
+    valid: ['gho_' + 'a'.repeat(36)],
+    invalid: ['gho_short', 'gho_'],
+  },
+  'github-app': {
+    valid: ['ghs_' + 'a'.repeat(36)],
+    invalid: ['ghs_short', 'ghs_'],
+  },
+  'github-refresh': {
+    valid: ['ghr_' + 'a'.repeat(36)],
+    invalid: ['ghr_short', 'ghr_'],
+  },
+  'gitlab': {
+    valid: ['glpat-' + 'a'.repeat(20)],
+    invalid: ['glpat-short', 'glpat-'],
+  },
+  'gitlab-pipeline': {
+    valid: ['glptt-' + 'a'.repeat(40)],
+    invalid: ['glptt-short', 'glptt-'],
+  },
+  'gitlab-runner': {
+    valid: ['GR1348941' + 'a'.repeat(20)],
+    invalid: ['GR1348941short', 'GR1348941'],
+  },
+  'npm': {
+    valid: ['npm_' + 'a'.repeat(36)],
+    invalid: ['npm_short', 'npm_'],
+  },
+  'pypi': {
+    valid: ['pypi-' + 'a'.repeat(50)],
+    invalid: ['pypi-short', 'pypi-' + 'a'.repeat(10)],
+  },
+  'dockerhub': {
+    valid: ['dckr_pat_' + 'a'.repeat(20)],
+    invalid: ['dckr_pat_short', 'dckr_pat_'],
+  },
+  'bitbucket': {
+    valid: ['ATBB' + 'a'.repeat(32)],
+    invalid: ['ATBB' + 'a'.repeat(5), 'ATBBshort'],
+  },
+
+  // Payment
+  'stripe-test': {
+    valid: ['sk_test_' + 'a'.repeat(24)],
+    invalid: ['sk_test_short', 'sk_test_'],
+  },
+  'stripe-restricted': {
+    valid: ['rk_live_' + 'a'.repeat(24)],
+    invalid: ['rk_live_short', 'rk_live_'],
+  },
+  'stripe': {
+    valid: ['sk_live_' + 'a'.repeat(24)],
+    invalid: ['sk_live_short', 'sk_live_'],
+  },
+  'stripe-webhook': {
+    valid: ['whsec_' + 'a'.repeat(32)],
+    invalid: ['whsec_short', 'whsec_'],
+  },
+  'square': {
+    valid: ['sq0csp-' + 'a'.repeat(22)],
+    invalid: ['sq0csp-short', 'sq0CSP-' + 'a'.repeat(22)],
+  },
+
+  // Database
+  'mongodb': {
+    valid: ['mongodb+srv://user:pass@cluster.mongodb.net/db'],
+    invalid: ['mongodb://lo', 'mongo+srv://x'],
+  },
+  'postgres': {
+    valid: ['postgres://user:pass@localhost:5432/mydb'],
+    invalid: ['postgres://s', 'pg://user:pass@host/db'],
+  },
+  'mysql': {
+    valid: ['mysql://user:pass@localhost:3306/mydb'],
+    invalid: ['mysql://sh', 'msql://user:pass@host/db'],
+  },
+  'redis': {
+    valid: ['redis://user:pass@localhost:6379/0', 'rediss://secure@host:6379'],
+    invalid: ['redis://sh', 'rds://host:6379'],
+  },
+
+  // Auth & Crypto
+  'google': {
+    valid: ['AIzaSyB-abc_def123456789012345678901234'],
+    invalid: ['AIzaShort', 'BIzaSyBabc1234567890123456789012345'],
+  },
+  'google-oauth': {
+    valid: ['ya29.' + 'a'.repeat(50)],
+    invalid: ['ya29.' + 'a'.repeat(10), 'ya29.short'],
+  },
+  'pem-private-key': {
+    valid: [
+      '-----BEGIN PRIVATE KEY-----',
+      '-----BEGIN RSA PRIVATE KEY-----',
+      '-----BEGIN EC PRIVATE KEY-----',
+      '-----BEGIN OPENSSH PRIVATE KEY-----',
+    ],
+    invalid: ['-----BEGIN PUBLIC KEY-----', '-----BEGIN CERTIFICATE-----'],
+  },
+  'firebase-fcm': {
+    valid: ['AAAA1234567:' + 'a'.repeat(140)],
+    invalid: ['AAAA123:short', 'AAAA1234567:' + 'a'.repeat(10)],
+  },
+
+  // Monitoring
+  'newrelic': {
+    valid: ['NRAK-' + 'A'.repeat(27)],
+    invalid: ['NRAK-short', 'NRAK-' + 'A'.repeat(5)],
+  },
+  'newrelic-insight': {
+    valid: ['NRIQ-' + 'A'.repeat(27)],
+    invalid: ['NRIQ-short', 'NRIQ-' + 'A'.repeat(5)],
+  },
+  'sentry': {
+    valid: ['sntrys_' + 'a'.repeat(40)],
+    invalid: ['sntrys_short', 'sntrys_' + 'a'.repeat(5)],
+  },
+  'grafana': {
+    valid: ['glc_' + 'a'.repeat(32)],
+    invalid: ['glc_short', 'glc_' + 'a'.repeat(5)],
+  },
+  'linear': {
+    valid: ['lin_api_' + 'a'.repeat(40)],
+    invalid: ['lin_api_short', 'lin_api_' + 'a'.repeat(5)],
+  },
+};
+
+describe('CREDENTIAL_PATTERNS', () => {
+  // Parametric: every pattern matches its valid samples
+  for (const pattern of CREDENTIAL_PATTERNS) {
+    const testCase = PATTERN_TEST_CASES[pattern.id];
+    if (!testCase) continue;
+
+    describe(pattern.id, () => {
+      for (const valid of testCase.valid) {
+        it(`matches valid sample: ${valid.substring(0, 40)}...`, () => {
+          expect(pattern.regex.test(valid)).toBe(true);
+        });
+      }
+
+      for (const invalid of testCase.invalid) {
+        it(`rejects invalid sample: ${invalid.substring(0, 40)}...`, () => {
+          expect(pattern.regex.test(invalid)).toBe(false);
+        });
+      }
+    });
+  }
+
+  it('has test cases for every pattern', () => {
+    const missing = CREDENTIAL_PATTERNS.filter(p => !PATTERN_TEST_CASES[p.id]).map(p => p.id);
+    expect(missing).toEqual([]);
+  });
+
+  it('has no duplicate pattern IDs', () => {
+    const ids = CREDENTIAL_PATTERNS.map(p => p.id);
+    const unique = [...new Set(ids)];
+    expect(ids).toEqual(unique);
+  });
+
+  it('orders specific sk- prefixes before openai-legacy catch-all', () => {
+    const ids = CREDENTIAL_PATTERNS.map(p => p.id);
+    const anthropicIdx = ids.indexOf('anthropic');
+    const openaiProjIdx = ids.indexOf('openai-proj');
+    const openrouterIdx = ids.indexOf('openrouter');
+    const openaiLegacyIdx = ids.indexOf('openai-legacy');
+
+    expect(anthropicIdx).toBeLessThan(openaiLegacyIdx);
+    expect(openaiProjIdx).toBeLessThan(openaiLegacyIdx);
+    expect(openrouterIdx).toBeLessThan(openaiLegacyIdx);
+  });
+
+  it('orders stripe-test and stripe-restricted before stripe live', () => {
+    const ids = CREDENTIAL_PATTERNS.map(p => p.id);
+    const stripeTestIdx = ids.indexOf('stripe-test');
+    const stripeRestrictedIdx = ids.indexOf('stripe-restricted');
+    const stripeIdx = ids.indexOf('stripe');
+
+    expect(stripeTestIdx).toBeLessThan(stripeIdx);
+    expect(stripeRestrictedIdx).toBeLessThan(stripeIdx);
+  });
+
+  it('every pattern has a category', () => {
+    const missing = CREDENTIAL_PATTERNS.filter(p => !p.category).map(p => p.id);
+    expect(missing).toEqual([]);
+  });
+
+  it('no regex causes ReDoS on adversarial input (completes within 50ms)', () => {
+    // Adversarial string: repeated characters that could cause backtracking
+    const adversarial = 'a'.repeat(10000);
+    for (const pattern of CREDENTIAL_PATTERNS) {
+      const start = performance.now();
+      pattern.regex.test(adversarial);
+      const elapsed = performance.now() - start;
+      expect(elapsed, `Pattern ${pattern.id} took ${elapsed}ms on adversarial input`).toBeLessThan(50);
+    }
+  });
+});
+
+describe('CREDENTIAL_PREFIX_QUICK_CHECK', () => {
+  it('is a valid RegExp', () => {
+    expect(CREDENTIAL_PREFIX_QUICK_CHECK).toBeInstanceOf(RegExp);
+  });
+
+  it('matches known credential prefixes', () => {
+    expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('sk-ant-api03-xxx')).toBe(true);
+    expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('sk-proj-xxx')).toBe(true);
+    expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('AKIA1234567890123456')).toBe(true);
+    expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('ghp_abc')).toBe(true);
+    expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('xoxb-123')).toBe(true);
+    expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('gsk_abc')).toBe(true);
+    expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('glpat-abc')).toBe(true);
+    expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('npm_abc')).toBe(true);
+  });
+
+  it('does not match random text', () => {
+    expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('hello world')).toBe(false);
+    expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('just some normal text')).toBe(false);
+  });
+});

--- a/packages/credential-patterns/src/patterns.ts
+++ b/packages/credential-patterns/src/patterns.ts
@@ -1,0 +1,210 @@
+/**
+ * @opena2a/credential-patterns — canonical credential regex catalog for OpenA2A tools.
+ *
+ * Pure relocation of secretless-ai's pattern catalog so secretless-ai (PR 2) and
+ * hackmyagent (PR 3) consume one source of truth. Add new patterns here, not in
+ * downstream tools — duplicating regexes was the drift source behind issue #64.
+ *
+ * ORDERING RULE: More specific prefixes (e.g. sk-ant-, sk-proj-, sk-or-v1-)
+ * MUST precede catch-all patterns (e.g. openai-legacy sk-[a-zA-Z0-9]{48,})
+ * because scanners break on first match.
+ */
+
+export interface CredentialPattern {
+  id: string;
+  name: string;
+  regex: RegExp;
+  envPrefix: string;
+  category?: string;
+}
+
+export const CREDENTIAL_PATTERNS: CredentialPattern[] = [
+  // ── AI/ML (category: ai-ml) ──────────────────────────────────────────
+  { id: 'anthropic', name: 'Anthropic API Key', regex: /sk-ant-api\d{2}-[a-zA-Z0-9_-]{20,}/, envPrefix: 'ANTHROPIC_API_KEY', category: 'ai-ml' },
+  { id: 'openai-proj', name: 'OpenAI Project Key', regex: /sk-proj-[a-zA-Z0-9]{20,}/, envPrefix: 'OPENAI_API_KEY', category: 'ai-ml' },
+  { id: 'openrouter', name: 'OpenRouter API Key', regex: /sk-or-v1-[a-zA-Z0-9]{48,}/, envPrefix: 'OPENROUTER_API_KEY', category: 'ai-ml' },
+  { id: 'openai-legacy', name: 'OpenAI Legacy Key', regex: /sk-[a-zA-Z0-9]{48,}/, envPrefix: 'OPENAI_API_KEY', category: 'ai-ml' },
+  { id: 'groq', name: 'Groq API Key', regex: /gsk_[a-zA-Z0-9]{20,}/, envPrefix: 'GROQ_API_KEY', category: 'ai-ml' },
+  { id: 'replicate', name: 'Replicate API Token', regex: /r8_[a-zA-Z0-9]{20,}/, envPrefix: 'REPLICATE_API_TOKEN', category: 'ai-ml' },
+  { id: 'huggingface', name: 'Hugging Face Token', regex: /hf_[a-zA-Z0-9]{20,}/, envPrefix: 'HUGGING_FACE_HUB_TOKEN', category: 'ai-ml' },
+  { id: 'perplexity', name: 'Perplexity API Key', regex: /pplx-[a-zA-Z0-9]{48,}/, envPrefix: 'PERPLEXITY_API_KEY', category: 'ai-ml' },
+  { id: 'fireworks', name: 'Fireworks AI Key', regex: /fw_[a-zA-Z0-9]{20,}/, envPrefix: 'FIREWORKS_API_KEY', category: 'ai-ml' },
+
+  // ── Cloud Providers (category: cloud) ─────────────────────────────────
+  { id: 'aws-access', name: 'AWS Access Key', regex: /AKIA[0-9A-Z]{16}/, envPrefix: 'AWS_ACCESS_KEY_ID', category: 'cloud' },
+  { id: 'aws-sts', name: 'AWS STS Temporary Key', regex: /ASIA[0-9A-Z]{16}/, envPrefix: 'AWS_ACCESS_KEY_ID', category: 'cloud' },
+  { id: 'gcp-service-account', name: 'GCP Service Account JSON', regex: /"type"\s*:\s*"service_account"/, envPrefix: 'GOOGLE_APPLICATION_CREDENTIALS', category: 'cloud' },
+  { id: 'digitalocean', name: 'DigitalOcean PAT', regex: /dop_v1_[a-f0-9]{64}/, envPrefix: 'DIGITALOCEAN_TOKEN', category: 'cloud' },
+  { id: 'heroku', name: 'Heroku API Key', regex: /HRKU-[a-zA-Z0-9_-]{30,}/, envPrefix: 'HEROKU_API_KEY', category: 'cloud' },
+  { id: 'fly-io', name: 'Fly.io Token', regex: /fo1_[a-zA-Z0-9_-]{20,}/, envPrefix: 'FLY_API_TOKEN', category: 'cloud' },
+  { id: 'netlify', name: 'Netlify PAT', regex: /nfp_[a-zA-Z0-9]{40,}/, envPrefix: 'NETLIFY_AUTH_TOKEN', category: 'cloud' },
+  { id: 'azure', name: 'Azure Key', regex: /(?:AccountKey|SharedAccessKey|azure[_-]?(?:storage|key|account))\s*[=:]\s*[a-zA-Z0-9+/]{43}=/i, envPrefix: 'AZURE_API_KEY', category: 'cloud' },
+  { id: 'supabase', name: 'Supabase Service Key', regex: /eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.[a-zA-Z0-9_-]{50,}/, envPrefix: 'SUPABASE_SERVICE_ROLE_KEY', category: 'cloud' },
+
+  // ── Communication (category: communication) ───────────────────────────
+  { id: 'slack', name: 'Slack Token', regex: /xox[baprs]-[0-9]{10,13}-[0-9]{10,13}-[a-zA-Z0-9]{24}/, envPrefix: 'SLACK_TOKEN', category: 'communication' },
+  { id: 'slack-webhook', name: 'Slack Webhook URL', regex: /hooks\.slack\.com\/services\/T[A-Z0-9]{8,}\/B[A-Z0-9]{8,}\/[a-zA-Z0-9]{24}/, envPrefix: 'SLACK_WEBHOOK_URL', category: 'communication' },
+  { id: 'slack-app', name: 'Slack App Token', regex: /xapp-[0-9]+-[A-Z0-9]+-[0-9]+-[a-z0-9]+/, envPrefix: 'SLACK_APP_TOKEN', category: 'communication' },
+  { id: 'telegram-bot', name: 'Telegram Bot Token', regex: /[0-9]{8,10}:[A-Za-z0-9_-]{35}/, envPrefix: 'TELEGRAM_BOT_TOKEN', category: 'communication' },
+  { id: 'discord-bot', name: 'Discord Bot Token', regex: /[MN][A-Za-z\d]{23,}\.[\w-]{6}\.[\w-]{27,}/, envPrefix: 'DISCORD_BOT_TOKEN', category: 'communication' },
+  { id: 'discord-webhook', name: 'Discord Webhook URL', regex: /discord(?:app)?\.com\/api\/webhooks\/[0-9]+\/[A-Za-z0-9_-]+/, envPrefix: 'DISCORD_WEBHOOK_URL', category: 'communication' },
+  { id: 'twilio', name: 'Twilio API Key', regex: /SK[0-9a-fA-F]{32}/, envPrefix: 'TWILIO_API_KEY', category: 'communication' },
+  { id: 'sendgrid', name: 'SendGrid Key', regex: /SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}/, envPrefix: 'SENDGRID_API_KEY', category: 'communication' },
+
+  // ── Developer Platforms (category: developer) ─────────────────────────
+  { id: 'github-pat', name: 'GitHub Token', regex: /ghp_[a-zA-Z0-9]{36}/, envPrefix: 'GITHUB_TOKEN', category: 'developer' },
+  { id: 'github-fine', name: 'GitHub Fine-Grained PAT', regex: /github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}/, envPrefix: 'GITHUB_TOKEN', category: 'developer' },
+  { id: 'github-oauth', name: 'GitHub OAuth Token', regex: /gho_[a-zA-Z0-9]{36}/, envPrefix: 'GITHUB_TOKEN', category: 'developer' },
+  { id: 'github-app', name: 'GitHub App Installation Token', regex: /ghs_[a-zA-Z0-9]{36}/, envPrefix: 'GITHUB_TOKEN', category: 'developer' },
+  { id: 'github-refresh', name: 'GitHub Refresh Token', regex: /ghr_[a-zA-Z0-9]{36,}/, envPrefix: 'GITHUB_TOKEN', category: 'developer' },
+  { id: 'gitlab', name: 'GitLab PAT', regex: /glpat-[a-zA-Z0-9_-]{20,}/, envPrefix: 'GITLAB_TOKEN', category: 'developer' },
+  { id: 'gitlab-pipeline', name: 'GitLab Pipeline Trigger', regex: /glptt-[a-f0-9]{40,}/, envPrefix: 'GITLAB_TOKEN', category: 'developer' },
+  { id: 'gitlab-runner', name: 'GitLab Runner Token', regex: /GR1348941[a-zA-Z0-9_-]{20,}/, envPrefix: 'GITLAB_TOKEN', category: 'developer' },
+  { id: 'npm', name: 'npm Access Token', regex: /npm_[a-zA-Z0-9]{36}/, envPrefix: 'NPM_TOKEN', category: 'developer' },
+  { id: 'pypi', name: 'PyPI API Token', regex: /pypi-[A-Za-z0-9_-]{50,}/, envPrefix: 'PYPI_API_TOKEN', category: 'developer' },
+  { id: 'dockerhub', name: 'Docker Hub PAT', regex: /dckr_pat_[a-zA-Z0-9_-]{20,}/, envPrefix: 'DOCKER_TOKEN', category: 'developer' },
+  { id: 'bitbucket', name: 'Bitbucket App Password', regex: /ATBB[a-zA-Z0-9]{32,}/, envPrefix: 'BITBUCKET_TOKEN', category: 'developer' },
+
+  // ── Payment (category: payment) ───────────────────────────────────────
+  { id: 'stripe-test', name: 'Stripe Test Key', regex: /sk_test_[0-9a-zA-Z]{24,}/, envPrefix: 'STRIPE_SECRET_KEY', category: 'payment' },
+  { id: 'stripe-restricted', name: 'Stripe Restricted Key', regex: /rk_live_[0-9a-zA-Z]{24,}/, envPrefix: 'STRIPE_RESTRICTED_KEY', category: 'payment' },
+  { id: 'stripe', name: 'Stripe Live Key', regex: /sk_live_[0-9a-zA-Z]{24,}/, envPrefix: 'STRIPE_SECRET_KEY', category: 'payment' },
+  { id: 'stripe-webhook', name: 'Stripe Webhook Secret', regex: /whsec_[a-zA-Z0-9]{32,}/, envPrefix: 'STRIPE_WEBHOOK_SECRET', category: 'payment' },
+  { id: 'square', name: 'Square API Key', regex: /sq0[a-z]{3}-[a-zA-Z0-9_-]{22,}/, envPrefix: 'SQUARE_ACCESS_TOKEN', category: 'payment' },
+
+  // ── Database (category: database) ─────────────────────────────────────
+  { id: 'mongodb', name: 'MongoDB Connection String', regex: /mongodb\+srv:\/\/[^\s]{10,}/, envPrefix: 'MONGODB_URI', category: 'database' },
+  { id: 'postgres', name: 'PostgreSQL Connection String', regex: /postgres(?:ql)?:\/\/[^\s]{10,}/, envPrefix: 'DATABASE_URL', category: 'database' },
+  { id: 'mysql', name: 'MySQL Connection String', regex: /mysql:\/\/[^\s]{10,}/, envPrefix: 'DATABASE_URL', category: 'database' },
+  { id: 'redis', name: 'Redis Connection String', regex: /rediss?:\/\/[^\s]{10,}/, envPrefix: 'REDIS_URL', category: 'database' },
+
+  // ── Auth & Crypto (category: auth) ────────────────────────────────────
+  { id: 'google', name: 'Google API Key', regex: /AIza[0-9A-Za-z_-]{35}/, envPrefix: 'GOOGLE_API_KEY', category: 'auth' },
+  { id: 'google-oauth', name: 'Google OAuth Access Token', regex: /ya29\.[a-zA-Z0-9_-]{50,}/, envPrefix: 'GOOGLE_ACCESS_TOKEN', category: 'auth' },
+  { id: 'pem-private-key', name: 'PEM Private Key', regex: /-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/, envPrefix: 'PRIVATE_KEY', category: 'auth' },
+  { id: 'firebase-fcm', name: 'Firebase FCM Server Key', regex: /AAAA[a-zA-Z0-9_-]{7}:[a-zA-Z0-9_-]{140,}/, envPrefix: 'FIREBASE_SERVER_KEY', category: 'auth' },
+
+  // ── Monitoring (category: monitoring) ──────────────────────────────────
+  { id: 'newrelic', name: 'New Relic API Key', regex: /NRAK-[A-Z0-9]{27}/, envPrefix: 'NEW_RELIC_API_KEY', category: 'monitoring' },
+  { id: 'newrelic-insight', name: 'New Relic Insights Key', regex: /NRIQ-[A-Z0-9]{27,}/, envPrefix: 'NEW_RELIC_API_KEY', category: 'monitoring' },
+  { id: 'sentry', name: 'Sentry Auth Token', regex: /sntrys_[a-zA-Z0-9]{40,}/, envPrefix: 'SENTRY_AUTH_TOKEN', category: 'monitoring' },
+  { id: 'grafana', name: 'Grafana Cloud API Key', regex: /glc_[a-zA-Z0-9_+/]{32,}=*/, envPrefix: 'GRAFANA_API_KEY', category: 'monitoring' },
+  { id: 'linear', name: 'Linear API Key', regex: /lin_api_[a-zA-Z0-9]{40,}/, envPrefix: 'LINEAR_API_KEY', category: 'monitoring' },
+];
+
+/**
+ * Quick-check regex: if a line contains ${VAR} but no credential prefix, skip it.
+ * Auto-generated from pattern prefixes so it stays in sync as patterns are added.
+ */
+export const CREDENTIAL_PREFIX_QUICK_CHECK = new RegExp(
+  CREDENTIAL_PATTERNS.map(p => {
+    const src = p.regex.source;
+    // Extract leading literal prefix (up to first quantifier or alternation)
+    const m = src.match(/^([a-zA-Z0-9_\-.+:/]{3,})/);
+    return m ? m[1].replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : null;
+  })
+  .filter(Boolean)
+  // Deduplicate prefixes (e.g. multiple sk- patterns)
+  .filter((v, i, a) => a.indexOf(v) === i)
+  .join('|')
+);
+
+/**
+ * Known example/placeholder credentials used in documentation and tutorials.
+ * These are NOT real secrets and should be excluded from scan results.
+ */
+export const KNOWN_EXAMPLE_KEYS = new Set([
+  // AWS (official docs)
+  'AKIAIOSFODNN7EXAMPLE',
+  'AKIAI44QH8DHBEXAMPLE',
+  // OpenAI (from docs)
+  'sk-proj-abc123',
+]);
+
+/**
+ * Substrings that indicate a credential is a placeholder, not a real secret.
+ * Case-insensitive check against the matched credential value.
+ */
+export const PLACEHOLDER_INDICATORS = [
+  'example', 'placeholder', 'your_', 'your-', 'insert_', 'insert-',
+  'xxx', 'XXXX', 'test_key', 'test_secret', 'fake_', 'fake-',
+  'dummy', 'sample', 'replace_me', 'change_me', 'todo', '<your',
+  'not-a-real', 'not_a_real', 'just-for-testing', 'supabase-demo',
+];
+
+/** File patterns that should never be read by AI tools */
+export const SECRET_FILE_PATTERNS: string[] = [
+  '.env',
+  '.env.local',
+  '.env.development',
+  '.env.production',
+  '.env.staging',
+  '*.key',
+  '*.pem',
+  '*.p12',
+  '*.pfx',
+  '*.crt',
+  '.aws/credentials',
+  '.ssh/*',
+  '.docker/config.json',
+  '.git-credentials',
+  '.npmrc',
+  '.pypirc',
+  '*.tfstate',
+  '*.tfvars',
+  'secrets/',
+  'credentials/',
+  '.opena2a/secretless-ai/',
+];
+
+/** Config files that may contain hardcoded secrets */
+export const CONFIG_FILES = [
+  'config.json', 'config.yaml', 'config.yml',
+  '.env', '.env.local',
+  'package.json', 'mcp.json',
+  'CLAUDE.md',
+  '.openclaw/config.json', '.moltbot/config.json',
+  'openclaw.json', 'moltbot.json',
+  '.curse/mcp.json', '.vscode/mcp.json',
+  '.claude/settings.json',
+  '.cursor/settings.json',
+  '.github/copilot-instructions.md',
+  // Nanobot variants
+  '.nanobot/config.json', 'nanobot.yaml', 'nanobot.yml',
+  // Docker/containers
+  'docker-compose.yml', 'docker-compose.yaml', 'docker-compose.override.yml',
+  // Terraform
+  'terraform.tfvars', 'terraform.tfvars.json',
+  // Other AI tools
+  '.codeium/config.json', '.tabnine/config.json',
+  // Kubernetes
+  'kubeconfig.yaml', '.kube/config',
+];
+
+/** Source file extensions to scan for hardcoded credentials */
+export const SOURCE_FILE_EXTENSIONS = new Set([
+  '.js', '.jsx', '.mjs', '.cjs',
+  '.ts', '.tsx', '.mts', '.cts',
+  '.py',
+  '.go',
+  '.java',
+  '.rb',
+  '.rs',
+  '.cs',
+  '.php',
+  '.swift',
+  '.kt', '.kts',
+  '.scala',
+  '.sh', '.bash', '.zsh',
+]);
+
+/** Directories to skip when walking source files */
+export const SOURCE_SKIP_DIRS = new Set([
+  'node_modules', '.git', '.svn', '.hg',
+  'vendor', 'dist', 'build', 'out', '.next',
+  '__pycache__', '.venv', 'venv', 'env',
+  '.tox', '.mypy_cache', '.pytest_cache',
+  'target', 'bin', 'obj',
+  '.gradle', '.maven',
+  'coverage', '.nyc_output',
+]);

--- a/packages/credential-patterns/tsconfig.json
+++ b/packages/credential-patterns/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Extracts secretless-ai's credential pattern catalog into a new shared package `@opena2a/credential-patterns@0.1.0` so secretless-ai (PR 2) and hackmyagent (PR 3) consume one source of truth instead of carrying parallel inferior copies. Pure relocation — no semantic changes, no consumer changes in this PR.

The drift this fixes: `hackmyagent/src/plugins/credvault.ts` carries ~15 patterns; `secretless/src/patterns.ts` has ~38 (the canonical set). secretless-ai issue #64 (`scan` vs `verify` rule-set drift) traces to this duplication.

## What ships in 0.1.0

- 56 credential regexes across ai-ml, cloud, communication, developer, payment, database, auth, monitoring categories — byte-identical to `secretless/src/patterns.ts`.
- `KNOWN_EXAMPLE_KEYS`, `PLACEHOLDER_INDICATORS` allowlist data.
- `SECRET_FILE_PATTERNS`, `CONFIG_FILES`, `SOURCE_FILE_EXTENSIONS`, `SOURCE_SKIP_DIRS` — file-system scan rules.
- `findRealMatch` / `isKnownExample` — match-with-allowlist helpers lifted from `secretless/src/scan.ts:59-97` so the canonical "skip example, keep real" contract lives with the patterns.
- 187 tests (181 pattern + 6 match-helper). All passing locally.

## Verification — byte-equivalence with secretless

```
new count: 56
old count: 56
diff /tmp/old-patterns.json /tmp/new-patterns.json  →  (no diff)
BYTE-EQUIVALENT ✓
```

Also verified equivalent: `CREDENTIAL_PREFIX_QUICK_CHECK`, `KNOWN_EXAMPLE_KEYS`, `PLACEHOLDER_INDICATORS`, `SECRET_FILE_PATTERNS`, `CONFIG_FILES`, `SOURCE_FILE_EXTENSIONS`, `SOURCE_SKIP_DIRS`. Helper function bodies are byte-equivalent at source level (only diff in compiled output is ESM named imports vs CJS namespaced — pure compiler artifact).

## Adversarial Phase 4.5 review — verdict: SHIP

Detection-logic change → spawned `general-purpose` adversarial subagent per `pre-push-review` SKILL.md Phase 4.5.

- **CRITICAL (detection narrowing):** none. Byte-identical regex array.
- **HIGH (test depth):** none gating PR 1. Boundary-test gaps preexist in secretless source — ~25 patterns where invalid case is `_short` and valid case is the exact lower bound, so an off-by-one quantifier typo (`{20,}` → `{30,}`) would not be caught by tests. **Out of scope for a pure relocation.** Filed for follow-up after PR 2/3 land.
- **LOW (allowlist completeness):** 6 candidate additions to `KNOWN_EXAMPLE_KEYS` (well-known public-doc examples for ghp_, stripe-test, supabase demo, slack-webhook, AIza Maps tutorial key). Will surface as FPs in PR 2/3 kitchen-sink scans; folding into a follow-up keeps PR 1 pure.

## Release plumbing

- `.github/workflows/release.yml`: added `credential-patterns-v*` to tag patterns, added `publish_if_new packages/credential-patterns @opena2a/credential-patterns` to the publish step (idempotent — short-circuits if version already on npm).
- 0.1.0 ships via manual bootstrap — first publish for new `@opena2a/*` packages requires this before TP can take over (per `opena2a_npm_first_publish_bootstrap.md`).
- Trusted Publishing takes over from 0.1.1 with SLSA v1 attestations.

## Consumers

- `secretless-ai 0.17` (PR 2 — separate session) migrates `src/{scan,scan-staged,verify}.ts` to import from this package, with a regression test asserting `CREDENTIAL_PATTERNS.length === 56`.
- `hackmyagent` (PR 3 — separate session) replaces `src/plugins/credvault.ts` and switches `src/plugins/secretless.ts` from runtime `import('secretless-ai')` to a compile-time dep on this package.

Both pin exact: `"@opena2a/credential-patterns": "0.1.0"`. PR 2/3 inherit the full `cli-finding-ux-standard.md` audit on kitchen-sink + tiny-clean-repo corpus before merge.

## Pre-push review — quality gate PASSED

| Phase | Status |
|---|---|
| 1. Sensitive files | PASS |
| 2. Build/test/lint | PASS (187/187 tests, tsc clean, turbo build clean) |
| 3. AI code review | PASS (no findings) |
| 4. HMA static scan | PASS (98/100, 1 LOW informational) |
| 4.5 Adversarial | PASS (verdict: SHIP, zero CRITICAL/HIGH for PR 1 scope) |
| 5. hma-hunter | SKIPPED (library, no API surface) |
| 6. New-user walkthrough | PASS (ESM static + CJS dynamic-import both work) |
| 7. Documentation | PASS |

## Test plan

- [ ] Reviewer: `git fetch origin && git checkout feat/credential-patterns-package && cd packages/credential-patterns && npm test` — expect 187/187 pass.
- [ ] Reviewer: `cd packages/credential-patterns && npx tsc --noEmit` — expect zero errors.
- [ ] Reviewer: smoke the byte-equivalence check by running the JSON diff between `dist/index.js` `CREDENTIAL_PATTERNS` and `secretless/dist/patterns.js` `CREDENTIAL_PATTERNS`.
- [ ] After merge: bootstrap-publish 0.1.0, then configure Trusted Publishing on npmjs.com (org: `opena2a-org`, repo: `opena2a`, workflow: `release.yml`, environment: blank). PR 2/3 follow on separate sessions and consume `0.1.0` with exact pin.
