### PR TITLE
fix(cli): setup prints user-facing dashboard URL, deep-links to agent page, auto-launches login

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.10.2
+
+### Bug Fixes
+- **`opena2a setup` printed the backend host as the dashboard URL.** The success block built `${auth.serverUrl}/dashboard` directly, which on AIM Cloud became `https://aim.oa2a.org/dashboard` — the API host, which serves a JSON health endpoint, not the UI. Backend = `oa2a.org`, frontend = `opena2a.org`; the two were never meant to be the same host. New helper `resolveDashboardUrl(serverUrl)` in `packages/cli/src/util/server-url.ts` maps API host → frontend host (`aim.oa2a.org` → `aim.opena2a.org`, `api.aim.opena2a.org` → `aim.opena2a.org`, self-hosted hostnames are passed through unchanged). 6 new unit tests in `__tests__/util/server-url.test.ts` pin the four URL flavors plus a defensive non-URL case. Release-smoke section 4 (`docs/testing/release-smoke.md`) asserts the wire output every release — URL drift is invisible to scoring tests so it needs its own gate.
+- **`opena2a setup` deep-links to the agent that was just created.** Printed link is now `https://aim.opena2a.org/dashboard/agents/<agentId>` (the resource the user just created), with a separate `MCP inventory:` line when MCP servers were attached. Reduces the click-distance from "agent registered" to "I can see my agent" from N+1 clicks to zero.
+- **`opena2a setup` auto-launches login when not authenticated.** Previously emitted `Run: opena2a login` and exited code 1, which forced the user to cancel + retry the setup flow. Setup now calls into the existing `login()` flow inline, prints a one-line "Press Ctrl+C to cancel and use --server <url>" hint for users who actually want a self-hosted AIM, and continues into identity creation once auth lands. JSON callers (`--json`) keep the strict-mode behavior — they still error out with the machine-readable code.
+- **Help/error strings stop leaking the backend host.** `opena2a login --server <url>` help and the "server URL required" error message both used to say "omit for aim.oa2a.org" — that domain is for backend/API traffic, never for human eyes. Now mentions `aim.opena2a.org` (the user-facing domain) and explicitly calls out `localhost:8080` as the self-hosted shorthand.
+
+### What just happened
+`opena2a setup` text output expanded to include a "What just happened" block (agent registered with Ed25519 keypair, N MCP servers discovered/attached, trust score reflects the agent + every MCP it depends on) and a "Next:" block with concrete follow-up commands (`watch`, `identity list`, `trust <package>`). The cloud-auth path also prints a "Self-hosted instead?" hint that names a `--server` example so users on AIM Cloud are aware they can swap to their own AIM at any time.
+
 ## 0.10.0
 
 ### New Features

