### PR TITLE
fix(init): UX audit wave 1 (closes #117 #118 #119 #116, audit-bug B)

### DIFF
--- a/packages/cli/__tests__/commands/init.test.ts
+++ b/packages/cli/__tests__/commands/init.test.ts
@@ -21,6 +21,23 @@ function captureStdout(fn: () => Promise<number>): Promise<{ exitCode: number; o
   });
 }
 
+function captureStderr(fn: () => Promise<number>): Promise<{ exitCode: number; stderr: string }> {
+  const chunks: string[] = [];
+  const origWrite = process.stderr.write;
+  process.stderr.write = ((chunk: any) => {
+    chunks.push(String(chunk));
+    return true;
+  }) as any;
+
+  return fn().then(exitCode => {
+    process.stderr.write = origWrite;
+    return { exitCode, stderr: chunks.join('') };
+  }).catch(err => {
+    process.stderr.write = origWrite;
+    throw err;
+  });
+}
+
 describe('init', () => {
   let tempDir: string;
 
@@ -434,6 +451,33 @@ describe('init', () => {
     expect(output).not.toContain('recoverable');
     // Should contain deduction indicators
     expect(output).toContain('Recommendations');
+  });
+
+  // Regression: audit-wave-1 bug B — ENOENT must print Next Steps with
+  // discoverable usage. Bare "Directory not found" was a CISO Rule 1 dead
+  // end. JSON mode emits a structured error object so CI consumers can
+  // distinguish ENOENT from valid-zero-finding states.
+  it('text-mode ENOENT prints Next Steps with --help reference (audit B)', async () => {
+    const { stderr, exitCode } = await captureStderr(() => init({
+      targetDir: '/tmp/opena2a-init-enoent-' + Date.now(),
+    }));
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('Directory not found');
+    expect(stderr).toContain('Next steps');
+    expect(stderr).toContain('opena2a init --help');
+  });
+
+  it('json-mode ENOENT emits structured error object (audit B)', async () => {
+    const missing = '/tmp/opena2a-init-enoent-json-' + Date.now();
+    const { output, exitCode } = await captureStdout(() => init({
+      targetDir: missing,
+      format: 'json',
+    }));
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(output);
+    expect(parsed.error).toBe('directory-not-found');
+    expect(parsed.directory).toBe(missing);
+    expect(parsed.message).toContain('Directory not found');
   });
 
   // Regression: opena2a/issues/119 — JSON findings must carry the same

--- a/packages/cli/__tests__/commands/init.test.ts
+++ b/packages/cli/__tests__/commands/init.test.ts
@@ -436,6 +436,42 @@ describe('init', () => {
     expect(output).toContain('Recommendations');
   });
 
+  // Regression: opena2a/issues/119 — JSON findings must carry the same
+  // verify / fix / locations the text view prints. CI gates and IDE
+  // plugins parse the JSON; missing fields force them to re-run scanners.
+  it('JSON findings populate verify, fix, and locations (#119)', async () => {
+    fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'test' }));
+    fs.writeFileSync(path.join(tempDir, '.gitignore'), '.env\n');
+    fs.writeFileSync(path.join(tempDir, 'mcp.json'), JSON.stringify({
+      mcpServers: {
+        'fs': { command: 'filesystem-server', args: [] },
+      },
+    }));
+    const fakeKey = 'sk-ant-api03-' + 'P'.repeat(85);
+    fs.writeFileSync(path.join(tempDir, 'config.ts'), `const k = "${fakeKey}";`);
+
+    const { output } = await captureStdout(() => init({
+      targetDir: tempDir,
+      format: 'json',
+    }));
+
+    const report = JSON.parse(output);
+    const credFinding = report.findings.find((f: any) => f.findingId.startsWith('CRED-'));
+    expect(credFinding).toBeDefined();
+    expect(typeof credFinding.verify).toBe('string');
+    expect(credFinding.verify.length).toBeGreaterThan(0);
+    expect(credFinding.fix).toBe('opena2a protect');
+    expect(credFinding.locations.length).toBeGreaterThan(0);
+    expect(credFinding.locations[0]).toMatchObject({ file: expect.any(String), line: expect.any(Number) });
+
+    const mcpFinding = report.findings.find((f: any) => f.findingId === 'MCP-TOOLS');
+    expect(mcpFinding).toBeDefined();
+    expect(mcpFinding.verify).toContain('mcp.json');
+    expect(mcpFinding.fix).toBe('opena2a shield init');
+    expect(mcpFinding.locations.length).toBeGreaterThan(0);
+    expect(mcpFinding.locations[0].file.endsWith('mcp.json')).toBe(true);
+  });
+
   // Regression: opena2a/issues/117 — Fix commands must point to runnable
   // mutations, never to status/read-only commands. `opena2a shield status`
   // is read-only and creates a dead-end UX (CISO Rule 3 violation).

--- a/packages/cli/__tests__/commands/init.test.ts
+++ b/packages/cli/__tests__/commands/init.test.ts
@@ -435,4 +435,28 @@ describe('init', () => {
     // Should contain deduction indicators
     expect(output).toContain('Recommendations');
   });
+
+  // Regression: opena2a/issues/117 — Fix commands must point to runnable
+  // mutations, never to status/read-only commands. `opena2a shield status`
+  // is read-only and creates a dead-end UX (CISO Rule 3 violation).
+  it('action commands never point to read-only status commands (#117)', async () => {
+    fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'test' }));
+    fs.writeFileSync(path.join(tempDir, '.gitignore'), '.env\n');
+    fs.writeFileSync(path.join(tempDir, 'mcp.json'), JSON.stringify({
+      mcpServers: {
+        'fs': { command: 'filesystem-server', args: [] },
+      },
+    }));
+
+    const { output } = await captureStdout(() => init({
+      targetDir: tempDir,
+      format: 'json',
+    }));
+
+    const report = JSON.parse(output);
+    for (const action of report.actions) {
+      expect(action.command).not.toBe('opena2a shield status');
+      expect(action.command).not.toMatch(/\bstatus\s*$/);
+    }
+  });
 });

--- a/packages/cli/__tests__/commands/init.test.ts
+++ b/packages/cli/__tests__/commands/init.test.ts
@@ -394,8 +394,9 @@ describe('init', () => {
     }));
 
     const report = JSON.parse(output);
-    // MCP-TOOLS adds 5 to environment deduction
-    expect(report.scoreBreakdown.environment.deduction).toBeGreaterThanOrEqual(5);
+    // Per #116: MCP-TOOLS now scales by server count (-3 per server,
+    // sub-cap -15). Single-server fixture deducts 3, not 5.
+    expect(report.scoreBreakdown.environment.deduction).toBeGreaterThanOrEqual(3);
     expect(report.scoreBreakdown.environment.detail).toContain('MCP');
   });
 
@@ -480,6 +481,140 @@ describe('init', () => {
     expect(parsed.message).toContain('Directory not found');
   });
 
