### PR TITLE
chore(deps): pin hackmyagent to 0.22.0 (closes #121, #128, W3-D5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2358,17 +2358,21 @@
       }
     },
     "node_modules/hackmyagent": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/hackmyagent/-/hackmyagent-0.17.0.tgz",
-      "integrity": "sha512-fiKfp5L9FPwCCHRgEG//S+oPWlKwZw18OR0DxTlDSTSuPj2Yr1PP/bYz3temnnuzj6HkVh9+bIGGLGGRibnbuQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/hackmyagent/-/hackmyagent-0.22.0.tgz",
+      "integrity": "sha512-ZBA/saV9rilZwmILWqR7s7RSaOCjqLdCv+FB/dxw061hDBZzi5QTZAxdq1eodbPSEIYrEesPRq+lCvRvtmP5MA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@noble/ed25519": "^2.3.0",
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/aim-core": "^0.1.2",
+        "@opena2a/check-core": "0.2.0",
+        "@opena2a/cli-ui": "0.5.0",
         "@opena2a/contribute": "^0.1.0",
+        "@opena2a/registry-client": "0.1.0",
         "@opena2a/shared": "^0.1.0",
+        "@opena2a/telemetry": "0.1.2",
         "ai-trust": "^0.2.6",
         "commander": "^12.0.0",
         "js-yaml": "^4.1.1",
@@ -3932,7 +3936,7 @@
         "@opena2a/telemetry": "0.1.2",
         "ai-trust": "^0.2.23",
         "commander": "^13.1.0",