--- a/packages/cli/__tests__/util/server-url.test.ts
+++ b/packages/cli/__tests__/util/server-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveServerUrl } from '../../src/util/server-url.js';
+import { resolveServerUrl, resolveDashboardUrl } from '../../src/util/server-url.js';
 
 describe('resolveServerUrl', () => {
   it('resolves "cloud" to https://aim.oa2a.org', () => {
@@ -53,5 +53,37 @@ describe('resolveServerUrl', () => {
   it('trims whitespace', () => {
     expect(resolveServerUrl('  cloud  ')).toBe('https://aim.oa2a.org');
     expect(resolveServerUrl('  localhost:8080  ')).toBe('http://localhost:8080');
+  });
+});
+
+describe('resolveDashboardUrl', () => {
+  it('maps the AIM Cloud backend host to the user-facing frontend host', () => {
+    // oa2a.org = backend, opena2a.org = frontend. The CLI used to print the
+    // backend URL with /dashboard appended, sending users to an API
+    // health endpoint that does not render a UI.
+    expect(resolveDashboardUrl('https://aim.oa2a.org')).toBe('https://aim.opena2a.org');
+    expect(resolveDashboardUrl('https://aim.oa2a.org/')).toBe('https://aim.opena2a.org');
+  });
+
+  it('maps the community API host to the community frontend (drops api. prefix)', () => {
+    expect(resolveDashboardUrl('https://api.aim.opena2a.org')).toBe('https://aim.opena2a.org');
+  });
+
+  it('keeps localhost untouched (self-hosted AIM serves API + UI on the same host)', () => {
+    expect(resolveDashboardUrl('http://localhost:8080')).toBe('http://localhost:8080');
+    expect(resolveDashboardUrl('http://127.0.0.1:8080')).toBe('http://127.0.0.1:8080');
+  });
+
+  it('keeps custom self-hosted hostnames untouched', () => {
+    expect(resolveDashboardUrl('https://aim.example.internal')).toBe('https://aim.example.internal');
+    expect(resolveDashboardUrl('https://aim.example.com:9090')).toBe('https://aim.example.com:9090');
+  });
+
+  it('strips trailing slashes and any path the caller passed in', () => {
+    expect(resolveDashboardUrl('https://aim.example.com/api/v1/')).toBe('https://aim.example.com');
+  });
+
+  it('returns input untouched when not a parseable URL (defensive)', () => {
+    expect(resolveDashboardUrl('not-a-url')).toBe('not-a-url');
   });
 });

--- a/packages/cli/docs/testing/release-smoke.md
+++ b/packages/cli/docs/testing/release-smoke.md
@@ -61,6 +61,62 @@ unset OPENA2A_TELEMETRY_URL
 # overwrite ~/.config/opena2a/telemetry.json.
 ```
 
+## 4. Setup-flow URLs — frontend host invariant (1 min)
+
+`opena2a setup` prints links the user is expected to click. Backend host
+(`oa2a.org`) serves the API; frontend host (`opena2a.org`) renders the UI.
+Printing the backend host as a "Dashboard:" link sends users to a JSON health
+endpoint, not the dashboard. This invariant is unit-tested in
+`__tests__/util/server-url.test.ts` (`resolveDashboardUrl`); the smoke checks
+the wire output every release because URL drift is invisible to scoring tests.
+
+Run setup with the JSON flag against a fresh auth file pointed at `cloud`. If
+you don't have a live AIM Cloud auth on this machine, skip 4.2 and run the
+helper-output check (4.3) by itself — it covers the regression.
+
+```bash
+# 4.1 - inspect the cloud-auth path (real flow; needs a valid login first)
+opena2a login --server cloud   # one-time
+opena2a setup --json | jq '.dashboard, .mcpDashboard, .serverUrl'
+```
+
+| # | Assertion |
+|---|-----------|
+| 4.1.a | `dashboard` and `mcpDashboard` start with `https://aim.opena2a.org/` (NEVER `aim.oa2a.org`, NEVER `api.aim.opena2a.org`). |
+| 4.1.b | `dashboard` ends with `/dashboard/agents/<agentId>` — deep link to the agent we just created, not the generic `/dashboard`. |
+| 4.1.c | `serverUrl` is the API host (`https://aim.oa2a.org` for cloud) — that field is for downstream tooling, kept distinct from `dashboard`. |
+
+Text-mode output should include a "Self-hosted instead?" hint that names a
+`--server` example (e.g. `localhost:8080`). If that line is missing, the
+self-hosted disclosure regressed — release-blocker.
+
+```bash
+# 4.2 - self-hosted shape (no live server needed; reads cached config)
+node -e "
+  const { resolveDashboardUrl } = require('./dist/util/server-url.js');
+  const cases = {
+    cloudBackend:    'https://aim.oa2a.org',
+    communityApi:    'https://api.aim.opena2a.org',
+    selfHostedLocal: 'http://localhost:8080',
+    selfHostedCorp:  'https://aim.example.internal',
+  };
+  for (const [k, v] of Object.entries(cases)) console.log(k, '->', resolveDashboardUrl(v));
+"
+```
+
+Expected (line for line):
+
+```
+cloudBackend -> https://aim.opena2a.org
+communityApi -> https://aim.opena2a.org
+selfHostedLocal -> http://localhost:8080
+selfHostedCorp -> https://aim.example.internal
+```
+
+Fail the release if any line drifts. The two `*.opena2a.org` lines must NOT
+contain `oa2a.org` (no `n`-drop) and the two self-hosted lines must echo the
+input host exactly — same protocol, same port.
+
 ## When this checklist isn't enough
 
 - If the diff touches `src/router.ts` or any subcommand action — also run the relevant subcommand against a real target (`opena2a check express`, `opena2a status`, etc.) — telemetry hooks fire on the postAction phase, so a broken hook only surfaces with a real action.

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -27,7 +27,7 @@ export async function login(options: LoginOptions): Promise<number> {
     if (isJson) {
       console.log(JSON.stringify({ error: 'invalid_server', message: 'Server URL is required.' }));
     } else {
-      console.error('Server URL is required. Use --server <url> or omit for aim.oa2a.org.');
+      console.error('Server URL is required. Use --server <url> or omit to use AIM Cloud (aim.opena2a.org).');
     }
     return 1;
   }

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -272,7 +272,13 @@ export async function setup(options: SetupOptions): Promise<number> {
   const dashboardBase = resolveDashboardUrl(auth.serverUrl);
   const agentUrl = `${dashboardBase}/dashboard/agents/${agentId}`;
   const mcpUrl = `${dashboardBase}/dashboard/mcp`;
-  const isCloud = /aim\.(opena2a|oa2a)\.org$/.test(new URL(auth.serverUrl).host);
+  // Defensive: a corrupted auth.json could carry an unparseable serverUrl
+  // (e.g. "not a url"). Don't crash the post-success path on it — degrade
+  // the cloud-only "Self-hosted instead?" hint to off.
+  let isCloud = false;
+  try {
+    isCloud = /aim\.(opena2a|oa2a)\.org$/.test(new URL(auth.serverUrl).host);
+  } catch { /* unparseable serverUrl — leave isCloud=false */ }
 
   if (isJson) {
     process.stdout.write(JSON.stringify({

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import { bold, dim, green, yellow, red, cyan, gray } from '../util/colors.js';
 import { AimClient, loadServerConfig, saveServerConfig } from '../util/aim-client.js';
 import { loadAuth, isAuthValid } from '../util/auth.js';
+import { resolveDashboardUrl } from '../util/server-url.js';
 import { scanMcpServers } from './detect.js';
 
 export interface SetupOptions {
@@ -69,16 +70,34 @@ export async function setup(options: SetupOptions): Promise<number> {
   const isJson = options.json || options.format === 'json';
   const dir = options.targetDir;
 
-  // Step 1: Check authentication
-  const auth = loadAuth();
+  // Step 1: Check authentication. If missing or expired, run the browser login
+  // flow inline so the user doesn't have to cancel + retry. JSON callers stay
+  // strict-mode (still error with a machine-readable code).
+  let auth = loadAuth();
   if (!auth || !isAuthValid(auth)) {
     if (isJson) {
       process.stdout.write(JSON.stringify({ error: 'not_authenticated', message: 'Run: opena2a login' }, null, 2) + '\n');
-    } else {
-      process.stderr.write(red('Not authenticated.') + '\n');
-      process.stderr.write('Run: ' + cyan('opena2a login') + '\n');
+      return 1;
     }
-    return 1;
+
+    process.stdout.write(yellow('  Not authenticated.') + ' Launching browser login...\n');
+    process.stdout.write(dim('  (Press Ctrl+C to cancel and use --server <url> for a self-hosted AIM server.)') + '\n\n');
+
+    const { login } = await import('./login.js');
+    const loginCode = await login({
+      ci: options.ci,
+      format: options.format,
+    });
+    if (loginCode !== 0) {
+      return loginCode;
+    }
+
+    auth = loadAuth();
+    if (!auth || !isAuthValid(auth)) {
+      process.stderr.write(red('  Login completed but no valid credentials were saved. Try opena2a login again.') + '\n');
+      return 1;
+    }
+    process.stdout.write('\n');
   }
 
   if (!isJson) {
@@ -248,7 +267,12 @@ export async function setup(options: SetupOptions): Promise<number> {
   } catch { /* use initial trust score */ }
 
   // Output results
-  const dashboardUrl = `${auth.serverUrl.replace(/\/+$/, '')}/dashboard`;
+  // Backend host (oa2a.org) serves the API; the dashboard renders on the
+  // frontend host (opena2a.org). Map API host -> frontend before printing.
+  const dashboardBase = resolveDashboardUrl(auth.serverUrl);
+  const agentUrl = `${dashboardBase}/dashboard/agents/${agentId}`;
+  const mcpUrl = `${dashboardBase}/dashboard/mcp`;
+  const isCloud = /aim\.(opena2a|oa2a)\.org$/.test(new URL(auth.serverUrl).host);
 
   if (isJson) {
     process.stdout.write(JSON.stringify({
@@ -257,14 +281,32 @@ export async function setup(options: SetupOptions): Promise<number> {
       trustScore,
       mcpServersDiscovered: mcpCount,
       mcpServersAttached: mcpAttached,
-      dashboard: dashboardUrl,
+      serverUrl: auth.serverUrl,
+      dashboard: agentUrl,
+      mcpDashboard: mcpUrl,
     }, null, 2) + '\n');
   } else {
     // Server returns 0-1 scale; display as percentage
     const displayScore = trustScore <= 1 ? Math.round(trustScore * 100) : Math.round(trustScore);
     process.stdout.write(green('  Trust score:') + ` ${displayScore}/100\n`);
-    process.stdout.write(green('  Dashboard:') + ` ${cyan(dashboardUrl)}\n`);
-    process.stdout.write('\n' + dim('  Agent is registered and monitored.') + '\n');
+    process.stdout.write(green('  Agent page:') + ` ${cyan(agentUrl)}\n`);
+    if (mcpCount > 0) {
+      process.stdout.write(green('  MCP inventory:') + ` ${cyan(mcpUrl)}\n`);
+    }
+    process.stdout.write('\n');
+    process.stdout.write(bold('  What just happened:') + '\n');
+    process.stdout.write(dim('    - Agent identity registered on AIM (signed Ed25519 keypair, agent_id ') + cyan(agentId.slice(0, 8)) + dim(')') + '\n');
+    process.stdout.write(dim(`    - ${mcpCount} MCP server${mcpCount === 1 ? '' : 's'} discovered, ${mcpAttached} attached and now scored against the trust graph`) + '\n');
+    process.stdout.write(dim('    - Trust score reflects the agent + every MCP it depends on; it updates as new evidence arrives') + '\n');
+    process.stdout.write('\n');
+    process.stdout.write(bold('  Next:') + '\n');
+    process.stdout.write(dim('    opena2a watch                  # live activity tail\n'));
+    process.stdout.write(dim('    opena2a identity list          # list your agents\n'));
+    process.stdout.write(dim('    opena2a trust <package>        # trust query for any npm/MCP\n'));
+    if (isCloud) {
+      process.stdout.write('\n');
+      process.stdout.write(dim('  Self-hosted instead? Re-run: ') + cyan('opena2a login --server localhost:8080') + dim(' (or any URL of an AIM instance you control).') + '\n');
+    }
   }
 
   return 0;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -442,7 +442,7 @@ analysis runs and results can be shared with the community.
   program
     .command('login')
     .description('Authenticate with an AIM server via browser login')
-    .option('--server <url>', 'AIM server URL (default: cloud, i.e. aim.oa2a.org)')
+    .option('--server <url>', 'AIM server URL (default: cloud = aim.opena2a.org; pass localhost:8080 or a URL for a self-hosted AIM)')
     .option('--json', 'Output as JSON')
     .action(async (opts) => {
       const { login } = await import('./commands/login.js');

--- a/packages/cli/src/util/server-url.ts
+++ b/packages/cli/src/util/server-url.ts
@@ -36,3 +36,41 @@ export function resolveServerUrl(input: string): string {
   // Any other hostname -- default to https
   return `https://${trimmed}`.replace(/\/+$/, '');
 }
+
+/**
+ * Map an AIM API/server URL to the user-facing frontend host (where the
+ * dashboard renders). Backend = oa2a.org, frontend = opena2a.org. Printing the
+ * backend host as a "Dashboard:" link sends users to the API health endpoint
+ * instead of the UI.
+ *
+ *   https://aim.oa2a.org             -> https://aim.opena2a.org
+ *   https://api.aim.opena2a.org      -> https://aim.opena2a.org
+ *   http://localhost:8080            -> http://localhost:8080  (self-hosted: same host serves both)
+ *   https://aim.example.internal     -> https://aim.example.internal (self-hosted: same host)
+ */
+export function resolveDashboardUrl(serverUrl: string): string {
+  const trimmed = serverUrl.trim().replace(/\/+$/, '');
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    // Caller passed something that isn't parseable; return it untouched so
+    // callers don't crash on unexpected config.
+    return trimmed;
+  }
+
+  // AIM Cloud backend -> AIM Cloud frontend
+  if (url.host === 'aim.oa2a.org') {
+    return 'https://aim.opena2a.org';
+  }
+
+  // Community API host -> community frontend (drop the api. prefix)
+  if (url.host === 'api.aim.opena2a.org') {
+    return 'https://aim.opena2a.org';
+  }
+
+  // Self-hosted (localhost or custom hostname): same host serves API + UI.
+  // Strip any path so the caller can append its own.
+  return `${url.protocol}//${url.host}`;
+}


### PR DESCRIPTION
## Summary

- `opena2a setup` was printing `\${auth.serverUrl}/dashboard`, which on AIM Cloud became `https://aim.oa2a.org/dashboard` — the API host. Backend = `oa2a.org`, frontend = `opena2a.org`; the API host returns JSON and does not render the UI.
- New helper `resolveDashboardUrl()` in `packages/cli/src/util/server-url.ts` maps API host → frontend host (`aim.oa2a.org` → `aim.opena2a.org`, `api.aim.opena2a.org` → `aim.opena2a.org`, self-hosted hostnames pass through unchanged).
- Setup deep-links to `/dashboard/agents/<agentId>` instead of generic `/dashboard`, prints a separate `MCP inventory:` line when MCPs were attached, expands the "What just happened" + "Next:" footer, and prints a self-hosted hint on cloud.
- Setup auto-launches the existing `login()` flow when not authenticated, so users no longer have to cancel + retry. JSON callers keep the strict-mode error.
- `opena2a login --server` help and the missing-server-url error stop leaking the backend host (`aim.oa2a.org`).

## Why

User reported that `npx opena2a-cli setup` printed `https://aim.oa2a.org/dashboard` after a successful login, but the dashboard lives at `https://aim.opena2a.org/dashboard`. Same user flagged that the output was too sparse and that there was no mention of self-hosted AIM. The auto-login change closes a UX gap where setup exited code 1 with "Run: opena2a login" and forced the user to retry.

## Coverage

- 6 new unit tests in `__tests__/util/server-url.test.ts` pin the four URL flavors plus a defensive non-URL case (`resolveDashboardUrl` happy paths + trailing slash + non-URL fallback).
- Adversarial review caught: `new URL(auth.serverUrl).host` in the `isCloud` line was unguarded — a corrupted serverUrl would crash AFTER agent registration on the server. Wrapped in try/catch; isCloud degrades to false on parse failure.
- Release-smoke section 4 (`docs/testing/release-smoke.md`) gates the wire output every cli-v* tag push: `opena2a setup --json | jq .dashboard` MUST start with `https://aim.opena2a.org/` (NEVER `aim.oa2a.org`, NEVER `api.aim.opena2a.org`) and end with `/dashboard/agents/<id>`.
- 976/976 tests pass. End-to-end verified against live AIM Cloud auth.

## Pairs with

#NN — `feat(cli): store OAuth tokens in OS keychain instead of plaintext on disk` (companion PR for 0.10.2). Both PRs ship together; merge order doesn't matter, but the second-merged will need a one-line rebase on `release-smoke.md` (URL fix adds section 4; keychain adds section 5 in the post-merge state).

## Test plan

- [x] `npm test` (976/976)
- [x] Local build clean
- [x] End-to-end against live AIM Cloud: `setup --json` returns `dashboard: "https://aim.opena2a.org/dashboard/agents/<id>"`
- [x] Help text: `login --help` no longer mentions `aim.oa2a.org`
- [ ] Reviewer: confirm the URL helper matches the org's frontend/backend split for any custom self-hosted setup you have