+  // Regression: opena2a/issues/116 — `init` was scoring kitchen-sink-class
+  // malicious projects at 96/100 because the quick-scan path did not detect
+  // private-key files in source. The fix adds .key/.pem detection and
+  // surfaces them as CRITICAL credential findings.
+  it('detects .key/.pem private-key files as CRITICAL credentials (#116)', async () => {
+    fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'test' }));
+    fs.writeFileSync(path.join(tempDir, '.gitignore'), '.env\n');
+    fs.writeFileSync(path.join(tempDir, 'fake-private.key'), '-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----');
+    fs.writeFileSync(path.join(tempDir, 'fake-cert.pem'), '-----BEGIN CERTIFICATE-----');
+
+    const { output } = await captureStdout(() => init({
+      targetDir: tempDir,
+      format: 'json',
+    }));
+
+    const report = JSON.parse(output);
+    expect(report.credentialsBySeverity.critical).toBeGreaterThanOrEqual(2);
+    const keyFinding = report.findings.find((f: any) => f.findingId === 'CRED-KEYFILE');
+    expect(keyFinding).toBeDefined();
+    expect(keyFinding.severity).toBe('critical');
+    // Score must drop materially below the pre-#116 baseline of 96/100 for
+    // a project carrying .key + .pem in its root.
+    expect(report.securityScore).toBeLessThan(70);
+  });
+
+  it('scales MCP-tools deduction by server count across multiple configs (#116)', async () => {
+    fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'test' }));
+    fs.writeFileSync(path.join(tempDir, '.gitignore'), '.env\n');
+    fs.writeFileSync(path.join(tempDir, 'package-lock.json'), '{}');
+    fs.writeFileSync(path.join(tempDir, 'mcp.json'), JSON.stringify({
+      mcpServers: {
+        'a': { command: 'filesystem-server' },
+        'b': { command: 'filesystem-server' },
+        'c': { command: 'filesystem-server' },
+        'd': { command: 'filesystem-server' },
+      },
+    }));
+    fs.mkdirSync(path.join(tempDir, '.cursor'));
+    fs.writeFileSync(path.join(tempDir, '.cursor', 'mcp.json'), JSON.stringify({
+      mcpServers: {
+        'e': { command: 'filesystem-server' },
+      },
+    }));
+
+    const { output } = await captureStdout(() => init({
+      targetDir: tempDir,
+      format: 'json',
+    }));
+
+    const report = JSON.parse(output);
+    expect(report.scoreBreakdown.environment.detail).toContain('5 server');
+    // 5 servers × -3 = -15 to environment, plus the score must reflect
+    // that this is a high-impact MCP surface (well below the
+    // single-server baseline).
+    expect(report.scoreBreakdown.environment.deduction).toBeGreaterThanOrEqual(15);
+  });
+
+  it('surfaces unsigned skill files as a discrete AI-SKILLS finding (#116)', async () => {
+    fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'test' }));
+    fs.writeFileSync(path.join(tempDir, '.gitignore'), '.env\n');
+    fs.writeFileSync(path.join(tempDir, 'SKILL.md'), '# unsigned skill');
+    fs.writeFileSync(path.join(tempDir, 'extra.skill.md'), '# unsigned skill');
+
+    const { output } = await captureStdout(() => init({
+      targetDir: tempDir,
+      format: 'json',
+    }));
+
+    const report = JSON.parse(output);
+    const skillFinding = report.findings.find((f: any) => f.findingId === 'AI-SKILLS');
+    expect(skillFinding).toBeDefined();
+    expect(skillFinding.severity).toBe('medium');
+    expect(skillFinding.locations.length).toBeGreaterThan(0);
+  });
+
+  it('benign + buggy + malicious-shaped fixtures keep monotonic score order (#116)', async () => {
+    // Benign: lock file + security config + .gitignore + nothing else
+    const benignDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opena2a-benign-'));
+    try {
+      fs.writeFileSync(path.join(benignDir, 'package.json'), JSON.stringify({ name: 'b' }));
+      fs.writeFileSync(path.join(benignDir, '.gitignore'), '.env\nnode_modules\n');
+      fs.writeFileSync(path.join(benignDir, 'package-lock.json'), '{}');
+      fs.mkdirSync(path.join(benignDir, '.opena2a'), { recursive: true });
+      fs.mkdirSync(path.join(benignDir, '.opena2a', 'guard'), { recursive: true });
+      fs.writeFileSync(path.join(benignDir, '.opena2a', 'guard', 'signatures.json'), '{}');
+
+      const { output: benignOut } = await captureStdout(() => init({ targetDir: benignDir, format: 'json' }));
+      const benign = JSON.parse(benignOut);
+
+      // Buggy: 1 hardcoded credential in .env.example
+      const buggyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opena2a-buggy-'));
+      fs.writeFileSync(path.join(buggyDir, 'package.json'), JSON.stringify({ name: 'bg' }));
+      fs.writeFileSync(path.join(buggyDir, '.gitignore'), '.env\n');
+      const fakeKey = 'sk-ant-api03-' + 'Q'.repeat(85);
+      fs.writeFileSync(path.join(buggyDir, '.env.example'), `KEY=${fakeKey}\n`);
+
+      const { output: buggyOut } = await captureStdout(() => init({ targetDir: buggyDir, format: 'json' }));
+      const buggy = JSON.parse(buggyOut);
+
+      // Malicious: private key + 4-server MCP + unsigned skill
+      const malDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opena2a-mal-'));
+      fs.writeFileSync(path.join(malDir, 'package.json'), JSON.stringify({ name: 'm' }));
+      fs.writeFileSync(path.join(malDir, '.gitignore'), '.env\n');
+      fs.writeFileSync(path.join(malDir, 'fake-private.key'), '-----BEGIN PRIVATE KEY-----\nFAKE');
+      fs.writeFileSync(path.join(malDir, 'fake-cert.pem'), '-----BEGIN CERTIFICATE-----');
+      fs.writeFileSync(path.join(malDir, 'mcp.json'), JSON.stringify({
+        mcpServers: {
+          'a': { command: 'filesystem-server' },
+          'b': { command: 'filesystem-server' },
+          'c': { command: 'filesystem-server' },
+          'd': { command: 'filesystem-server' },
+        },
+      }));
+      fs.writeFileSync(path.join(malDir, 'SKILL.md'), '# unsigned');
+
+      const { output: malOut } = await captureStdout(() => init({ targetDir: malDir, format: 'json' }));
+      const mal = JSON.parse(malOut);
+
+      // Monotonicity: benign > buggy > malicious. With band assertions:
+      expect(benign.securityScore).toBeGreaterThan(buggy.securityScore);
+      expect(buggy.securityScore).toBeGreaterThan(mal.securityScore);
+      expect(benign.securityScore).toBeGreaterThanOrEqual(80);
+      expect(buggy.securityScore).toBeGreaterThanOrEqual(50);
+      expect(buggy.securityScore).toBeLessThanOrEqual(80);
+      // Malicious must drop below 60 (pre-#116 it was 96/100).
+      expect(mal.securityScore).toBeLessThan(60);
+
+      fs.rmSync(buggyDir, { recursive: true, force: true });
+      fs.rmSync(malDir, { recursive: true, force: true });
+    } finally {
+      fs.rmSync(benignDir, { recursive: true, force: true });
+    }
+  });
+
   // Regression: opena2a/issues/119 — JSON findings must carry the same
   // verify / fix / locations the text view prints. CI gates and IDE
   // plugins parse the JSON; missing fields force them to re-run scanners.
@@ -493,6 +628,10 @@ describe('init', () => {
     }));
     const fakeKey = 'sk-ant-api03-' + 'P'.repeat(85);
     fs.writeFileSync(path.join(tempDir, 'config.ts'), `const k = "${fakeKey}";`);
+    // Add a key file so we can also assert CRED-KEYFILE carries a non-
+    // misleading fix command (Phase 4.5 follow-up: pre-fix this routed
+    // to `opena2a protect` which silently no-ops on binary key files).
+    fs.writeFileSync(path.join(tempDir, 'leak.key'), '-----BEGIN PRIVATE KEY-----\nFAKE');
 
     const { output } = await captureStdout(() => init({
       targetDir: tempDir,
@@ -500,13 +639,21 @@ describe('init', () => {
     }));
 
     const report = JSON.parse(output);
-    const credFinding = report.findings.find((f: any) => f.findingId.startsWith('CRED-'));
-    expect(credFinding).toBeDefined();
-    expect(typeof credFinding.verify).toBe('string');
-    expect(credFinding.verify.length).toBeGreaterThan(0);
-    expect(credFinding.fix).toBe('opena2a protect');
-    expect(credFinding.locations.length).toBeGreaterThan(0);
-    expect(credFinding.locations[0]).toMatchObject({ file: expect.any(String), line: expect.any(Number) });
+    const textCred = report.findings.find((f: any) => f.findingId === 'CRED-001');
+    expect(textCred).toBeDefined();
+    expect(typeof textCred.verify).toBe('string');
+    expect(textCred.verify.length).toBeGreaterThan(0);
+    expect(textCred.fix).toBe('opena2a protect');
+    expect(textCred.locations.length).toBeGreaterThan(0);
+    expect(textCred.locations[0]).toMatchObject({ file: expect.any(String), line: expect.any(Number) });
+
+    const keyfile = report.findings.find((f: any) => f.findingId === 'CRED-KEYFILE');
+    expect(keyfile).toBeDefined();
+    // Critical: CRED-KEYFILE must NOT route to plain `opena2a protect`,
+    // which silently no-ops on binary key files. The fix command must
+    // mention `git rm` so the user has an actionable next step.
+    expect(keyfile.fix).not.toBe('opena2a protect');
+    expect(keyfile.fix).toContain('git rm');
 
     const mcpFinding = report.findings.find((f: any) => f.findingId === 'MCP-TOOLS');
     expect(mcpFinding).toBeDefined();
@@ -514,6 +661,44 @@ describe('init', () => {
     expect(mcpFinding.fix).toBe('opena2a shield init');
     expect(mcpFinding.locations.length).toBeGreaterThan(0);
     expect(mcpFinding.locations[0].file.endsWith('mcp.json')).toBe(true);
+  });
+
+  // Phase 4.5 follow-up: a single MEDIUM `.crt` finding alone must NOT
+  // co-exist with a 100/100 score and a "+5 security config" bonus.
+  // Pre-fix `hasHighImpact` only checked critCount/highCount.
+  it('MEDIUM CRED-CERTFILE alone suppresses the security-config bonus (#116/Phase4.5)', async () => {
+    fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'test' }));
+    fs.writeFileSync(path.join(tempDir, '.gitignore'), '.env\n');
+    fs.writeFileSync(path.join(tempDir, 'package-lock.json'), '{}');
+    fs.mkdirSync(path.join(tempDir, '.opena2a', 'guard'), { recursive: true });
+    fs.writeFileSync(path.join(tempDir, '.opena2a', 'guard', 'signatures.json'), '{}');
+    fs.writeFileSync(path.join(tempDir, 'leaf.crt'), '-----BEGIN CERTIFICATE-----');
+
+    const { output } = await captureStdout(() => init({
+      targetDir: tempDir,
+      format: 'json',
+    }));
+
+    const report = JSON.parse(output);
+    expect(report.securityScore).toBeLessThan(100);
+    const certFinding = report.findings.find((f: any) => f.findingId === 'CRED-CERTFILE');
+    expect(certFinding).toBeDefined();
+    expect(certFinding.severity).toBe('medium');
+  });
+
+  // Phase 4.5 follow-up: assert the real corpus is checked when present
+  // so monotonicity isn't only validated on synthetic shapes.
+  const corpusKitchenSink = path.join(os.homedir(), 'workspace', 'opena2a-org', 'opena2a-corpus', 'repo', 'malicious', 'kitchen-sink');
+  const corpusBenign = path.join(os.homedir(), 'workspace', 'opena2a-org', 'opena2a-corpus', 'repo', 'benign', 'tiny-clean-repo');
+  const hasCorpus = fs.existsSync(corpusKitchenSink) && fs.existsSync(corpusBenign);
+  it.skipIf(!hasCorpus)('real corpus: malicious < buggy ceiling, benign within band (#116)', async () => {
+    const { output: malOut } = await captureStdout(() => init({ targetDir: corpusKitchenSink, format: 'json' }));
+    const mal = JSON.parse(malOut);
+    expect(mal.securityScore).toBeLessThan(60); // pre-#116 was 96
+    const { output: benignOut } = await captureStdout(() => init({ targetDir: corpusBenign, format: 'json' }));
+    const benign = JSON.parse(benignOut);
+    expect(benign.securityScore).toBeGreaterThan(mal.securityScore);
+    expect(benign.securityScore).toBeGreaterThanOrEqual(80);
   });
 
   // Regression: opena2a/issues/117 — Fix commands must point to runnable

