### PR TITLE
fix(cli): register secure alias + check --nanomind/--rescan flags (closes #135)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.10.3
+
+### Bug Fixes
+- **`opena2a secure --fix` and `opena2a check <pkg> --nanomind` no longer dead-end (closes #135).** Both commands appear in HackMyAgent's prefix-substituted Next Steps text every time `opena2a scan` runs against a fixture with findings — `HMA_CLI_PREFIX=opena2a` translates HMA's `hackmyagent secure --fix` to `opena2a secure --fix`, but opena2a-cli renamed `secure` → `scan` and stripped `--nanomind` from `check` (CHANGELOG 0.10.0 audit B17). User following the cited command saw `error: unknown command 'secure'` or `error: too many arguments for 'check'`. Now: `secure` is registered as a Commander alias of `scan` via a new `aliases?: string[]` field on `AdapterConfig` (`packages/cli/src/adapters/types.ts`), populated by the `scan` adapter entry in `packages/cli/src/adapters/registry.ts`. The `check` command registers `--nanomind` and `--rescan` as known options + `.allowExcessArguments(true)`, with both flags forwarded to HMA's check subprocess via `extraArgs`. New regression test `__tests__/adapters/aliases.test.ts` (2 cases) pins the alias list and verifies no collision with another registered command name. CISO Rule 11 / release-test Phase 4f — every cited command now resolves through the parser.
+
 ## 0.10.2
 
 ### Security

--- a/packages/cli/__tests__/adapters/aliases.test.ts
+++ b/packages/cli/__tests__/adapters/aliases.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { ADAPTER_REGISTRY } from '../../src/adapters/registry.js';
+
+describe('AdapterConfig.aliases — closes #135 dead-end command citations', () => {
+  it('scan registers `secure` as an alias so HMA-emitted Next Steps text resolves', () => {
+    const scan = ADAPTER_REGISTRY['scan'];
+    expect(scan).toBeDefined();
+    expect(scan.aliases).toBeDefined();
+    expect(scan.aliases).toContain('secure');
+  });
+
+  it('aliases array does not collide with another registered command name', () => {
+    const allNames = new Set(Object.keys(ADAPTER_REGISTRY));
+    for (const config of Object.values(ADAPTER_REGISTRY)) {
+      for (const alias of config.aliases ?? []) {
+        expect(allNames.has(alias)).toBe(false);
+      }
+    }
+  });
+});

--- a/packages/cli/src/adapters/registry.ts
+++ b/packages/cli/src/adapters/registry.ts
@@ -7,6 +7,9 @@ export const ADAPTER_REGISTRY: Record<string, AdapterConfig> = {
     packageName: 'hackmyagent',
     subcommand: 'secure',
     description: 'Scan AI agent for security vulnerabilities (HackMyAgent)',
+    // `secure` resolves the dead-end command HMA emits via HMA_CLI_PREFIX
+    // substitution in scan output Next Steps (closes #135).
+    aliases: ['secure'],
   },
   secrets: {
     name: 'secrets',

--- a/packages/cli/src/adapters/types.ts
+++ b/packages/cli/src/adapters/types.ts
@@ -17,6 +17,8 @@ export interface AdapterConfig {
   ports?: string[];
   /** Description shown in help text */
   description: string;
+  /** Commander aliases for this command (e.g. scan exposes `secure` so HMA's prefix-substituted Next Steps text resolves). */
+  aliases?: string[];
 }
 
 export interface RunOptions {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -138,6 +138,10 @@ Learn more: https://opena2a.org/docs`);
       .allowUnknownOption(true)
       .helpOption(false); // Disable Commander's --help interception so it passes through to the adapter
 
+    if (config.aliases?.length) {
+      adapterCmd.aliases(config.aliases);
+    }
+
     adapterCmd.action(async (args: string[], _opts: unknown, _cmd: unknown) => {
         // Handle --help / -h: show adapter info without delegating to Docker/external tools
         if (args.includes('--help') || args.includes('-h')) {
@@ -238,7 +242,10 @@ Learn more: https://opena2a.org/docs`);
     program
       .command('check [target]')
       .description('Security check for npm packages, GitHub repos, or local directories')
+      .option('--nanomind', 'Run AI-assisted analysis on top of static checks (passthrough to HackMyAgent)')
+      .option('--rescan', 'Force a fresh scan even if registry has recent data')
       .allowUnknownOption(true)
+      .allowExcessArguments(true)
       .addHelpText('after', `
 Examples:
   $ opena2a check @modelcontextprotocol/server-filesystem   Check npm package via Registry + HMA
@@ -253,9 +260,12 @@ Packages and repos are checked against the OpenA2A Registry first. If fresh data
 exists (< 3 days), it is shown immediately. Otherwise a full HMA security
 analysis runs and results can be shared with the community.
 `)
-      .action(async (target: string | undefined, _opts, cmd) => {
+      .action(async (target: string | undefined, opts: { nanomind?: boolean; rescan?: boolean }, cmd) => {
         const globalOpts = program.opts();
         const extraArgs = cmd.args?.filter((a: string) => a !== target) ?? [];
+        // Registered passthrough flags (HMA emits these in scan Next Steps; #135).
+        if (opts.nanomind) extraArgs.push('--nanomind');
+        if (opts.rescan) extraArgs.push('--rescan');
 
         // Detect npm package names and GitHub repos — both delegate to HMA check:
         //   - Scoped packages (@scope/name) are always npm


### PR DESCRIPTION
## Summary

Closes [#135](https://github.com/opena2a-org/opena2a-org/opena2a/issues/135). Both \`opena2a secure --fix\` and \`opena2a check <pkg> --nanomind\` were dead-end command citations emitted in HMA's Next Steps text via \`HMA_CLI_PREFIX=opena2a\` substitution. This PR registers them as working entry points without changing HMA.

## What changed

- **\`AdapterConfig\` gains \`aliases?: string[]\`** (\`packages/cli/src/adapters/types.ts\`). Optional. The Commander setup loop in \`packages/cli/src/index.ts\` calls \`.aliases(config.aliases)\` when populated.
- **\`scan\` adapter declares \`aliases: ['secure']\`** (\`packages/cli/src/adapters/registry.ts\`). \`opena2a secure --fix\` now routes through the same dispatch path as \`opena2a scan --fix\`.
- **\`check\` command registers \`--nanomind\` and \`--rescan\`** as known options (\`packages/cli/src/index.ts\`). Both forward into \`extraArgs\` so the npm-package code path (\`spawnHmaCheck\`) and the local-path code path (\`dispatchCommand\`) pass them through to HMA. \`.allowExcessArguments(true)\` covers the bare-positional case Commander 13 was rejecting.
- **New regression test** \`__tests__/adapters/aliases.test.ts\` (2 cases): pins the alias list and verifies no collision with another registered command name.

## Verification

- \`opena2a secure --fix\` on a temp dir → exit 0 (delegates to scan/secure)
- \`opena2a secure --help\` → renders the scan adapter help block, no \`unknown command\` error
- \`opena2a check express --nanomind\` → reaches HMA (then trips an unrelated HMA-side \`package_integrity\` bug filed as [opena2a-org/hackmyagent#170](https://github.com/opena2a-org/hackmyagent/issues/170))
- \`opena2a check . --rescan\` → reaches scan secure (the \`Unknown target: .\` is opena2a#120 and is out of scope here)
- Tests: 994/994 (was 992; +2 from the new regression)

## Why this approach (alternatives rejected)

\`\`\`
[CHIEF-CPO] DECISION: Add `secure` as Commander alias of `scan` + register
`--nanomind` as a passthrough flag on `check`.

RATIONALE: Surgical, preserves muscle memory for users typing `opena2a secure`,
doesn't require coordinating with HMA, makes every cited command actually work.
Phase 4f gate (release-test) requires all citations resolve.

ALTERNATIVES REJECTED:
- Post-process HMA stdout: brittle, couples to HMA text format.
- HMA-side `HMA_VERB_MAP` env var: cleanest contract but cross-repo
  coordination + new HMA release. Defer to a future HMA PR; not a blocker.
- Strip the citations from HMA's Next Steps (filter HMA stdout): brittle.
- Drop HMA_CLI_PREFIX so users see `hackmyagent secure --fix`: violates the
  wrapper UX promise (users installed opena2a, not hackmyagent).

ESCALATION: If --nanomind passthrough reveals more dead-end shape (e.g. HMA
prints further opena2a-incompatible verbs downstream), open a sister issue
and consider the HMA-side HMA_VERB_MAP path.
\`\`\`

## Test plan

- [x] \`npm test --workspace=packages/cli\` → 994/994
- [x] \`npm run build --workspace=packages/cli\` → clean
- [x] \`npm run typecheck --workspace=packages/cli\` → clean
- [x] \`opena2a secure --help\` renders adapter help block (no error)
- [x] \`opena2a secure <tmpdir> --ci\` exits 0
- [x] \`opena2a check express --nanomind\` reaches HMA dispatch (Commander parses cleanly)
- [x] Pre-existing-on-main verification: \`git checkout origin/main -- packages/cli/src/{index.ts,adapters/registry.ts,adapters/types.ts}\` → integrity error reproduces (confirms the integrity bug is HMA-side, not introduced by this patch)