### PR TITLE
chore(cli): bump to 0.10.3 — adopt @opena2a/telemetry 0.2.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opena2a-cli",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Unified CLI for the OpenA2A security platform",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Ships opena2a-cli 0.10.3 to consume the just-published `@opena2a/telemetry@0.2.0`. The inline success-heuristic fix already landed via #144; this PR is the version bump that triggers the npm publish.

## What users get

- Stable `install_id` across container restarts (machine-id source on Linux/macOS/Windows; hostname-hash fallback).
- `opena2a` commands that exit with code 1 because findings were detected are now correctly reported as `success: true` in telemetry, instead of inflating the failure rate.

Visible via `opena2a telemetry status` returning the same `installId` across runs and across container rebuilds.

## Test plan

- [x] 992/992 cli tests pass locally
- [x] 47/47 telemetry SDK tests pass
- [x] @opena2a/telemetry 0.2.0 is on npm (published 15:21Z, SLSA v1 provenance verified)
- [ ] After merge: tag `cli-v0.10.3` triggers GHA publish via OIDC
- [ ] Verify `npm view opena2a-cli version` returns 0.10.3 with attestations