--- a/packages/cli/__tests__/commands/security-score.test.ts
+++ b/packages/cli/__tests__/commands/security-score.test.ts
@@ -21,11 +21,14 @@ describe('calculateSecurityScore', () => {
     const { score: score2 } = calculateSecurityScore({ critical: 2 }, cleanChecks);
     const { score: score3 } = calculateSecurityScore({ critical: 5 }, cleanChecks);
 
-    // First critical = -20, each subsequent = -8
-    expect(score1).toBe(100 - 20 + 5); // 85 (with +5 config bonus)
-    expect(score2).toBe(100 - 20 - 8 + 5); // 77
+    // First critical = -20, each subsequent = -8.
+    // Per #116: security-config bonus is suppressed when CRITICAL
+    // findings exist (a signed signatures.json doesn't compensate).
+    // Pre-#116 these returned 85 / 77 / 61 with the +5 bonus.
+    expect(score1).toBe(100 - 20); // 80
+    expect(score2).toBe(100 - 20 - 8); // 72
     // 5 critical: 20 + 4*8 = 52, but cap additional at 24, so 20+24=44
-    expect(score3).toBe(100 - 44 + 5); // 61
+    expect(score3).toBe(100 - 44); // 56
   });
 
   it('caps credential deduction at 60', () => {
@@ -124,14 +127,28 @@ describe('calculateSecurityScore', () => {
     expect(b.breakdown.configuration.detail).not.toContain('.gitignore');
   });
 
-  it('includes MCP high-risk tools in environment deduction (+5)', () => {
+  it('includes MCP high-risk tools in environment deduction (-3 per server, post-#116)', () => {
     const checksWithMcp = [
       ...cleanChecks,
       { label: 'MCP high-risk tools', status: 'warn' as const, detail: '1 server with filesystem access' },
     ];
     const { breakdown } = calculateSecurityScore({}, checksWithMcp);
-    expect(breakdown.environment.deduction).toBeGreaterThanOrEqual(5);
+    // Pre-#116 was a flat -5 regardless of server count. Post-#116 the
+    // per-server scale is -3 with a sub-cap of -15.
+    expect(breakdown.environment.deduction).toBeGreaterThanOrEqual(3);
     expect(breakdown.environment.detail).toContain('MCP high-risk tools');
+  });
+
+  it('scales MCP-tools deduction by server count across multiple configs (#116)', () => {
+    const checksMultiMcp = [
+      ...cleanChecks,
+      { label: 'MCP high-risk tools', status: 'warn' as const, detail: '4 servers with filesystem/shell access in mcp.json' },
+      { label: 'MCP high-risk tools', status: 'warn' as const, detail: '1 server with filesystem/shell access in .cursor/mcp.json' },
+    ];
+    const { breakdown } = calculateSecurityScore({}, checksMultiMcp);
+    // 5 servers × 3 = 15 (sub-cap of 15)
+    expect(breakdown.environment.deduction).toBeGreaterThanOrEqual(15);
+    expect(breakdown.environment.detail).toContain('5 server');
   });
 
   it('includes MCP credentials in environment deduction (+5)', () => {
@@ -154,7 +171,7 @@ describe('calculateSecurityScore', () => {
     expect(breakdown.environment.detail).toContain('AI config exposed');
   });
 
-  it('caps environment at 25 even with MCP + AI + LLM + env issues', () => {
+  it('caps environment at 30 even with MCP + AI + LLM + env + skill + soul issues (#116)', () => {
     const heavyChecks = [
       { label: 'Credential scan', status: 'pass' as const, detail: 'no findings' },
       { label: '.gitignore', status: 'pass' as const, detail: 'present' },
@@ -162,11 +179,29 @@ describe('calculateSecurityScore', () => {
       { label: 'Lock file', status: 'pass' as const, detail: 'package-lock.json' },
       { label: 'Security config', status: 'pass' as const, detail: '.opena2a.yaml' },
       { label: 'LLM server exposure', status: 'warn' as const, detail: 'Ollama on :11434' },
-      { label: 'MCP high-risk tools', status: 'warn' as const, detail: '1 server' },
+      { label: 'MCP high-risk tools', status: 'warn' as const, detail: '5 servers' },
       { label: 'MCP credentials', status: 'warn' as const, detail: 'hardcoded' },
       { label: 'AI config exposure', status: 'warn' as const, detail: '3 files' },
+      { label: 'Skill files', status: 'warn' as const, detail: '4 unsigned' },
+      { label: 'Soul file', status: 'warn' as const, detail: 'override patterns' },
     ];
     const { breakdown } = calculateSecurityScore({}, heavyChecks);
-    expect(breakdown.environment.deduction).toBeLessThanOrEqual(25);
+    expect(breakdown.environment.deduction).toBeLessThanOrEqual(30);
+  });
+
+  it('suppresses security-config bonus when CRITICAL/HIGH findings exist (#116)', () => {
+    const cleanChecks = [
+      { label: 'Credential scan', status: 'pass' as const, detail: 'no findings' },
+      { label: '.gitignore', status: 'pass' as const, detail: 'present' },
+      { label: '.env protection', status: 'pass' as const, detail: 'in .gitignore' },
+      { label: 'Lock file', status: 'pass' as const, detail: 'package-lock.json' },
+      { label: 'Security config', status: 'pass' as const, detail: '.opena2a/guard/signatures.json' },
+    ];
+    const { score: scoreWithBonus } = calculateSecurityScore({}, cleanChecks);
+    expect(scoreWithBonus).toBe(100);
+
+    // With a CRITICAL credential, the +5 bonus must NOT apply.
+    const { score: scoreWithCrit } = calculateSecurityScore({ critical: 1 }, cleanChecks);
+    expect(scoreWithCrit).toBe(80); // 100 - 20, no bonus
   });
 });

--- a/packages/cli/__tests__/util/canonical.test.ts
+++ b/packages/cli/__tests__/util/canonical.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { HMA_CHECK_COUNT, CANONICAL_NUMBERS_REVISION } from '../../src/util/canonical';
+
+const SRC_ROOT = path.resolve(__dirname, '..', '..', 'src');
+
+function listTsFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules') continue;
+      listTsFiles(full, out);
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('canonical numbers (#118)', () => {
+  it('exposes HMA_CHECK_COUNT and a revision marker', () => {
+    expect(typeof HMA_CHECK_COUNT).toBe('number');
+    expect(HMA_CHECK_COUNT).toBeGreaterThan(0);
+    expect(typeof CANONICAL_NUMBERS_REVISION).toBe('number');
+  });
+
+  it('mirrors hmaChecks.value from the website canonical-numbers.json when accessible', () => {
+    const candidates = [
+      path.resolve(__dirname, '..', '..', '..', '..', '..', 'opena2a-website', 'data', 'canonical-numbers.json'),
+      path.resolve(__dirname, '..', '..', '..', '..', '..', '..', 'opena2a-website', 'data', 'canonical-numbers.json'),
+    ];
+    const found = candidates.find(p => fs.existsSync(p));
+    if (!found) {
+      // Sibling repo not checked out (CI clone, npm install) — skip.
+      return;
+    }
+    const data = JSON.parse(fs.readFileSync(found, 'utf-8'));
+    const websiteValue = data?.hmaChecks?.value;
+    if (typeof websiteValue !== 'number') return;
+    expect(HMA_CHECK_COUNT).toBe(websiteValue);
+  });
+
+  it('no source file embeds the prior or current literal as a check-count copy (must use HMA_CHECK_COUNT)', () => {
+    const files = listTsFiles(SRC_ROOT);
+    const offenders: { file: string; line: number; text: string }[] = [];
+    // Match copy that pairs a number with the word "checks" so unrelated
+    // literals (CSS rgba, severity counts, port numbers) don't false-positive.
+    const copyRegex = /\b(?:209|238|240)\s+(?:security\s+)?checks?\b/i;
+    for (const file of files) {
+      // The constants module itself is allowed to declare the number.
+      if (file.endsWith(path.join('src', 'util', 'canonical.ts'))) continue;
+      const lines = fs.readFileSync(file, 'utf-8').split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (copyRegex.test(lines[i])) {
+          offenders.push({ file: path.relative(SRC_ROOT, file), line: i + 1, text: lines[i].trim() });
+        }
+      }
+    }
+    expect(offenders, `Hardcoded check-count copy found. Use HMA_CHECK_COUNT from util/canonical.ts:\n${offenders.map(o => `${o.file}:${o.line}  ${o.text}`).join('\n')}`).toEqual([]);
+  });
+});

--- a/packages/cli/__tests__/util/crypto-key-files.test.ts
+++ b/packages/cli/__tests__/util/crypto-key-files.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { scanCryptoKeyFiles } from '../../src/util/crypto-key-files.js';
+
+describe('scanCryptoKeyFiles (#116)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opena2a-keyfiles-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('flags .key files as CRITICAL CRED-KEYFILE', () => {
+    fs.writeFileSync(path.join(dir, 'fake-private.key'), '-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----');
+    const matches = scanCryptoKeyFiles(dir);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].severity).toBe('critical');
+    expect(matches[0].findingId).toBe('CRED-KEYFILE');
+    expect(matches[0].title).toContain('Private key');
+  });
+
+  it('flags .pem files as CRITICAL', () => {
+    fs.writeFileSync(path.join(dir, 'fake-cert.pem'), '-----BEGIN CERTIFICATE-----');
+    const matches = scanCryptoKeyFiles(dir);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].severity).toBe('critical');
+  });
+
+  it('flags .p12 and .pfx as CRITICAL', () => {
+    fs.writeFileSync(path.join(dir, 'store.p12'), '');
+    fs.writeFileSync(path.join(dir, 'store.pfx'), '');
+    const matches = scanCryptoKeyFiles(dir);
+    expect(matches).toHaveLength(2);
+    expect(matches.every(m => m.severity === 'critical')).toBe(true);
+  });
+
+  it('flags .crt and .cer as MEDIUM CRED-CERTFILE (public certs are not secrets)', () => {
+    fs.writeFileSync(path.join(dir, 'public.crt'), '-----BEGIN CERTIFICATE-----');
+    fs.writeFileSync(path.join(dir, 'chain.cer'), '-----BEGIN CERTIFICATE-----');
+    const matches = scanCryptoKeyFiles(dir);
+    expect(matches).toHaveLength(2);
+    expect(matches.every(m => m.severity === 'medium')).toBe(true);
+    expect(matches.every(m => m.findingId === 'CRED-CERTFILE')).toBe(true);
+  });
+
+  it('ignores files without key/cert extensions', () => {
+    fs.writeFileSync(path.join(dir, 'README.md'), '# hi');
+    fs.writeFileSync(path.join(dir, 'src.ts'), 'export {}');
+    const matches = scanCryptoKeyFiles(dir);
+    expect(matches).toHaveLength(0);
+  });
+
+  it('does not descend into node_modules / dist / .git', () => {
+    fs.mkdirSync(path.join(dir, 'node_modules'));
+    fs.writeFileSync(path.join(dir, 'node_modules', 'leaked.key'), 'x');
+    fs.mkdirSync(path.join(dir, '.git'));
+    fs.writeFileSync(path.join(dir, '.git', 'leaked.pem'), 'x');
+    const matches = scanCryptoKeyFiles(dir);
+    expect(matches).toHaveLength(0);
+  });
+
+  it('descends into normal subdirectories', () => {
+    fs.mkdirSync(path.join(dir, 'certs'));
+    fs.writeFileSync(path.join(dir, 'certs', 'leaf.key'), '');
+    const matches = scanCryptoKeyFiles(dir);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].filePath.endsWith('leaf.key')).toBe(true);
+  });
+
+  it('attaches a clear explanation, businessImpact, and line=1', () => {
+    fs.writeFileSync(path.join(dir, 'a.key'), 'x');
+    const [m] = scanCryptoKeyFiles(dir);
+    expect(m.line).toBe(1);
+    expect(typeof m.explanation).toBe('string');
+    expect(m.explanation!.length).toBeGreaterThan(20);
+    expect(typeof m.businessImpact).toBe('string');
+    expect(m.businessImpact!.length).toBeGreaterThan(20);
+  });
+});

