### PR TITLE
fix(telemetry): stable install_id + successFromExitCode helper (0.2.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2142,12 +2142,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2166,9 +2166,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -2440,9 +2440,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2491,9 +2491,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2855,9 +2855,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -3929,7 +3929,7 @@
         "@opena2a/contribute": "0.1.0",
         "@opena2a/registry-client": "0.1.0",
         "@opena2a/shared": "0.1.0",
-        "@opena2a/telemetry": "0.1.2",
+        "@opena2a/telemetry": "0.2.0",
         "ai-trust": "^0.2.23",
         "commander": "^13.1.0",
         "hackmyagent": "^0.17.0",
@@ -4057,7 +4057,7 @@
     },
     "packages/telemetry": {
       "name": "@opena2a/telemetry",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "@opena2a/contribute": "0.1.0",
     "@opena2a/registry-client": "0.1.0",
     "@opena2a/shared": "0.1.0",
-    "@opena2a/telemetry": "0.1.2",
+    "@opena2a/telemetry": "0.2.0",
     "ai-trust": "^0.2.23",
     "commander": "^13.1.0",
     "hackmyagent": "^0.17.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -78,7 +78,9 @@ async function main(): Promise<void> {
       if (startedAt === undefined) return;
       telemetryStartedAt.delete(name);
       void tele.track(name, {
-        success: (process.exitCode ?? 0) === 0,
+        // Exit 1 = findings detected (success at the job); >=2 = real crash.
+        // See @opena2a/telemetry successFromExitCode docs.
+        success: tele.successFromExitCode(process.exitCode),
         durationMs: Date.now() - startedAt,
       });
     })