-        "hackmyagent": "^0.17.0",
+        "hackmyagent": "0.22.0",
         "secretless-ai": "^0.14.1"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3925,7 +3925,7 @@
     },
     "packages/cli": {
       "name": "opena2a-cli",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.10.1
+
+### Changed
+- **`hackmyagent` runtime dep pinned exact `0.22.0`** (was `^0.17.0`, which resolved to 0.17.0 because pre-1.0 caret pins minor). Closes [#121](https://github.com/opena2a-org/opena2a/issues/121) (status/verify advertised stale HMA 0.17.0), [#128](https://github.com/opena2a-org/opena2a/issues/128) (HMA 0.17 text renderer leaked the multi-line `fix` field as raw `## Trust Hierarchy` / `1. System instructions` lines into `scan` stdout — verified zero occurrences post-bump on the malicious kitchen-sink fixture), and the W3-D5 audit finding (`secrets` reporting stale HMA version). Five-minor jump (0.17 → 0.22) brings: HMA Finding v2 fields (`evidence` / `rationale` / `concept` / `attackClass`) populated 114/114 with `attackClass` on every static-check finding (HMA #138, #146); the proximity-gated `transmit` URL capture (HMA #148); the heuristic compiler verbatim-evidence emit (HMA #151, #152); the integrity-verifier hardening (HMA #160). The opena2a-cli renderer wiring shipped in 0.10.0 (PR #114) now sees populated v2 fields end-to-end. Per-package "exact version pins" rule (CLAUDE.md). Phase 4.5 Tier B adversarial review on the boundary contract: PASS — load-bearing surfaces clean (CLI argv, JSON shape, render assumptions, activation gates, exit code, transitive ai-trust 0.16.7 isolated to ai-trust subprocess); 4 pre-existing follow-ups noted (init.ts dead-code branch checking non-existent HMA exports; `interactive-html.ts` evidence-string type land-mine; `review.ts:890` bare-catch swallow; `review` malicious-tier composite scoring at 69/100 — all pre-existed in 0.17 and are out of scope for this bump).
+
 ## 0.10.0
 
 ### New Features

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -56,7 +56,7 @@ opena2a                             # Interactive guided wizard (no args)
 | `opena2a identity mcp attach` | Auto-discover and attach MCP servers |
 | `opena2a identity integrate` | Wire security tools to identity (audit + trust) |
 | `opena2a harden-soul` | Generate SOUL.md governance rules |
-| `opena2a scan` | 204 security checks via HackMyAgent |
+| `opena2a scan` | 209 static · 32 semantic checks via HackMyAgent |
 | `opena2a mcp audit` | Audit MCP server configurations with trust scores |
 | `opena2a guard sign` | Sign config files for tamper detection |
 | `opena2a shield init` | Full security setup — all of the above, one command |
@@ -69,7 +69,7 @@ Each command routes to a specialized tool, installed on first use:
 |---------|------|-------------|
 | `detect` | Shadow AI | Discover AI agents, MCP servers, AI configs |
 | `identity` | [AIM](https://github.com/opena2a-org/agent-identity-management) | Cryptographic identity, audit logs, trust scoring |
-| `scan` | [HackMyAgent](https://github.com/opena2a-org/hackmyagent) | 204 security checks, attack simulation, auto-fix |
+| `scan` | [HackMyAgent](https://github.com/opena2a-org/hackmyagent) | 209 static · 32 semantic checks, attack simulation, auto-fix |
 | `secrets` | [Secretless AI](https://github.com/opena2a-org/secretless-ai) | Credential management for AI coding tools |
 | `mcp` | MCP Security | Audit, sign, and verify MCP server configurations |
 | `benchmark` | [OASB](https://github.com/opena2a-org/open-agent-security-benchmark) | 222 attack scenarios, compliance scoring |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opena2a-cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Unified CLI for the OpenA2A security platform",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "@opena2a/telemetry": "0.1.2",
     "ai-trust": "^0.2.23",
     "commander": "^13.1.0",
-    "hackmyagent": "^0.17.0",
+    "hackmyagent": "0.22.0",
     "secretless-ai": "^0.14.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## Summary

Bumps `opena2a-cli`'s `hackmyagent` runtime dep from `^0.17.0` (which was resolving to 0.17.0 — pre-1.0 caret pins minor) to **exact `0.22.0`**. Five-minor jump (0.17 → 0.22) brings:

- Finding v2 fields (`evidence` / `rationale` / `concept` / `attackClass`) populated end-to-end. `attackClass` lands on every static-check finding (HMA #138, #146). The opena2a-cli renderer wiring shipped in 0.10.0 (PR #114) now sees populated v2 fields. Verified 114/114 with `attackClass`, 42/114 with `rationale` on the malicious kitchen-sink fixture.
- Proximity-gated `transmit` URL capture (HMA #148)
- Heuristic compiler verbatim-evidence emit (HMA #151, #152)
- Integrity-verifier hardening (HMA #160)

Per the workspace "Exact version pins" rule, the new pin is `0.22.0` exact, not `^0.22.0`.

Path A from the Wave 3 pickup (deferred Option C credential-patterns broadening to a future coordinated bump that bundles secretless-ai's planned 0.1.1 FP suppressions + the SEM-CRED-* additions for #130). This PR closes the boundary-only items.

## Issues closed

- **#121** — `opena2a status`/`verify` advertised stale HMA 0.17.0
- **#128** — HMA 0.17 text renderer leaked the multi-line `fix` field as raw `## Trust Hierarchy` / `1. System instructions` lines into `scan` stdout. **Verified zero occurrences post-bump** on the malicious kitchen-sink fixture (was 20+ on 0.17.0).
- **W3-D5** — `secrets` reporting stale HMA version

## Pre-push review verdict

**PASS-WITH-CAVEAT** — full 8-phase walkthrough completed, marker created.

| Phase | Result |
|---|---|
| 1. Sensitive files | PASS |
| 2. Build/test/lint | PASS — 970/970 tests, build + typecheck clean |
| 3. AI code review | PASS — diff is one-line dep bump + CHANGELOG + README check-count update |
| 4. HMA scan | PASS-WITH-CAVEAT — 28/100 self-scan score (was 61/100). 13 findings, all pre-existing intentional patterns (eval-detector regex in `src/scanners/skillguard-checks.ts`, test fixtures with embedded eval strings in `__tests__/scanners/skillguard-checks.test.ts`, standard `env: { ...process.env }` spawn pattern in `src/adapters/`). HMA 0.22's new NEMO-007/008/009 + MEM-006 checks now surface what 0.17 didn't see. Classification (d) expanded-detection per `CLAUDE.md` doc-classifier FP backlog allowance ("HMA self-scan on packages/cli reports a doc-classifier FP backlog at score 61/100 — pre-existing, do not regression-trip on this count"). |
| 4.5. Adversarial review (Tier B) | PASS-WITH-CAVEAT — boundary contract clean: argv, JSON shape, render assumptions, activation gates (`isHmaEvidence` / `isHmaRationale` runtime guards), exit code parity, transitive ai-trust 0.16.7 isolated. 4 pre-existing follow-ups noted: `init.ts:148-156` dead-code branch checking non-existent HMA exports `checkShellEnvironment` / `checkShellHistory`; `interactive-html.ts:31` `evidence?: string` type land-mine vs HMA's actual object shape; `review.ts:890` bare `try/catch` swallows HMA errors silently; `review --ci` malicious-tier composite score 69/100 (above ≤60 CLAUDE.md band). All pre-existed in 0.17 and are out of scope. |
| 5. hma-hunter | SKIP (CLI-only) |
| 6. New-user walkthrough | PASS — surface coverage: benign secretless 71/100 (60-90 band), malicious kitchen-sink scan 0/100, empty tmpdir 75/100, trust express works, #128 leak markers 0 occurrences |
| 7a. Docs accuracy | FIXED — README "204 security checks" updated to "209 static · 32 semantic" (commit 61dc5db) |
| 7b. Cross-repo sweep | DEFER — 9+ stale "204" references in opena2a-website blog posts / docs / demos. HMA release session owns those updates; separate scope. |
| 8. Auto-fix loop | n/a |

## Test plan

- [x] `npm test --workspace=packages/cli` → 970/970
- [x] `npm run build --workspace=packages/cli` → clean
- [x] `npm run typecheck --workspace=packages/cli` → clean
- [x] Smoke: `node packages/cli/dist/index.js scan ~/.opena2a/corpus/repo/malicious/kitchen-sink --ci | grep -cE 'Trust Hierarchy|System instructions|Developer configuration'` → **0** (was 20+ on 0.17.0)
- [x] `node node_modules/hackmyagent/dist/cli.js secure ~/.opena2a/corpus/repo/malicious/kitchen-sink --json --no-registry | jq '[.findings[] | select(.attackClass != null)] | length'` → **114/114**
- [x] `opena2a review ~/workspace/opena2a-org/secretless --ci` → 71/100 (within 60-90 benign band)
- [x] Phase 4.5 adversarial review subagent ran independently against the boundary contract

## Coordination notes

- Active sibling on `feat/credential-patterns-0.1.1` (no session file but visible in worktree) carries WIP credential-patterns FP-suppression edits matching secretless-ai's planned 0.1.1 scope (bare `'fake'` PLACEHOLDER + localhost+demo allowlist). Stashed during this work as `sibling-session-credential-patterns-0.1.1-WIP-v2` to preserve. Not touched by this PR.
- Wave 1 PR #129 (`feat/ux-audit-wave-1`) is the parent of the Wave 3 audit doc and remains open. This PR is independent of Wave 1 and rebases cleanly off main.