--- a/packages/cli/__tests__/util/scoring.test.ts
+++ b/packages/cli/__tests__/util/scoring.test.ts
@@ -24,8 +24,12 @@ describe('calculateSecurityScore (shared module)', () => {
   it('applies diminishing returns for critical findings', () => {
     const { score: s1 } = calculateSecurityScore({ critical: 1 }, cleanChecks);
     const { score: s2 } = calculateSecurityScore({ critical: 2 }, cleanChecks);
-    expect(s1).toBe(85); // 100 - 20 + 5
-    expect(s2).toBe(77); // 100 - 20 - 8 + 5
+    // Per #116: security-config bonus is suppressed when CRITICAL/HIGH
+    // findings exist (a signed signatures.json doesn't compensate for a
+    // private key in source). Pre-#116 these returned 85 and 77 with
+    // a +5 bonus included.
+    expect(s1).toBe(80); // 100 - 20
+    expect(s2).toBe(72); // 100 - 20 - 8
   });
 
   it('caps credential deduction at 60', () => {
@@ -36,7 +40,7 @@ describe('calculateSecurityScore (shared module)', () => {
     expect(breakdown.credentials.deduction).toBeLessThanOrEqual(60);
   });
 
-  it('caps environment deduction at 25', () => {
+  it('caps environment deduction at 30 (was 25 pre-#116)', () => {
     const heavy: HygieneCheck[] = [
       ...cleanChecks.filter(c => c.label !== '.env protection'),
       { label: '.env protection', status: 'warn', detail: 'NOT in .gitignore' },
@@ -44,9 +48,11 @@ describe('calculateSecurityScore (shared module)', () => {
       { label: 'MCP high-risk tools', status: 'warn', detail: '1 server' },
       { label: 'MCP credentials', status: 'warn', detail: 'hardcoded' },
       { label: 'AI config exposure', status: 'warn', detail: '3 files' },
+      { label: 'Skill files', status: 'warn', detail: '5 unsigned skill files' },
+      { label: 'Soul file', status: 'warn', detail: 'override patterns' },
     ];
     const { breakdown } = calculateSecurityScore({}, heavy);
-    expect(breakdown.environment.deduction).toBeLessThanOrEqual(25);
+    expect(breakdown.environment.deduction).toBeLessThanOrEqual(30);
   });
 
   it('score never goes below 0 or above 100', () => {

--- a/packages/cli/__tests__/util/scoring.test.ts
+++ b/packages/cli/__tests__/util/scoring.test.ts
@@ -89,3 +89,43 @@ describe('formatCredCount', () => {
     expect(formatCredCount(0, 0, 3, 1)).toBe('3 medium, 1 low');
   });
 });
+
+// Regression: the security-config +5 bonus must suppress on ANY user-visible
+// finding, not just CRED-*/HMA on the credential side. Pre-fix, a project
+// with only HMA findings — or only `.env unprotected`, or only AI-config
+// exposure — would still receive the bonus and render "strong" 95+.
+describe('configuration bonus suppression covers all live-warn surfaces', () => {
+  const cleanChecks: HygieneCheck[] = [
+    { label: 'Credential scan', status: 'pass', detail: 'no findings' },
+    { label: '.gitignore', status: 'pass', detail: 'present' },
+    { label: '.env protection', status: 'pass', detail: 'in .gitignore' },
+    { label: 'Lock file', status: 'pass', detail: 'package-lock.json' },
+    { label: 'Security config', status: 'pass', detail: '.opena2a.yaml' },
+  ];
+
+  it('HMA criticals alone suppress the security-config bonus', () => {
+    const { breakdown } = calculateSecurityScore({ critical: 3 }, cleanChecks);
+    // configBonus = 0 because hasHighImpact is true via hmaFindingCount > 0.
+    // breakdown.configuration.deduction is (deduction - configBonus). With
+    // clean config (Lock pass + secConfig pass) raw deduction is 0; subtract
+    // configBonus=0 → 0. Pre-fix this was -5 (the bonus applied).
+    expect(breakdown.configuration.deduction).toBe(0);
+  });
+
+  it('.env unprotected alone suppresses the security-config bonus', () => {
+    const envWarnChecks: HygieneCheck[] = cleanChecks.map(c =>
+      c.label === '.env protection' ? { ...c, status: 'warn', detail: 'not in .gitignore' } : c,
+    );
+    const { breakdown } = calculateSecurityScore({}, envWarnChecks);
+    expect(breakdown.configuration.deduction).toBe(0);
+  });
+
+  it('AI config exposure alone suppresses the security-config bonus', () => {
+    const aiConfigWarnChecks: HygieneCheck[] = [
+      ...cleanChecks,
+      { label: 'AI config exposure', status: 'warn', detail: 'CLAUDE.md contains key' },
+    ];
+    const { breakdown } = calculateSecurityScore({}, aiConfigWarnChecks);
+    expect(breakdown.configuration.deduction).toBe(0);
+  });
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,8 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
     "dev": "tsc --watch",
-    "release-smoke:corpus": "tsx scripts/release-smoke-corpus.ts"
+    "release-smoke:corpus": "tsx scripts/release-smoke-corpus.ts",
+    "release-smoke:init": "tsx scripts/release-smoke-init.ts"
   },
   "dependencies": {
     "@inquirer/prompts": "^7.0.0",

--- a/packages/cli/scripts/release-smoke-init.ts
+++ b/packages/cli/scripts/release-smoke-init.ts
@@ -1,0 +1,153 @@
+#!/usr/bin/env tsx
+/**
+ * release-smoke-init.ts — `opena2a init` corpus-tier monotonicity gate.
+ *
+ * Why this exists:
+ *   `opena2a init` produces a single security score that the user reads
+ *   first and acts on. Pre-#116 the scoring algorithm was missing surfaces
+ *   (private-key files, multi-MCP, unsigned skills) that allowed a
+ *   malicious-fixture project to score 96/100 ("strong"), HIGHER than the
+ *   benign-fixture project at 93/100. /release-test only exercised init
+ *   against a clean tree, so the regression shipped.
+ *
+ *   This harness exercises `opena2a init` against the canonical 3-tier
+ *   corpus (`benign/tiny-clean-repo`, `buggy/leaky-env-example`,
+ *   `malicious/kitchen-sink`) and asserts:
+ *
+ *     1. Score monotonicity: benign > buggy > malicious
+ *     2. Per-tier score band:
+ *        - benign:    >= 80
+ *        - buggy:     50..80 (inclusive)
+ *        - malicious: <= 60 (give 30-pt margin above the corpus
+ *                            ceiling of 30 — actively-malicious
+ *                            scoring will tighten in follow-up waves)
+ *
+ *   Failures are release-blockers. The init scoring algorithm cannot drift
+ *   past these bounds without an audit-doc decision and a band update.
+ *
+ * Per [CHIEF-CDS-028] OPENA2A_CORPUS_DETERMINISTIC=1.
+ *
+ * Exit code 0 = green, 1 = score-band failure, 2 = setup error.
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const CORPUS_ROOT =
+  process.env.OPENA2A_CORPUS_PATH ?? join(homedir(), '.opena2a', 'corpus');
+const FALLBACK_CORPUS = join(homedir(), 'workspace', 'opena2a-org', 'opena2a-corpus');
+const OPENA2A_CLI = resolve(__dirname, '..', 'dist', 'index.js');
+
+interface TierExpectation {
+  tier: 'benign' | 'buggy' | 'malicious';
+  fixture: string;
+  scoreFloor: number;
+  scoreCeiling: number;
+}
+
+const TIERS: TierExpectation[] = [
+  { tier: 'benign',    fixture: 'repo/benign/tiny-clean-repo',     scoreFloor: 80, scoreCeiling: 100 },
+  { tier: 'buggy',     fixture: 'repo/buggy/leaky-env-example',    scoreFloor: 50, scoreCeiling: 80 },
+  { tier: 'malicious', fixture: 'repo/malicious/kitchen-sink',     scoreFloor: 0,  scoreCeiling: 60 },
+];
+
+function resolveCorpusRoot(): string | null {
+  if (existsSync(CORPUS_ROOT)) return CORPUS_ROOT;
+  if (existsSync(FALLBACK_CORPUS)) return FALLBACK_CORPUS;
+  return null;
+}
+
+function runInit(targetDir: string): { score: number; raw: string } | null {
+  const result = spawnSync(
+    'node',
+    [OPENA2A_CLI, 'init', '--json', '--ci', '--no-contribute', targetDir],
+    {
+      env: { ...process.env, OPENA2A_CORPUS_DETERMINISTIC: '1' },
+      encoding: 'utf-8',
+    },
+  );
+  if (result.status !== 0 && result.status !== 1) return null;
+  try {
+    const parsed = JSON.parse(result.stdout);
+    if (typeof parsed.securityScore !== 'number') return null;
+    return { score: parsed.securityScore, raw: result.stdout };
+  } catch {
+    return null;
+  }
+}
+
+function main(): number {
+  const corpus = resolveCorpusRoot();
+  if (!corpus) {
+    process.stderr.write(`[release-smoke-init] corpus not found at ${CORPUS_ROOT} or ${FALLBACK_CORPUS}\n`);
+    process.stderr.write(`[release-smoke-init] set OPENA2A_CORPUS_PATH or check out opena2a-corpus alongside this repo.\n`);
+    return 2;
+  }
+  if (!existsSync(OPENA2A_CLI)) {
+    process.stderr.write(`[release-smoke-init] dist not built. Run: npm run build\n`);
+    return 2;
+  }
+
+  const results: Array<{ tier: string; score: number; passed: boolean; reason: string }> = [];
+  for (const t of TIERS) {
+    const target = join(corpus, t.fixture);
+    if (!existsSync(target)) {
+      results.push({ tier: t.tier, score: -1, passed: false, reason: `fixture missing: ${target}` });
+      continue;
+    }
+    const out = runInit(target);
+    if (!out) {
+      results.push({ tier: t.tier, score: -1, passed: false, reason: 'init failed or returned non-numeric score' });
+      continue;
+    }
+    const inBand = out.score >= t.scoreFloor && out.score <= t.scoreCeiling;
+    results.push({
+      tier: t.tier,
+      score: out.score,
+      passed: inBand,
+      reason: inBand ? '' : `score ${out.score} outside band [${t.scoreFloor}, ${t.scoreCeiling}]`,
+    });
+  }
+
+  const benign = results.find(r => r.tier === 'benign');
+  const buggy  = results.find(r => r.tier === 'buggy');
+  const mal    = results.find(r => r.tier === 'malicious');
+
+  let monotonicityOk = true;
+  let monotonicityReason = '';
+  if (benign && buggy && mal && benign.score >= 0 && buggy.score >= 0 && mal.score >= 0) {
+    if (!(benign.score > buggy.score && buggy.score > mal.score)) {
+      monotonicityOk = false;
+      monotonicityReason = `expected benign(${benign.score}) > buggy(${buggy.score}) > malicious(${mal.score})`;
+    }
+  } else {
+    monotonicityOk = false;
+    monotonicityReason = 'one or more tier results missing';
+  }
+
+  process.stdout.write('opena2a init — corpus-tier monotonicity gate\n');
+  process.stdout.write(`  corpus: ${corpus}\n`);
+  process.stdout.write('\n');
+  for (const r of results) {
+    const mark = r.passed ? 'PASS' : 'FAIL';
+    process.stdout.write(`  [${mark}] ${r.tier.padEnd(10)} score=${String(r.score).padStart(3)}${r.reason ? `  — ${r.reason}` : ''}\n`);
+  }
+  process.stdout.write('\n');
+  process.stdout.write(`  monotonicity: ${monotonicityOk ? 'PASS' : 'FAIL'}${monotonicityReason ? `  — ${monotonicityReason}` : ''}\n`);
+  process.stdout.write('\n');
+
+  const allBandsOk = results.every(r => r.passed);
+  if (allBandsOk && monotonicityOk) {
+    process.stdout.write('  RESULT: GREEN — init scoring is within contract.\n');
+    return 0;
+  }
+  process.stdout.write('  RESULT: RED — release-blocking. See per-tier failures above.\n');
+  return 1;
+}
+
+process.exit(main());

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -50,6 +50,12 @@ interface GroupedFinding {
   businessImpact: string;
   locations: { file: string; line: number }[];
   attackClass?: string;
+  // Populated from getVerificationCommand() / getToolRecommendation() so
+  // JSON consumers (CI gates, IDE plugins) get the same per-finding
+  // verify/fix mapping the text view prints. Undefined when no command
+  // is appropriate.
+  verify?: string;
+  fix?: string;
 }
 
 interface ActionItem {
@@ -161,7 +167,7 @@ export async function init(options: InitOptions): Promise<number> {
   }
 
   // 6. Group findings
-  const groupedFindings = groupFindings(credentialMatches, checks, hmaFindings);
+  const groupedFindings = groupFindings(credentialMatches, checks, hmaFindings, targetDir);
 
   // 7. Calculate unified security score
   if (isTTY) spinner.update('Assessing security posture...');
@@ -223,6 +229,15 @@ export async function init(options: InitOptions): Promise<number> {
   if (isTTY) spinner.stop();
 
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+
+  // 11.5 Enrich findings with verify/fix so JSON consumers see the same
+  // per-finding command mapping the text view prints (#119).
+  for (const f of groupedFindings) {
+    const verify = getVerificationCommand(f, targetDir);
+    if (verify) f.verify = verify;
+    const tool = getToolRecommendation(f.findingId);
+    if (tool) f.fix = tool.command;
+  }
 
   // 12. Build report
   const riskLevel = scoreToRiskLevel(score);
@@ -473,10 +488,31 @@ async function checkLLMServerExposure(): Promise<HygieneCheck | null> {
 
 // --- Finding grouping ---
 
+// File probes for hygiene-derived findings. Each entry returns the FIRST
+// existing file in the project, or null if none. Keeps `locations[]`
+// aligned with what `getVerificationCommand` would resolve.
+const HYGIENE_FILE_PROBES: Record<string, string[]> = {
+  'MCP-TOOLS': ['mcp.json', '.mcp.json', '.mcp/config.json', '.claude/settings.json', '.cursor/mcp.json'],
+  'MCP-CRED': ['mcp.json', '.mcp.json', '.mcp/config.json', '.claude/settings.json', '.cursor/mcp.json'],
+  'ENV-DOTENV': ['.gitignore'],
+  'AI-CONFIG': ['.gitignore', '.git/info/exclude'],
+};
+
+function probeHygieneLocation(findingId: string, dir: string): { file: string; line: number }[] {
+  const candidates = HYGIENE_FILE_PROBES[findingId];
+  if (!candidates) return [];
+  for (const rel of candidates) {
+    const full = path.join(dir, rel);
+    if (fs.existsSync(full)) return [{ file: full, line: 1 }];
+  }
+  return [];
+}
+
 function groupFindings(
   creds: CredentialMatch[],
   checks: HygieneCheck[],
   hmaFindings: { severity: string; checkId: string; message: string; attackClass?: string }[],
+  targetDir: string,
 ): GroupedFinding[] {
   const groups = new Map<string, GroupedFinding>();
 
@@ -525,7 +561,7 @@ function groupFindings(
       count: 1,
       explanation: 'Environment files may be committed to version control.',
       businessImpact: 'Adding .env to .gitignore keeps secrets out of version control.',
-      locations: [],
+      locations: probeHygieneLocation('ENV-DOTENV', targetDir),
     });
   }
 
@@ -539,7 +575,7 @@ function groupFindings(
       count: 1,
       explanation: 'MCP servers with filesystem or shell access can read, modify, or delete files on your system when invoked by an AI assistant.',
       businessImpact: 'Review server permissions to ensure each server has only the access it needs.',
-      locations: [],
+      locations: probeHygieneLocation('MCP-TOOLS', targetDir),
     });
   }
 
@@ -552,7 +588,7 @@ function groupFindings(
       count: 1,
       explanation: 'API keys hardcoded in MCP config files are readable by anyone with access to the project directory.',
       businessImpact: 'Move credentials to environment variables so they are not stored in plaintext.',
-      locations: [],
+      locations: probeHygieneLocation('MCP-CRED', targetDir),
     });
   }
 
@@ -565,7 +601,7 @@ function groupFindings(
       count: 1,
       explanation: 'AI instruction files (CLAUDE.md, .cursorrules, etc.) reveal tooling choices and system prompts when committed to a public repository.',
       businessImpact: 'Add these files to .git/info/exclude to keep them local without modifying .gitignore.',
-      locations: [],
+      locations: probeHygieneLocation('AI-CONFIG', targetDir),
     });
   }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -674,8 +674,8 @@ function generateActions(
   if (llmCheck) {
     actions.push({
       description: 'Secure LLM server',
-      command: 'opena2a shield status',
-      why: 'A local LLM server without authentication accepts requests from any process on the network. Binding to localhost or adding auth limits access.',
+      command: 'opena2a shield init',
+      why: 'A local LLM server without authentication accepts requests from any process on the network. shield init runs the 11-step setup that includes runtime guard binding and access policy.',
     });
   }
 
@@ -683,9 +683,9 @@ function generateActions(
   const mcpToolsFinding = findings.find(f => f.findingId === 'MCP-TOOLS');
   if (mcpToolsFinding) {
     actions.push({
-      description: 'Review MCP server permissions',
-      command: 'opena2a shield status',
-      why: 'MCP servers with filesystem or shell access can read, modify, or delete files when invoked by an AI assistant. Review each server to confirm it has only the access it needs.',
+      description: 'Review and lock down MCP server permissions',
+      command: 'opena2a shield init',
+      why: 'MCP servers with filesystem or shell access can read, modify, or delete files when invoked by an AI assistant. shield init walks each server, captures a signed baseline, and applies the recommended permission policy.',
     });
   }
 
@@ -840,7 +840,7 @@ function getToolRecommendation(
     return { command: 'opena2a protect', label: 'opena2a protect' };
   }
   if (findingId === 'ENV-LLM') {
-    return { command: 'opena2a shield status', label: 'opena2a shield status' };
+    return { command: 'opena2a shield init', label: 'opena2a shield init' };
   }
   if (findingId === 'ENV-DOTENV') {
     return { command: 'opena2a protect', label: 'opena2a protect' };
@@ -849,7 +849,7 @@ function getToolRecommendation(
     return { command: 'opena2a scan --deep', label: 'opena2a scan --deep' };
   }
   if (findingId === 'MCP-TOOLS') {
-    return { command: 'opena2a shield status', label: 'opena2a shield status' };
+    return { command: 'opena2a shield init', label: 'opena2a shield init' };
   }
   if (findingId === 'MCP-CRED') {
     return { command: 'opena2a protect', label: 'opena2a protect' };
@@ -920,8 +920,8 @@ function getContextualTip(
   const hasLLM = report.findings.some(f => f.findingId === 'ENV-LLM');
   if (hasLLM) {
     return {
-      text: 'An unauthenticated LLM server is running locally. opena2a shield status shows which Shield modules are active and what ARP is monitoring at the process and network level.',
-      command: 'opena2a shield status',
+      text: 'An unauthenticated LLM server is running locally. opena2a shield init runs the 11-step setup that binds runtime guard, captures a signed baseline, and applies an access policy.',
+      command: 'opena2a shield init',
     };
   }
 
@@ -939,8 +939,8 @@ function getContextualTip(
   }
 
   return {
-    text: 'opena2a shield status shows all active protections: ARP runtime monitoring, Guard config integrity, Secretless credential management, and HackMyAgent scan coverage.',
-    command: 'opena2a shield status',
+    text: 'opena2a shield init runs the 11-step orchestration: ARP runtime monitoring, Guard config integrity baseline, Secretless credential migration, and HackMyAgent scan coverage.',
+    command: 'opena2a shield init',
   };
 }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -26,6 +26,7 @@ import {
   type HygieneCheck as HygieneCheckShared,
   type ScoreBreakdown as ScoreBreakdownShared,
 } from '../util/scoring.js';
+import { HMA_CHECK_COUNT } from '../util/canonical.js';
 
 // --- Types ---
 
@@ -325,7 +326,7 @@ export async function init(options: InitOptions): Promise<number> {
     process.stdout.write(dim('  To set up full Shield protection (11-step orchestration): opena2a shield init') + '\n');
 
     // Deeper analysis hint
-    process.stdout.write(dim('  For deeper analysis (238 checks): opena2a scan --deep') + '\n');
+    process.stdout.write(dim(`  For deeper analysis (${HMA_CHECK_COUNT} checks): opena2a scan --deep`) + '\n');
 
     // Global install hint (only when running via npx)
     if (isRunningViaNpx()) {
@@ -927,7 +928,7 @@ function getContextualTip(
 
   if (report.securityScore >= 90) {
     return {
-      text: 'Strong baseline. HackMyAgent runs 238 checks including agent-layer attacks, MCP exploitation, and OASB-1 + OASB-2 compliance scoring.',
+      text: `Strong baseline. HackMyAgent runs ${HMA_CHECK_COUNT} checks including agent-layer attacks, MCP exploitation, and OASB-1 + OASB-2 compliance scoring.`,
       command: 'npx hackmyagent secure',
     };
   }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -10,6 +10,7 @@ import * as path from 'node:path';
 import { bold, green, yellow, red, cyan, dim, gray } from '../util/colors.js';
 import { detectProject, type ProjectInfo, type ProjectType } from '../util/detect.js';
 import { quickCredentialScan, type CredentialMatch } from '../util/credential-patterns.js';
+import { scanCryptoKeyFiles } from '../util/crypto-key-files.js';
 import { checkAdvisories, printAdvisoryWarnings, type AdvisoryCheck } from '../util/advisories.js';
 import { wordWrap, severityLabel, severityColor } from '../util/format.js';
 import { getVersion } from '../util/version.js';
@@ -140,6 +141,16 @@ export async function init(options: InitOptions): Promise<number> {
     if (!seenCredValues.has(mc.value)) {
       credentialMatches.push(mc);
       seenCredValues.add(mc.value);
+    }
+  }
+
+  // Cryptographic key/cert files (private keys, PKCS#12 stores, certs) are
+  // credentials by file type, not by string content (#116). Without this
+  // pass, kitchen-sink fixtures with `.key` / `.pem` files in source score
+  // artificially high.
+  for (const km of scanCryptoKeyFiles(targetDir)) {
+    if (!credentialMatches.some(m => m.filePath === km.filePath && m.findingId === km.findingId)) {
+      credentialMatches.push(km);
     }
   }
 
@@ -509,6 +520,8 @@ const HYGIENE_FILE_PROBES: Record<string, string[]> = {
   'MCP-CRED': ['mcp.json', '.mcp.json', '.mcp/config.json', '.claude/settings.json', '.cursor/mcp.json'],
   'ENV-DOTENV': ['.gitignore'],
   'AI-CONFIG': ['.gitignore', '.git/info/exclude'],
+  'AI-SKILLS': ['SKILL.md'],
+  'AI-SOUL': ['SOUL.md', 'soul.md'],
 };
 
 function probeHygieneLocation(findingId: string, dir: string): { file: string; line: number }[] {
@@ -618,6 +631,37 @@ function groupFindings(
     });
   }
 
+  // Surface unsigned skill files as a discrete finding so the user sees
+  // it in the text view and the JSON `findings[]` array, not just buried
+  // in `hygieneChecks`. Pre-#116 this warn was emitted but never shown
+  // as a finding, which made `init` look quieter than the project was.
+  const skillCheck = checks.find(c => c.label === 'Skill files' && c.status === 'warn');
+  if (skillCheck) {
+    groups.set('AI-SKILLS', {
+      findingId: 'AI-SKILLS',
+      title: skillCheck.detail,
+      severity: 'medium',
+      count: 1,
+      explanation: 'Skill files declare AI-agent capabilities. Without an opena2a-guard signature block, modifications are not detectable and the agent has no integrity baseline.',
+      businessImpact: 'Sign each skill file so future tampering is visible and the agent\'s capability surface is anchored to a known-good baseline.',
+      locations: probeHygieneLocation('AI-SKILLS', targetDir),
+    });
+  }
+
+  // Surface SOUL.md prompt-injection / override patterns the same way.
+  const soulCheck = checks.find(c => c.label === 'Soul file' && c.status === 'warn');
+  if (soulCheck) {
+    groups.set('AI-SOUL', {
+      findingId: 'AI-SOUL',
+      title: soulCheck.detail,
+      severity: 'high',
+      count: 1,
+      explanation: 'SOUL.md is the agent\'s governance document. Override / injection patterns here can defeat trust hierarchies and broaden the agent\'s authority beyond what the operator intended.',
+      businessImpact: 'Review the patterns and either remove them or document why they are required. Re-sign the file once corrections land.',
+      locations: probeHygieneLocation('AI-SOUL', targetDir),
+    });
+  }
+
   // Add HMA findings
   for (const f of hmaFindings) {
     const key = `HMA-${f.checkId}`;
@@ -668,11 +712,16 @@ function generateActions(
 ): ActionItem[] {
   const actions: ActionItem[] = [];
 
-  // Credential migration action
-  if (creds.length > 0) {
-    // Build breakdown string
+  // Split key/cert files from text-pattern credentials. `opena2a protect`
+  // can migrate text patterns to a vault but cannot rotate or untrack
+  // binary key files — surfacing both under a single protect-action would
+  // be a CISO Rule 1 dead end on the keyfile side (Phase 4.5 finding).
+  const keyfileCreds = creds.filter(c => c.findingId === 'CRED-KEYFILE' || c.findingId === 'CRED-CERTFILE');
+  const textCreds = creds.filter(c => c.findingId !== 'CRED-KEYFILE' && c.findingId !== 'CRED-CERTFILE');
+
+  if (textCreds.length > 0) {
     const byTitle = new Map<string, number>();
-    for (const c of creds) {
+    for (const c of textCreds) {
       byTitle.set(c.title, (byTitle.get(c.title) || 0) + 1);
     }
     const breakdownParts = Array.from(byTitle.entries())
@@ -680,11 +729,22 @@ function generateActions(
       .join(', ');
 
     actions.push({
-      description: `Migrate ${creds.length} hardcoded credential${creds.length === 1 ? '' : 's'} to a vault`,
+      description: `Migrate ${textCreds.length} hardcoded credential${textCreds.length === 1 ? '' : 's'} to a vault`,
       command: 'opena2a protect',
       why: 'Credentials in source files are readable by anyone with repo access. A vault stores them encrypted, rotates them automatically, and provides an audit trail.',
       approach: 'Moves keys to environment variables backed by an encrypted vault. Keys rotate without code changes, and access is auditable.',
       detail: `Keys found: ${breakdownParts}`,
+    });
+  }
+
+  if (keyfileCreds.length > 0) {
+    const fileExamples = keyfileCreds.slice(0, 3).map(c => path.basename(c.filePath)).join(', ');
+    actions.push({
+      description: `Untrack ${keyfileCreds.length} key/cert file${keyfileCreds.length === 1 ? '' : 's'} and rotate at issuer`,
+      command: "git rm --cached '<file>' && echo '*.key' >> .gitignore",
+      why: 'Cryptographic key files (.key/.pem/.p12/.pfx) are credentials by file type. opena2a protect handles text-pattern keys but cannot rotate binary key material — that has to happen at the issuing CA, vault, or KMS.',
+      approach: 'Untrack the file from git, add the extension to .gitignore so it cannot be re-added, then issue a fresh key at the upstream provider. Treat the historical commit as a leak even after rotation — assume any holder of the old key has used it.',
+      detail: `Files: ${fileExamples}${keyfileCreds.length > 3 ? ` (+${keyfileCreds.length - 3} more)` : ''}`,
     });
   }
 
@@ -886,6 +946,24 @@ function getVerificationCommand(
 function getToolRecommendation(
   findingId: string,
 ): { command: string; label: string } | null {
+  // Cryptographic key/cert files are credentials by file type, not text
+  // content. `opena2a protect` only handles text-pattern credentials, so
+  // a Fix line pointing there would be a CISO Rule 1 dead end. Surface
+  // the actual remediation: untrack from git + add the extension to
+  // `.gitignore`. Rotation happens at the issuing CA / vault and cannot
+  // be automated by the CLI.
+  if (findingId === 'CRED-KEYFILE') {
+    return {
+      command: "git rm --cached '<file>' && echo '*.key' >> .gitignore",
+      label: 'untrack key file + .gitignore (then rotate the key at issuer)',
+    };
+  }
+  if (findingId === 'CRED-CERTFILE') {
+    return {
+      command: "git rm --cached '<file>' && echo '*.crt' >> .gitignore",
+      label: 'untrack cert file + .gitignore (verify the matching private key is not committed)',
+    };
+  }
   if (findingId.startsWith('CRED-') || findingId.startsWith('DRIFT-')) {
     return { command: 'opena2a protect', label: 'opena2a protect' };
   }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -104,7 +104,20 @@ export async function init(options: InitOptions): Promise<number> {
   const targetDir = path.resolve(options.targetDir ?? process.cwd());
 
   if (!fs.existsSync(targetDir)) {
-    process.stderr.write(red(`Directory not found: ${targetDir}\n`));
+    if (options.format === 'json') {
+      process.stdout.write(JSON.stringify({
+        error: 'directory-not-found',
+        directory: targetDir,
+        message: `Directory not found: ${targetDir}`,
+      }) + '\n');
+    } else {
+      process.stderr.write(red(`Directory not found: ${targetDir}\n`));
+      process.stderr.write('\n');
+      process.stderr.write(dim('  Next steps:\n'));
+      process.stderr.write(dim('    Scan the current directory:  opena2a init\n'));
+      process.stderr.write(dim('    Scan a specific path:        opena2a init <path>\n'));
+      process.stderr.write(dim('    Show all options:            opena2a init --help\n'));
+    }
     return 1;
   }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -897,6 +897,18 @@ function getVerificationCommand(
   ) {
     const loc = finding.locations[0];
     const rel = path.relative(reportDir, loc.file);
+    // Keyfile/certfile findings target binary or PEM-armored files. `sed -n
+    // '1p'` on a `.p12`/`.pfx` dumps raw binary to the terminal — a
+    // verification dead-end. For PEM-armored `.pem`/`.key`/`.crt`/`.cer` the
+    // first line `-----BEGIN ...-----` tells the user what the file actually
+    // is (private key vs public cert). For PKCS#12 we use `openssl pkcs12`.
+    if (finding.findingId === 'CRED-KEYFILE' || finding.findingId === 'CRED-CERTFILE') {
+      const ext = path.extname(rel).toLowerCase();
+      if (ext === '.p12' || ext === '.pfx') {
+        return `openssl pkcs12 -in ${rel} -info -nokeys -passin pass: 2>/dev/null | head -20 || file ${rel}`;
+      }
+      return `head -1 ${rel}`;
+    }
     return `sed -n '${loc.line}p' ${rel}`;
   }
 

--- a/packages/cli/src/guided/wizard.ts
+++ b/packages/cli/src/guided/wizard.ts
@@ -1,4 +1,5 @@
 import { bold, cyan, gray, dim } from '../util/colors.js';
+import { HMA_CHECK_COUNT } from '../util/canonical.js';
 
 interface WizardCategory {
   label: string;
@@ -17,7 +18,7 @@ const CATEGORIES: WizardCategory[] = [
     label: 'Scan & Harden',
     description: 'Find and fix security issues in AI agents',
     commands: [
-      { label: 'Full security scan', command: 'opena2a scan secure', description: '238 security checks with auto-fix' },
+      { label: 'Full security scan', command: 'opena2a scan secure', description: `${HMA_CHECK_COUNT} security checks with auto-fix` },
       { label: 'Attack mode', command: 'opena2a scan attack', description: 'Adversarial testing against your agent' },
       { label: 'Security benchmark', command: 'opena2a benchmark', description: 'OASB benchmark (222 standardized attack scenarios)' },
       { label: 'Credential scan', command: 'opena2a secrets scan', description: 'Find hardcoded secrets in your codebase' },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,7 @@ import { ADAPTER_REGISTRY } from './adapters/registry.js';
 import { getVersion } from './util/version.js';
 import { printFooter } from './util/footer.js';
 import { checkMinHmaVersion } from './util/hma-version.js';
+import { HMA_CHECK_COUNT } from './util/canonical.js';
 
 const VERSION = getVersion();
 // Wire-format tool name (analytics key in tool_usage_events). Matches the
@@ -108,7 +109,7 @@ Quick Start:
   $ opena2a protect              Detect and migrate hardcoded credentials
   $ opena2a guard sign           Sign config files for tamper detection
   $ opena2a check express        Check npm package against Registry + HMA
-  $ opena2a scan secure          Run 238 security checks on your AI agent
+  $ opena2a scan secure          Run ${HMA_CHECK_COUNT} security checks on your AI agent
   $ opena2a skill create         Scaffold a secure skill (SKILL.md, heartbeat, tests)
   $ opena2a guard harden         Scan skills for security issues (--fix to auto-fix)
   $ opena2a harden-skill         Harden a skill file (frontmatter, permissions, integrity pin)

--- a/packages/cli/src/natural/llm-fallback.ts
+++ b/packages/cli/src/natural/llm-fallback.ts
@@ -1,9 +1,10 @@
 import { bold, cyan, yellow, gray, dim, green } from '../util/colors.js';
+import { HMA_CHECK_COUNT } from '../util/canonical.js';
 
 const SYSTEM_PROMPT = `You are OpenA2A CLI, an AI agent security platform. Given a user's natural language query, suggest the most appropriate CLI command.
 
 Available commands:
-- opena2a scan secure -- Full security scan (238 checks)
+- opena2a scan secure -- Full security scan (${HMA_CHECK_COUNT} checks)
 - opena2a scan attack -- Attack mode (adversarial testing)
 - opena2a protect -- Detect and migrate credentials to vault
 - opena2a secrets init -- Set up credential protection

--- a/packages/cli/src/util/canonical.ts
+++ b/packages/cli/src/util/canonical.ts
@@ -1,0 +1,24 @@
+/**
+ * Canonical ecosystem constants used in user-facing copy.
+ *
+ * IMPORTANT: every value here mirrors `data/canonical-numbers.json` in
+ * the `opena2a-website` repo, which is the cross-repo source of truth.
+ * When a number changes there, update it here and bump
+ * `CANONICAL_NUMBERS_REVISION` so the regression test in
+ * `__tests__/util/canonical.test.ts` flags any source files that still
+ * embed an outdated literal.
+ *
+ * Adding a new canonical number?
+ * 1. Add the constant here with a JSDoc citing its `_source` path.
+ * 2. Replace every literal in `src/` and the test will block re-introductions.
+ */
+
+/**
+ * HackMyAgent check count. Mirrors `hmaChecks.value` in
+ * `opena2a-website/data/canonical-numbers.json`. Bumped on each HMA
+ * release that adds checks.
+ */
+export const HMA_CHECK_COUNT = 209;
+
+/** Bump when any constant in this file changes. */
+export const CANONICAL_NUMBERS_REVISION = 1;

--- a/packages/cli/src/util/crypto-key-files.ts
+++ b/packages/cli/src/util/crypto-key-files.ts
@@ -1,0 +1,91 @@
+/**
+ * Detect cryptographic key/cert files committed to source.
+ *
+ * `quickCredentialScan` matches text patterns inside files. Private keys
+ * stored as `.key` / `.pem` / `.p12` / `.pfx` files are credentials by
+ * file type, not by string content — and binary container formats are
+ * unreadable as text. We treat the file extension as the finding signal.
+ *
+ * The malicious-fixture under `opena2a-corpus/repo/malicious/kitchen-sink`
+ * carries `fake-private.key` and `fake-cert.pem` in the project root.
+ * Without this scanner those surfaces are invisible to `opena2a init`,
+ * so the assessment scores artificially high (#116).
+ *
+ * Severity table (per audit decision 2026-04-29):
+ *   .key  / .pem  / .p12 / .pfx — CRITICAL (private-key-bearing)
+ *   .crt  / .cer                 — MEDIUM   (cert; usually public, but
+ *                                            committing certs leaks chain
+ *                                            metadata and may indicate
+ *                                            sloppy key handling)
+ *
+ * `.pem` files can be public certs, but in source-tree context the
+ * convention is private-key material, so we keep CRITICAL with a clear
+ * verify command so the user can downgrade by inspection.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { CredentialMatch } from './credential-patterns.js';
+import { SKIP_DIRS } from './credential-patterns.js';
+
+const KEY_FILE_SEVERITY: Record<string, 'critical' | 'medium'> = {
+  '.key': 'critical',
+  '.pem': 'critical',
+  '.p12': 'critical',
+  '.pfx': 'critical',
+  '.crt': 'medium',
+  '.cer': 'medium',
+};
+
+const TITLE_BY_EXT: Record<string, string> = {
+  '.key': 'Private key file',
+  '.pem': 'PEM key/cert file',
+  '.p12': 'PKCS#12 keystore',
+  '.pfx': 'PKCS#12 keystore',
+  '.crt': 'X.509 certificate file',
+  '.cer': 'X.509 certificate file',
+};
+
+export function scanCryptoKeyFiles(targetDir: string): CredentialMatch[] {
+  const matches: CredentialMatch[] = [];
+  walk(targetDir, (full) => {
+    const ext = path.extname(full).toLowerCase();
+    const severity = KEY_FILE_SEVERITY[ext];
+    if (!severity) return;
+    matches.push({
+      value: path.basename(full),
+      filePath: full,
+      line: 1,
+      findingId: severity === 'critical' ? 'CRED-KEYFILE' : 'CRED-CERTFILE',
+      envVar: '',
+      severity,
+      title: TITLE_BY_EXT[ext] ?? 'Key/cert file in source',
+      explanation: severity === 'critical'
+        ? 'Cryptographic key file checked into source. Anyone with repository access has the key material.'
+        : 'X.509 certificate checked into source. Certs are usually public, but committing them often signals lax handling of the matching private key.',
+      businessImpact: severity === 'critical'
+        ? 'Rotate the key, remove the file from history, and store keys outside the repository (env var, vault, KMS).'
+        : 'Audit cert handling and verify the matching private key is not stored alongside.',
+    });
+  });
+  return matches;
+}
+
+function walk(dir: string, callback: (filePath: string) => void): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name.startsWith('.') && entry.name !== '.opena2a') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      walk(full, callback);
+    } else if (entry.isFile()) {
+      callback(full);
+    }
+  }
+}

--- a/packages/cli/src/util/crypto-key-files.ts
+++ b/packages/cli/src/util/crypto-key-files.ts
@@ -79,9 +79,12 @@ function walk(dir: string, callback: (filePath: string) => void): void {
     return;
   }
   for (const entry of entries) {
-    if (entry.name.startsWith('.') && entry.name !== '.opena2a') continue;
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
+      // Skip on SKIP_DIRS membership only — descend into dot directories
+      // like `.ssh/`, `.secrets/`, `.config/`, `.aws/` where private keys
+      // conventionally live. A blanket dot-prefix skip would hide those
+      // exact files this scanner exists to surface.
       if (SKIP_DIRS.has(entry.name)) continue;
       walk(full, callback);
     } else if (entry.isFile()) {

--- a/packages/cli/src/util/scoring.ts
+++ b/packages/cli/src/util/scoring.ts
@@ -51,7 +51,10 @@ export function calculateSecurityScore(
 
   const credDetail = formatCredCount(critCount, highCount, medCount, lowCount);
 
-  // --- Environment category (cap at -25) ---
+  // --- Environment category (cap at -30, was -25 pre-#116) ---
+  // Bumped 5 points so the high-impact surfaces (LLM exposed + multi-MCP
+  // + unsigned skills + SOUL overrides) can all contribute on a kitchen-
+  // sink fixture without saturating the cap before they're all counted.
   let envDeduction = 0;
   const llmCheck = checks.find(c => c.label === 'LLM server exposure');
   if (llmCheck?.status === 'warn') envDeduction += 10;
@@ -59,9 +62,21 @@ export function calculateSecurityScore(
   const envProtection = checks.find(c => c.label === '.env protection');
   if (envProtection?.status === 'warn') envDeduction += 8;
 
-  // MCP config findings
-  const mcpToolsCheck = checks.find(c => c.label === 'MCP high-risk tools' && c.status === 'warn');
-  if (mcpToolsCheck) envDeduction += 5;
+  // MCP config findings — scale by server count and count ALL warns
+  // (one per MCP config file). Pre-#116 this only counted the first
+  // matching warn at a flat -5, so a kitchen-sink fixture with five
+  // filesystem/shell servers across two configs deducted the same as
+  // a single low-risk server.
+  const mcpToolsChecks = checks.filter(c => c.label === 'MCP high-risk tools' && c.status === 'warn');
+  let mcpServerCount = 0;
+  for (const c of mcpToolsChecks) {
+    const m = c.detail.match(/(\d+)\s+server/);
+    mcpServerCount += m ? parseInt(m[1], 10) : 1;
+  }
+  if (mcpServerCount > 0) {
+    // -3 per server, sub-cap -15 so other findings can still contribute.
+    envDeduction += Math.min(mcpServerCount * 3, 15);
+  }
 
   const mcpCredCheck = checks.find(c => c.label === 'MCP credentials' && c.status === 'warn');
   if (mcpCredCheck) envDeduction += 5;
@@ -70,6 +85,15 @@ export function calculateSecurityScore(
   const aiConfigCheck = checks.find(c => c.label === 'AI config exposure' && c.status === 'warn');
   if (aiConfigCheck) envDeduction += 3;
 
+  // Skill files — unsigned skills indicate ungoverned capability surface.
+  // Pre-#116 this warn was emitted by `scanSkillFiles` but never scored.
+  const skillCheck = checks.find(c => c.label === 'Skill files' && c.status === 'warn');
+  if (skillCheck) envDeduction += 3;
+
+  // SOUL.md prompt-injection / override patterns flagged by `scanSoulFile`.
+  const soulCheck = checks.find(c => c.label === 'Soul file' && c.status === 'warn');
+  if (soulCheck) envDeduction += 5;
+
   // HMA shell findings
   if (hmaBySeverity) {
     envDeduction += Math.min((hmaBySeverity['critical'] || 0) * 10, 10);
@@ -77,14 +101,16 @@ export function calculateSecurityScore(
     envDeduction += Math.min((hmaBySeverity['medium'] || 0) * 3, 9);
   }
 
-  envDeduction = Math.min(envDeduction, 25); // category cap
+  envDeduction = Math.min(envDeduction, 30); // category cap
 
   const envDetails: string[] = [];
   if (llmCheck?.status === 'warn') envDetails.push('LLM server exposed');
   if (envProtection?.status === 'warn') envDetails.push('.env unprotected');
-  if (mcpToolsCheck) envDetails.push('MCP high-risk tools');
+  if (mcpServerCount > 0) envDetails.push(`MCP high-risk tools (${mcpServerCount} server${mcpServerCount === 1 ? '' : 's'})`);
   if (mcpCredCheck) envDetails.push('MCP credentials');
   if (aiConfigCheck) envDetails.push('AI config exposed');
+  if (skillCheck) envDetails.push('unsigned skills');
+  if (soulCheck) envDetails.push('SOUL override patterns');
   if (hmaBySeverity && Object.keys(hmaBySeverity).length > 0) envDetails.push('shell findings');
   const envDetail = envDetails.length > 0 ? envDetails.join(', ') : 'clean';
 
@@ -100,9 +126,26 @@ export function calculateSecurityScore(
   const secConfig = checks.find(c => c.label === 'Security config');
   if (secConfig?.status !== 'pass') configDeduction += 3;
 
-  // Bonus for having security config
+  // Bonus for having security config — but only when the project is
+  // otherwise clean. A signed `.opena2a/guard/signatures.json` does not
+  // compensate for a private key in source or a bench of filesystem-shell
+  // MCP servers, and pre-#116 the +5 bonus was the difference between a
+  // 96/100 "strong" verdict and a fixture that scored ≤30.
+  // Bonus must also suppress on MEDIUM findings (e.g. `.crt` cert files
+  // emit MEDIUM CRED-CERTFILE). Without medCount, a project with a single
+  // MEDIUM finding visible to the user still rendered 100/100 — CISO
+  // Rule 11 violation surfaced by Phase 4.5 review of #116.
+  const hasHighImpact =
+    critCount > 0 ||
+    highCount > 0 ||
+    medCount > 0 ||
+    mcpServerCount > 0 ||
+    !!skillCheck ||
+    !!soulCheck ||
+    (!!llmCheck && llmCheck.status === 'warn') ||
+    !!mcpCredCheck;
   let configBonus = 0;
-  if (secConfig?.status === 'pass') configBonus = 5;
+  if (secConfig?.status === 'pass' && !hasHighImpact) configBonus = 5;
 
   configDeduction = Math.min(configDeduction, 15); // category cap
 
@@ -110,6 +153,7 @@ export function calculateSecurityScore(
   if (lockCheck?.status !== 'pass') configDetails.push('no lock file');
   if (secConfig?.status !== 'pass') configDetails.push('no security config');
   if (configBonus > 0) configDetails.push('security config present');
+  else if (secConfig?.status === 'pass' && hasHighImpact) configDetails.push('security config present (bonus suppressed by active findings)');
   const configDetail = configDetails.length > 0 ? configDetails.join(', ') : 'clean';
 
   const score = Math.max(0, Math.min(100, 100 - credDeduction - envDeduction - configDeduction + configBonus));

--- a/packages/cli/src/util/scoring.ts
+++ b/packages/cli/src/util/scoring.ts
@@ -135,6 +135,9 @@ export function calculateSecurityScore(
   // emit MEDIUM CRED-CERTFILE). Without medCount, a project with a single
   // MEDIUM finding visible to the user still rendered 100/100 — CISO
   // Rule 11 violation surfaced by Phase 4.5 review of #116.
+  const hmaFindingCount = hmaBySeverity
+    ? (hmaBySeverity['critical'] || 0) + (hmaBySeverity['high'] || 0) + (hmaBySeverity['medium'] || 0)
+    : 0;
   const hasHighImpact =
     critCount > 0 ||
     highCount > 0 ||
@@ -143,7 +146,10 @@ export function calculateSecurityScore(
     !!skillCheck ||
     !!soulCheck ||
     (!!llmCheck && llmCheck.status === 'warn') ||
-    !!mcpCredCheck;
+    !!mcpCredCheck ||
+    (!!envProtection && envProtection.status === 'warn') ||
+    !!aiConfigCheck ||
+    hmaFindingCount > 0;
   let configBonus = 0;
   if (secConfig?.status === 'pass' && !hasHighImpact) configBonus = 5;
 


### PR DESCRIPTION
## Summary

Wave 1 of the opena2a-cli full-command UX audit. Six commits, one per bug, against `init` and the release-smoke harness.

- **#117** — Fix command pointed to `shield status` (read-only) instead of runnable mutations
- **#118** — Hardcoded "238 checks" string replaced with canonical-source `HMA_CHECK_COUNT=209` from new `util/canonical.ts`
- **#119** — `verify`/`fix`/`locations` populated on every JSON finding; `HYGIENE_FILE_PROBES` for HygieneCheck.detail
- **audit-bug B** — `init` on a missing dir prints structured JSON error and provides Next Steps instead of dead-ending on ENOENT
- **#116** — Malicious-fixture scoring gap closed (`util/crypto-key-files.ts` for .key/.pem/.p12/.pfx CRITICAL + .crt/.cer MEDIUM; MCP-server-count scaling; AI-SKILLS/AI-SOUL warns; bonus-suppression on hasHighImpact)
- **release-smoke harness** — `packages/cli/scripts/release-smoke-init.ts` + `npm run release-smoke:init` corpus-tier monotonicity gate (closes the gate that let #116-119 ship in 0.10.0)

## Score-band evidence (post-fix on opena2a-corpus)

- benign tiny-clean-repo: 93/100
- buggy leaky-env-example: 56/100
- malicious kitchen-sink: 42/100 (was 96 pre-fix)
- Monotonicity: 93 > 56 > 42 ✓

## Phase 4.5 adversarial review on #116 (Tier B per `feedback_phase45_tiered_protocol.md`)

Caught + fixed 3 ship-blockers in the same commit before merging:

1. CRED-KEYFILE finding emitted with no `protect` migration path (would dead-end users)
2. +5 score bonus survived MEDIUM .crt findings, masking partial cred exposure
3. Synthetic-only monotonicity test would not have caught the 96 → 42 score drop on real fixtures

Classification (d) expanded-detection — adds new TRUE-positive surfaces; not narrowing or relabeling.

## Tests

- `packages/cli` test suite: 993/993 passing (was 970)
- `npm run release-smoke:init` against opena2a-corpus: monotonicity gate green
- HMA self-scan unchanged

## Test plan

- [ ] Reviewer runs `npm --prefix packages/cli test`
- [ ] Reviewer runs `npm --prefix packages/cli run release-smoke:init` with corpus at `~/workspace/opena2a-org/opena2a-corpus` (or `OPENA2A_CORPUS_PATH`)
- [ ] Reviewer reviews #116 as classification (d) per the score-jump red-flag table
- [ ] Reviewer confirms no regression on `opena2a init` against the live opena2a-cli source tree

## Not in scope

This PR does NOT release 0.10.1. Wave 2 (opena2a #120-126) and Wave 3 (3 P0 + 19 lower findings, see `todo/2026-04-29-opena2a-cli-ux-audit.md` Wave 3 section) are deferred to follow-up branches.