### PR TITLE
chore(cli): bump to 0.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3921,7 +3921,7 @@
     },
     "packages/cli": {
       "name": "opena2a-cli",
-      "version": "0.10.0",
+      "version": "0.10.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opena2a-cli",
-  "version": "0.10.0",
+  "version": "0.10.2",
   "description": "Unified CLI for the OpenA2A security platform",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version bump for opena2a-cli 0.10.2. Tag will be created and pushed (cli-v0.10.2) after this merges to trigger the OIDC publish workflow.

Bundles #138 (URL fix) + #139 (keychain). CHANGELOG already updated via #139.