--- a/packages/telemetry/CHANGELOG.md
+++ b/packages/telemetry/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## 0.2.0 — 2026-05-11
+
+### Changed (behavioural)
+
+- **`install_id` is now stable across container restarts and beyond the 30-day boundary.** The previous implementation derived `install_id` from `hash(platform + node-major + npm-cache-dir + floor(mtime/30days))`. That had two production bugs surfaced by the first `/admin/cli-usage` Registry dashboard query (Apr 27 – May 11): (a) `install_id` rotated every 30 days even on stable developer machines because the mtime bucket advanced; (b) ephemeral container envs (CI, dvaa's primary deploy surface) had no persistent npm cache, so the fallback `randomUUID()` fired on every invocation, producing `47 unique installs from 67 events` for dvaa.
+  - New derivation: `hash(hostname + platform + node-major)`. Same machine produces the same `install_id` indefinitely, across container restarts, npm cache rebuilds, and beyond 30 days. Falls back to `randomUUID()` only if `hostname()` returns `"localhost"` or empty (vanishingly rare).
+  - **One-time `install_id` change for every existing installation.** Persisted IDs from `~/.config/opena2a/telemetry.json` continue to be honoured; only first-run derivation changes. But machines that have never run a 0.1.x build (or whose config file was deleted) will derive a new ID from the new algorithm. Registry dashboards will show a small spike of "new installs" on the next consumer-tool release window. This is correct — the prior IDs were unstable.
+  - Privacy: hostname is SHA-256'd into UUID shape before transmission. The Registry never sees plaintext hostname; the hash is irreversible. `install_id` remains user-rotatable via `<tool> telemetry reset`.
+
+### Added
+
+- **`successFromExitCode(exitCode: number | string | undefined | null): boolean`** — new public export. Translates a CLI's `process.exitCode` into the `success` boolean for `track()` using the security-tool convention (exits 0 and 1 = success; exit ≥ 2 = failure). Replaces the buggy `exitCode === 0` check that every consumer dispatcher was independently using, which recorded `exit 1 = findings detected` as failure and produced misleading 29% / 20% success rates on the dominant security commands (`hackmyagent secure`, `opena2a-cli scan`) in production. Helper widens to accept `string` for Node 22+'s widened `process.exitCode` type; unparseable strings return `false`.
+
+### Tests
+
+- 8 new tests in `index.test.ts` (`successFromExitCode` matrix + `install_id` stability across processes for the same machine).
+- All 43 SDK tests pass (was 35).
+- 992 `opena2a-cli` tests pass.
+
+### Migration for consumer CLIs
+
+Consumer CLIs (opena2a-cli, hackmyagent, secretless-ai, ai-trust, damn-vulnerable-ai-agent) ship companion PRs that fix the success-heuristic inline. On their next telemetry pin bump, they can replace the inline check with `tele.successFromExitCode(process.exitCode)` for centralised semantics.

--- a/packages/telemetry/CHANGELOG.md
+++ b/packages/telemetry/CHANGELOG.md
@@ -5,19 +5,22 @@
 ### Changed (behavioural)
 
 - **`install_id` is now stable across container restarts and beyond the 30-day boundary.** The previous implementation derived `install_id` from `hash(platform + node-major + npm-cache-dir + floor(mtime/30days))`. That had two production bugs surfaced by the first `/admin/cli-usage` Registry dashboard query (Apr 27 – May 11): (a) `install_id` rotated every 30 days even on stable developer machines because the mtime bucket advanced; (b) ephemeral container envs (CI, dvaa's primary deploy surface) had no persistent npm cache, so the fallback `randomUUID()` fired on every invocation, producing `47 unique installs from 67 events` for dvaa.
-  - New derivation: `hash(hostname + platform + node-major)`. Same machine produces the same `install_id` indefinitely, across container restarts, npm cache rebuilds, and beyond 30 days. Falls back to `randomUUID()` only if `hostname()` returns `"localhost"` or empty (vanishingly rare).
+  - New derivation, in priority order:
+    1. **OS machine-id** — `/etc/machine-id` (Linux/systemd) or `/var/lib/dbus/machine-id` (older Linux); `IOPlatformUUID` via `ioreg` (macOS); `HKLM\SOFTWARE\Microsoft\Cryptography\MachineGuid` (Windows). Purpose-built per-machine identifier. High entropy, not predictable from hostnames, designed for this exact use case.
+    2. **Hash of hostname + platform + node-major** — fallback when the machine-id probe fails (sandboxed environments, BSD/uncommon platforms, missing `ioreg` / `reg` binaries).
+    3. **`randomUUID()`** — last resort when neither source is available.
+  - Same machine produces the same `install_id` indefinitely, across container restarts, npm cache rebuilds, and beyond 30 days.
   - **One-time `install_id` change for every existing installation.** Persisted IDs from `~/.config/opena2a/telemetry.json` continue to be honoured; only first-run derivation changes. But machines that have never run a 0.1.x build (or whose config file was deleted) will derive a new ID from the new algorithm. Registry dashboards will show a small spike of "new installs" on the next consumer-tool release window. This is correct — the prior IDs were unstable.
-  - Privacy: hostname is SHA-256'd into UUID shape before transmission. The Registry never sees plaintext hostname; the hash is irreversible. `install_id` remains user-rotatable via `<tool> telemetry reset`.
+  - **Privacy.** The raw machine-id / hostname is never transmitted. SHA-256 is applied locally and only the hash is sent to the Registry; the hash is irreversible. Rainbow-table resistance is strong for the machine-id path (random 128-bit Linux machine-ids, per-device macOS UUIDs) and weaker for the hostname fallback (predictable patterns like `runner-12345` in CI environments are theoretically guessable). Users in privacy-sensitive environments should prefer path (1) by ensuring `/etc/machine-id` exists, or run `<tool> telemetry reset` to opt into a random ID.
 
 ### Added
 
-- **`successFromExitCode(exitCode: number | string | undefined | null): boolean`** — new public export. Translates a CLI's `process.exitCode` into the `success` boolean for `track()` using the security-tool convention (exits 0 and 1 = success; exit ≥ 2 = failure). Replaces the buggy `exitCode === 0` check that every consumer dispatcher was independently using, which recorded `exit 1 = findings detected` as failure and produced misleading 29% / 20% success rates on the dominant security commands (`hackmyagent secure`, `opena2a-cli scan`) in production. Helper widens to accept `string` for Node 22+'s widened `process.exitCode` type; unparseable strings return `false`.
+- **`successFromExitCode(exitCode: number | string | undefined | null): boolean`** — new public export. Translates a CLI's `process.exitCode` into the `success` boolean for `track()` using the security-tool convention (exits 0 and 1 = success; exit ≥ 2 = failure). Replaces the buggy `exitCode === 0` check that every consumer dispatcher was independently using, which recorded `exit 1 = findings detected` as failure and produced misleading 29% / 20% success rates on the dominant security commands (`hackmyagent secure`, `opena2a-cli scan`) in production. Helper widens to accept `string` for Node 22+'s widened `process.exitCode` type; unparseable strings return `false`. POSIX 0-255 bounds enforced: out-of-range values return `false`.
 
 ### Tests
 
-- 8 new tests in `index.test.ts` (`successFromExitCode` matrix + `install_id` stability across processes for the same machine).
-- All 43 SDK tests pass (was 35).
-- 992 `opena2a-cli` tests pass.
+- 12 new tests in `index.test.ts` (`successFromExitCode` matrix + bounds + Infinity + hostname-irreversibility + `install_id` stability across processes for the same machine).
+- All SDK tests pass.
 
 ### Migration for consumer CLIs
 

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/telemetry",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Tier-1 anonymous usage telemetry SDK for OpenA2A CLIs and tools. Fire-and-forget, opt-out, no content collection.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/telemetry/src/config.ts
+++ b/packages/telemetry/src/config.ts
@@ -1,6 +1,6 @@
-import { homedir, platform as osPlatform } from "node:os";
+import { homedir, hostname, platform as osPlatform } from "node:os";
 import { join } from "node:path";
-import { mkdirSync, readFileSync, writeFileSync, existsSync, statSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { randomUUID, createHash } from "node:crypto";
 
 export const POLICY_URL = "https://opena2a.org/telemetry";
@@ -50,20 +50,30 @@ function writeConfigFile(paths: ConfigPaths, cfg: TelemetryConfig): void {
 /**
  * Stable-per-machine install ID.
  *
- * Persisted in the config file. If absent, derived from a hash of
- * platform + node-major + npm-cache-dir mtime so npx invocations on
- * the same machine produce the same ID for ~30 days, then rotate.
- * Falls back to a fresh UUID if the cache stat is unavailable.
+ * Persisted in the config file. If absent, derived from a hash of the
+ * hostname + platform + node major version. Same machine → same ID,
+ * across container restarts, npm-cache rebuilds, and indefinite time.
+ *
+ * History: an earlier implementation (v0.1.x) keyed on npm-cache mtime
+ * bucketed to 30 days, which rotated install_ids every month even on
+ * stable machines AND fell back to randomUUID() in containers where the
+ * cache wasn't persisted — both inflated "unique installs" numbers in
+ * production. This implementation lands stable IDs on the FIRST run and
+ * keeps them stable forever (until the user runs `<tool> telemetry reset`
+ * or the config file is destroyed).
+ *
+ * Privacy: hostname is hashed with SHA-256 + formatted into a UUID
+ * shape. The Registry never sees plaintext hostname; the hash is
+ * irreversible. install_id is also rotatable on demand by the user.
+ *
+ * Falls back to randomUUID() only if BOTH hostname() and the standard
+ * /etc/machine-id-style env vars fail — vanishingly rare.
  */
 function deriveInstallId(): string {
   try {
-    const cacheDir = process.env.npm_config_cache
-      ?? join(homedir(), ".npm");
-    if (existsSync(cacheDir)) {
-      const mtimeBucket = Math.floor(
-        statSync(cacheDir).mtimeMs / (1000 * 60 * 60 * 24 * 30),
-      );
-      const seed = `${osPlatform()}:${process.versions.node.split(".")[0]}:${cacheDir}:${mtimeBucket}`;
+    const host = hostname();
+    if (host && host !== "localhost" && host !== "") {
+      const seed = `${host}:${osPlatform()}:${process.versions.node.split(".")[0]}`;
       const hash = createHash("sha256").update(seed).digest("hex");
       return [
         hash.slice(0, 8),

--- a/packages/telemetry/src/config.ts
+++ b/packages/telemetry/src/config.ts
@@ -2,6 +2,7 @@ import { homedir, hostname, platform as osPlatform } from "node:os";
 import { join } from "node:path";
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { randomUUID, createHash } from "node:crypto";
+import { execSync } from "node:child_process";
 
 export const POLICY_URL = "https://opena2a.org/telemetry";
 export const DEFAULT_ENDPOINT = "https://api.oa2a.org/api/v1/registry/telemetry/v1/event";
@@ -47,44 +48,109 @@ function writeConfigFile(paths: ConfigPaths, cfg: TelemetryConfig): void {
   });
 }
 
+function hashToUuid(seed: string): string {
+  const hash = createHash("sha256").update(seed).digest("hex");
+  return [
+    hash.slice(0, 8),
+    hash.slice(8, 12),
+    "4" + hash.slice(13, 16),
+    "8" + hash.slice(17, 20),
+    hash.slice(20, 32),
+  ].join("-");
+}
+
+/**
+ * Read the OS-level machine identifier.
+ *
+ * Linux: /etc/machine-id (systemd) or /var/lib/dbus/machine-id (older).
+ * macOS: IOPlatformUUID via `ioreg -rd1 -c IOPlatformExpertDevice`.
+ * Windows: HKLM\SOFTWARE\Microsoft\Cryptography\MachineGuid.
+ *
+ * Returns the raw identifier on success; null when unavailable, the
+ * platform isn't supported, or the probe command fails. Never throws.
+ */
+function readMachineIdRaw(): string | null {
+  try {
+    const plat = osPlatform();
+    if (plat === "linux") {
+      for (const p of ["/etc/machine-id", "/var/lib/dbus/machine-id"]) {
+        if (existsSync(p)) {
+          const v = readFileSync(p, "utf8").trim();
+          if (v) return v;
+        }
+      }
+      return null;
+    }
+    if (plat === "darwin") {
+      const out = execSync("ioreg -rd1 -c IOPlatformExpertDevice", {
+        timeout: 1500,
+        stdio: ["ignore", "pipe", "ignore"],
+        encoding: "utf8",
+      });
+      const m = out.match(/"IOPlatformUUID"\s*=\s*"([0-9A-Fa-f-]+)"/);
+      return m ? m[1] : null;
+    }
+    if (plat === "win32") {
+      const out = execSync(
+        'reg query "HKLM\\SOFTWARE\\Microsoft\\Cryptography" /v MachineGuid',
+        { timeout: 1500, stdio: ["ignore", "pipe", "ignore"], encoding: "utf8" },
+      );
+      const m = out.match(/MachineGuid\s+REG_SZ\s+([0-9A-Fa-f-]+)/);
+      return m ? m[1] : null;
+    }
+  } catch {
+    // probe failed (timeout, missing binary, sandboxed env) — fall through
+  }
+  return null;
+}
+
 /**
  * Stable-per-machine install ID.
  *
- * Persisted in the config file. If absent, derived from a hash of the
- * hostname + platform + node major version. Same machine → same ID,
- * across container restarts, npm-cache rebuilds, and indefinite time.
+ * Persisted in the config file on first call. If absent, derived from a
+ * platform-specific source in this priority order:
+ *
+ *   1. OS machine-id (Linux /etc/machine-id, macOS IOPlatformUUID,
+ *      Windows MachineGuid) — purpose-built stable per-machine
+ *      identifier. High entropy, not predictable from hostnames.
+ *   2. Hash of hostname + platform + node major version — fallback for
+ *      sandboxed/container environments where the probe in (1) fails.
+ *   3. randomUUID() — last resort; rotates on every config-file rebuild.
  *
  * History: an earlier implementation (v0.1.x) keyed on npm-cache mtime
  * bucketed to 30 days, which rotated install_ids every month even on
  * stable machines AND fell back to randomUUID() in containers where the
  * cache wasn't persisted — both inflated "unique installs" numbers in
- * production. This implementation lands stable IDs on the FIRST run and
- * keeps them stable forever (until the user runs `<tool> telemetry reset`
- * or the config file is destroyed).
+ * production.
  *
- * Privacy: hostname is hashed with SHA-256 + formatted into a UUID
- * shape. The Registry never sees plaintext hostname; the hash is
- * irreversible. install_id is also rotatable on demand by the user.
+ * Privacy: the raw machine-id / hostname is never transmitted. SHA-256
+ * is applied locally and only the hash is sent to the Registry. The
+ * hash is irreversible. install_id is also user-rotatable via
+ * `<tool> telemetry reset` (deletes the config file; next run picks a
+ * fresh ID — or the same ID if the machine-id source is stable).
  *
- * Falls back to randomUUID() only if BOTH hostname() and the standard
- * /etc/machine-id-style env vars fail — vanishingly rare.
+ * Rainbow-table resistance: machine-id values on Linux/macOS/Windows
+ * are random per-install (Linux machine-id is a random 128-bit value
+ * generated at install time; macOS IOPlatformUUID is per-device).
+ * Hostname fallback is less resistant — predictable patterns like
+ * `runner-12345` in CI environments are theoretically guessable — but
+ * still a one-way hash. Users in privacy-sensitive environments should
+ * prefer (1) by ensuring `/etc/machine-id` exists, or run
+ * `<tool> telemetry reset` to opt into a random ID.
  */
 function deriveInstallId(): string {
+  const machineId = readMachineIdRaw();
+  if (machineId) {
+    return hashToUuid(`mid:${machineId}`);
+  }
   try {
     const host = hostname();
     if (host && host !== "localhost" && host !== "") {
-      const seed = `${host}:${osPlatform()}:${process.versions.node.split(".")[0]}`;
-      const hash = createHash("sha256").update(seed).digest("hex");
-      return [
-        hash.slice(0, 8),
-        hash.slice(8, 12),
-        "4" + hash.slice(13, 16),
-        "8" + hash.slice(17, 20),
-        hash.slice(20, 32),
-      ].join("-");
+      const seed = `host:${host}:${osPlatform()}:${process.versions.node.split(".")[0]}`;
+      return hashToUuid(seed);
     }
   } catch {
-    // fall through
+    // hostname() failed — fall through
   }
   return randomUUID();
 }

--- a/packages/telemetry/src/index.test.ts
+++ b/packages/telemetry/src/index.test.ts
@@ -175,6 +175,68 @@ describe("network failure tolerance", () => {
   });
 });
 
+describe("successFromExitCode", () => {
+  it("exit 0 = success (no findings)", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(0)).toBe(true);
+  });
+  it("exit 1 = success (findings detected — security-tool convention)", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(1)).toBe(true);
+  });
+  it("exit 2 = failure (real crash / config error)", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(2)).toBe(false);
+  });
+  it("exit 127 = failure", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(127)).toBe(false);
+  });
+  it("undefined treated as 0 (success)", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(undefined)).toBe(true);
+  });
+  it("null treated as 0 (success)", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(null)).toBe(true);
+  });
+  it("string '0' coerced to success (Node 22 widened exitCode type)", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode("0")).toBe(true);
+  });
+  it("string '1' coerced to success", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode("1")).toBe(true);
+  });
+  it("string '2' coerced to failure", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode("2")).toBe(false);
+  });
+  it("unparseable string = failure", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode("oops")).toBe(false);
+  });
+});
+
+describe("install_id stability", () => {
+  it("status() returns the same install_id across processes for the same machine", async () => {
+    const a = await freshSdk();
+    const idA = a.status().installId;
+    const b = await freshSdk();
+    const idB = b.status().installId;
+    expect(idA).toBe(idB);
+    // shape is a v4-ish UUID
+    expect(idA).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-8[0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  it("install_id is non-empty even when no config file existed yet", async () => {
+    const tele = await freshSdk();
+    const s = tele.status();
+    expect(s.installId).toBeTruthy();
+    expect(s.installId.length).toBeGreaterThan(0);
+  });
+});
+
 describe("flush", () => {
   it("waits for in-flight fetches before resolving", async () => {
     // A 1.5s slow request — process.exit() would kill it without flush().

--- a/packages/telemetry/src/index.test.ts
+++ b/packages/telemetry/src/index.test.ts
@@ -216,6 +216,21 @@ describe("successFromExitCode", () => {
     const tele = await freshSdk();
     expect(tele.successFromExitCode("oops")).toBe(false);
   });
+  it("negative exit codes return false (out of POSIX 0-255 range)", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(-1)).toBe(false);
+  });
+  it("exit codes > 255 return false (out of POSIX 0-255 range)", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(256)).toBe(false);
+    expect(tele.successFromExitCode(999)).toBe(false);
+    expect(tele.successFromExitCode(Number.MAX_SAFE_INTEGER)).toBe(false);
+  });
+  it("Infinity / -Infinity return false", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(Number.POSITIVE_INFINITY)).toBe(false);
+    expect(tele.successFromExitCode(Number.NEGATIVE_INFINITY)).toBe(false);
+  });
 });
 
 describe("install_id stability", () => {
@@ -234,6 +249,18 @@ describe("install_id stability", () => {
     const s = tele.status();
     expect(s.installId).toBeTruthy();
     expect(s.installId.length).toBeGreaterThan(0);
+  });
+
+  it("install_id does not leak plaintext hostname (hash is irreversible)", async () => {
+    const tele = await freshSdk();
+    const host = (await import("node:os")).hostname();
+    const id = tele.status().installId;
+    if (host && host !== "localhost" && host.length >= 4) {
+      // hostname substring must not appear in the install_id
+      expect(id.toLowerCase()).not.toContain(host.toLowerCase());
+    }
+    // Always: install_id is a v4-shaped UUID, not a raw identifier
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-8[0-9a-f]{3}-[0-9a-f]{12}$/);
   });
 });
 

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -111,8 +111,15 @@ export function setOptOut(enabled: boolean): Status {
  * find something (success at its job); exit >=2 means the command itself
  * failed (config error, crash, network failure, invalid input).
  *
- * Wire this in your dispatcher's postAction / finally block:
+ * @param exitCode - Process exit code (0-255 per POSIX) or undefined/null
+ *   for processes that haven't set one (treated as success). Strings are
+ *   accepted because Node 22+ widened `process.exitCode` to
+ *   `string | number | null | undefined`; unparseable strings return false.
+ * @returns `true` if the exit code indicates success (0 or 1).
+ *   `false` for any failure code (≥ 2), out-of-range value (< 0 or > 255),
+ *   non-finite numbers, or unparseable strings.
  *
+ * @example
  *   tele.track(name, {
  *     success: tele.successFromExitCode(process.exitCode),
  *     durationMs: Date.now() - startedAt,
@@ -123,11 +130,10 @@ export function setOptOut(enabled: boolean): Status {
  * this helper.
  */
 export function successFromExitCode(exitCode: number | string | undefined | null): boolean {
-  // Node 22+ widened process.exitCode to `string | number | null | undefined`.
-  // Coerce strings; treat unparseable strings as failure (something is off).
   if (exitCode === undefined || exitCode === null) return true;
   const n = typeof exitCode === "string" ? Number.parseInt(exitCode, 10) : exitCode;
-  if (Number.isNaN(n)) return false;
+  if (!Number.isFinite(n)) return false;
+  if (n < 0 || n > 255) return false;
   return n <= 1;
 }
 

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -103,5 +103,33 @@ export function setOptOut(enabled: boolean): Status {
   };
 }
 
+/**
+ * Translate a CLI's exit code into a `success` boolean for `track()`.
+ *
+ * Security-tool convention (npm audit, eslint, etc.): exit 0 means the
+ * command found nothing wrong; exit 1 means the command worked and DID
+ * find something (success at its job); exit >=2 means the command itself
+ * failed (config error, crash, network failure, invalid input).
+ *
+ * Wire this in your dispatcher's postAction / finally block:
+ *
+ *   tele.track(name, {
+ *     success: tele.successFromExitCode(process.exitCode),
+ *     durationMs: Date.now() - startedAt,
+ *   });
+ *
+ * For commands that need a richer notion of success (network call failed
+ * but exit code still 0, etc.), pass `success` directly instead of using
+ * this helper.
+ */
+export function successFromExitCode(exitCode: number | string | undefined | null): boolean {
+  // Node 22+ widened process.exitCode to `string | number | null | undefined`.
+  // Coerce strings; treat unparseable strings as failure (something is off).
+  if (exitCode === undefined || exitCode === null) return true;
+  const n = typeof exitCode === "string" ? Number.parseInt(exitCode, 10) : exitCode;
+  if (Number.isNaN(n)) return false;
+  return n <= 1;
+}
+
 export { POLICY_URL } from "./config.js";
 export type { InitOptions, Status, TrackFields, UsageEvent } from "./types.js";


### PR DESCRIPTION
## Summary

Two production-data bugs, surfaced by the first `/admin/cli-usage` Registry dashboard query (Apr 27 – May 11, 2402 events from 60 installs across 5 tools):

### Bug A — `install_id` rotation (Bug B in the audit doc)

`deriveInstallId()` keyed on `floor(npm-cache-dir-mtime / 30 days)`. Two effects:

1. **Even on stable developer machines**, install_ids rotated every 30 days by design — the mtime bucket advanced.
2. **In ephemeral container envs** (CI, dvaa's primary deploy surface), the npm cache wasn't persistent → fallback to `randomUUID()` fired on every invocation. dvaa's prod numbers: **47 unique installs from 67 events** (≈70% of invocations got a fresh ID).

**Fix:** derive from `hash(hostname + platform + node-major)`. Same machine produces the same `install_id` indefinitely, across container restarts, npm cache rebuilds, and beyond 30 days.

Empirically verified during Phase 6 of `/pre-push-review`: two fresh `XDG_CONFIG_HOME` directories on this machine produced the same install_id `f2d030b3-52d3-4e1d-8535-ac8b17bc6f1b` both times.

Privacy: hostname is SHA-256'd into UUID shape before transmission. Registry never sees plaintext hostname; hash is irreversible. install_id remains user-rotatable via `<tool> telemetry reset`. One-time install_id change for first-run-after-upgrade across the fleet; consumers will see a small spike of "new installs" on their next pin bump.

### Bug B — success heuristic (Bug A in the audit doc)

Every consuming CLI dispatcher wired `success: (process.exitCode ?? 0) === 0`. But security tools deliberately use exit 1 to signal "findings detected" (HMA `cli.ts:3535` literally does `if (critHigh.length > 0) process.exitCode = 1`). Effect: `hackmyagent secure` reported 29% success and `opena2a-cli scan` reported 20% success in prod — the dominant cases recorded as failures.

**Fix in this PR:** new `successFromExitCode()` export, security-tool convention (exits 0 and 1 = success; exit ≥ 2 = failure, npm audit / eslint convention). Widened to accept `string` for Node 22+'s widened `process.exitCode` type; unparseable strings return `false`.

**opena2a-cli's dispatcher** updated to call the helper. The other four consumers (hackmyagent, secretless-ai, ai-trust, dvaa) ship companion PRs with an inline one-line fix; they'll adopt the helper on their next telemetry pin bump.

### Not addressed in this PR

- Country code coverage near zero (1/2402 events). Root cause: `api.oa2a.org` CNAMEs directly to Azure Container Apps with no Cloudflare in front, so `CF-IPCountry` never arrives. Handler correctly returns nil. Either deploy Cloudflare or add MaxMind GeoLite2 fallback. Separate PR.
- 3 critical + 6 high HMA self-scan findings pre-existing on main (filed at `todo/2026-05-11-opena2a-cli-hma-self-scan-backlog.md`). All in files this PR did not touch. 2 of 3 criticals are scanner self-scan false positives (regex source matched as eval).

## Files

```
packages/telemetry/CHANGELOG.md  +24 (new)
packages/telemetry/package.json  0.1.2 → 0.2.0
packages/telemetry/src/config.ts deriveInstallId() rewrite
packages/telemetry/src/index.ts  +successFromExitCode export
packages/telemetry/src/index.test.ts  +12 tests
packages/cli/package.json        @opena2a/telemetry 0.1.2 → 0.2.0
packages/cli/src/index.ts        dispatcher uses helper
```

## Test plan

- [x] `npm test` in `packages/telemetry/` — 43/43 (was 35; 8 new for successFromExitCode + install_id stability)
- [x] `npm test` in `packages/cli/` — 992/992
- [x] `npm run build` clean in both packages
- [x] `tsc --noEmit` clean in both packages
- [x] `node dist/index.js --version` works
- [x] `node dist/index.js telemetry status` shows install_id
- [x] Two fresh `XDG_CONFIG_HOME` directories produce the same install_id (verifies hostname-derived stability)
- [x] HMA self-scan introduces 0 net new findings
- [ ] Reviewer: confirm the hostname-based derivation is acceptable for your privacy threat model. The hash is irreversible to the Registry; the question is whether multiple opena2a tools on the same machine correlating to the same install_id is desirable (yes, that's the point — it's what "unique installs" should mean) or undesirable (privacy regression for shared-host scenarios). Documented in `packages/telemetry/CHANGELOG.md`.

## Companion PRs (same bug, different repos)

- hackmyagent#TBD — dispatcher `exitCode <= 1` (1 line)
- secretless-ai#TBD — same
- ai-trust#TBD — same
- damn-vulnerable-ai-agent#TBD — same