### PR TITLE
docs(readme): mirror AIM README structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
-# opena2a
+# opena2a-cli
 
 > **[OpenA2A](https://github.com/opena2a-org/opena2a)**: [CLI](https://github.com/opena2a-org/opena2a) · [HackMyAgent](https://github.com/opena2a-org/hackmyagent) · [Secretless](https://github.com/opena2a-org/secretless-ai) · [AIM](https://github.com/opena2a-org/agent-identity-management) · [Browser Guard](https://github.com/opena2a-org/AI-BrowserGuard) · [DVAA](https://github.com/opena2a-org/damn-vulnerable-ai-agent)
 
-Your AI agents, IDE plugins, and MCP servers leak credentials, install untrusted skills, and act outside their declared scope. Most teams have no idea this is happening until something breaks. `opena2a` is the open-source security CLI that finds it, fixes it, and proves it stayed fixed — across every AI tool in your stack, locally, no account required.
+Unified CLI for the OpenA2A security toolchain. One command finds credential leaks, shadow AI, unsigned configs, and ungoverned agents, then fixes them. Apache 2.0.
 
-Apache 2.0. `npx opena2a-cli` away.
+[![npm version](https://img.shields.io/npm/v/opena2a-cli.svg)](https://www.npmjs.com/package/opena2a-cli)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
+[Website](https://opena2a.org) · [Docs](https://opena2a.org/docs) · [Demos](https://opena2a.org/demos) · [Discord](https://discord.gg/uRZa3KXgEn)
+
+## Quick start
 
 ```bash
 npx opena2a-cli review
@@ -27,216 +32,204 @@ npx opena2a-cli review
 
 ![opena2a review](docs/images/review-demo.gif)
 
-[All demos](https://opena2a.org/demos)
-
----
-
 ## Install
 
-### Quick — npm
+### npm
 
 ```bash
-npx opena2a-cli review               # zero-install, runs once
-npm install -g opena2a-cli           # install globally if you'd rather
+npx opena2a-cli review          # run once, no install
+npm install -g opena2a-cli      # install globally
 ```
 
-### Brew (macOS / Linux)
+Requires Node.js 18 or later.
+
+### Homebrew
 
 ```bash
-brew tap opena2a-org/tap
-brew tap-info opena2a-org/tap        # verify the tap source before installing
-brew install opena2a
+brew install opena2a-org/tap/opena2a
 ```
 
-### From source — for contributors
+### From source
 
-The CLI is a TypeScript monorepo. Clone and build if you want to inspect every line, contribute, or run an unreleased version.
+This repo is a TypeScript turborepo. Clone and build if you want to inspect the source, contribute, or run an unreleased version.
 
 ```bash
 git clone https://github.com/opena2a-org/opena2a.git
 cd opena2a
-git verify-tag $(git describe --tags --abbrev=0)   # verify the latest release tag's signature
+git verify-tag $(git describe --tags --abbrev=0)   # verify the latest release tag
 npm install
-npm run build                        # builds all workspaces via turbo
-./packages/cli/dist/index.js review  # run the freshly-built binary
+npm run build                                      # builds all workspaces via turbo
+./packages/cli/dist/index.js review                # run the freshly-built binary
 
 # Or link it globally for the current shell:
 cd packages/cli && npm link
 opena2a review
 ```
 
-The repo is a turborepo with these workspaces — `packages/cli` is the binary; the rest are libraries it consumes:
+The workspaces. `packages/cli` is the binary; the rest are libraries it consumes.
 
 ```
 packages/
-├── cli            ← the `opena2a` binary
-├── aim-core       ← local-first AIM (Ed25519 identity, audit log, policies)
-├── check-core     ← scanner orchestration
-├── shared         ← types + utilities
-├── cli-ui         ← shared render primitives
+├── cli                  the opena2a binary
+├── aim-core             local-first identity, audit log, policies
+├── check-core           scanner orchestration
+├── cli-ui               shared render primitives
 ├── credential-patterns
 ├── registry-client
 ├── ai-classifier
 ├── telemetry
-└── contribute     ← skill scaffolding
+├── contribute           skill scaffolding
+└── shared               types + utilities
 ```
 
-### Verifying what you installed
+The CLI also depends on three sister packages published from their own repos (declared as runtime deps in `packages/cli/package.json`): [`hackmyagent`](https://github.com/opena2a-org/hackmyagent), [`secretless-ai`](https://github.com/opena2a-org/secretless-ai), and [`ai-trust`](https://github.com/opena2a-org/ai-trust). `opena2a scan` delegates to `hackmyagent`. `opena2a secrets` delegates to `secretless-ai`. `opena2a trust` queries via `ai-trust`.
 
-Every release is published via npm Trusted Publishing with SLSA v1 provenance — there is no long-lived NPM_TOKEN in the publish workflow; the GitHub Actions runner exchanges its OIDC token with npm at publish time. To verify the package you installed was actually built from the source you can read on GitHub:
+### Verifying what was installed
+
+Every release publishes via npm Trusted Publishing with SLSA v1 provenance. No long-lived `NPM_TOKEN`. GitHub Actions exchanges its OIDC token with npm at publish time.
 
 ```bash
 npm view opena2a-cli dist.attestations --json
-# → non-empty result with predicateType "https://slsa.dev/provenance/v1"
+# Expects non-empty result with predicateType "https://slsa.dev/provenance/v1"
 ```
 
-For the local CLI's own integrity (defense against post-install tamper), `opena2a status` reports the binary's signature state — and `opena2a shield selfcheck` runs the full self-attestation against the embedded manifest. Built-in. No external tooling required.
+For local CLI integrity (post-install tamper), `opena2a status` reports the binary signature state. `opena2a shield selfcheck` runs the full self-attestation against the embedded manifest.
 
-Identity files generated by the CLI (`~/.opena2a/aim-core/identity.json`) are written `mode 0600` so only your user account can read the secret key. OAuth tokens land in the OS keychain by default; `~/.opena2a/auth.json` stores only metadata.
+Identity files (`~/.opena2a/aim-core/identity.json`) are written `mode 0600`. OAuth tokens live in the OS keychain by default. `~/.opena2a/auth.json` stores metadata only.
 
-### Requirements
+## Which OpenA2A CLI do I want
 
-- Node.js 18 or later
-- Optional: Docker (for `opena2a train`, which boots DVAA)
-- Optional: AIM server running locally (for capability authorization — see [AIM](https://github.com/opena2a-org/agent-identity-management))
+There are four published CLIs in the toolchain. `opena2a` is the unified front door. Each underlying tool can also be installed and run standalone if that fits better.
 
----
-
-## Which OpenA2A CLI do I want?
-
-There are five published CLIs in the toolchain. `opena2a` is the unified front door, but each underlying tool can be installed and run standalone if that's a better fit.
-
-| You want to… | Use | Standalone install |
+| You want to... | Use | Standalone install |
 |---|---|---|
-| Run one command and get a full security review of your project | `opena2a review` | — (front door) |
-| Scan a specific MCP server, skill, npm package, or GitHub repo for vulnerabilities | `opena2a scan <target>` or `hackmyagent check <target>` | `npm install -g hackmyagent` |
-| Wrap any subprocess with credentials injected at runtime (no env vars in shell history) | `opena2a secrets run --only KEY -- <cmd>` or `secretless-ai run --only KEY -- <cmd>` | `npm install -g secretless-ai` |
-| Check the trust posture of an npm/PyPI package before installing it | `opena2a trust <pkg>` or `ai-trust <pkg>` | `npm install -g ai-trust` |
-| Give your agent a cryptographic identity + local audit log, no server | `opena2a identity create --name X` | — (bundled in `opena2a-cli`) |
-| Pentest a live AI agent API endpoint to find real exploits | `hma-hunter hunt <url>` | `npm install -g @hma/hunter` |
-| Benchmark a security tool against 222 standard attack scenarios | `opena2a benchmark` | — (uses OASB internally) |
+| Run one command and get a full security review of your project | `opena2a review` | (front door) |
+| Scan a specific MCP server, skill, npm package, or GitHub repo | `opena2a scan <target>` or `hackmyagent check <target>` | `npm install -g hackmyagent` |
+| Wrap any subprocess with credentials injected at runtime | `opena2a secrets run --only KEY -- <cmd>` or `secretless-ai run --only KEY -- <cmd>` | `npm install -g secretless-ai` |
+| Check the trust posture of an npm or PyPI package before installing | `opena2a trust <pkg>` or `ai-trust <pkg>` | `npm install -g ai-trust` |
+| Give your agent a cryptographic identity and local audit log, no server | `opena2a identity create --name X` | (bundled in `opena2a-cli`) |
+| Benchmark a security tool against 222 standard attack scenarios | `opena2a benchmark` | (uses OASB internally) |
 
-If you're not sure which to start with, run `opena2a review` in your project root. It'll tell you what's wrong and which underlying tool to invoke for the fix.
-
----
+If you're not sure where to start, run `opena2a review` in your project root. It tells you what's wrong and which underlying tool to invoke for the fix.
 
 ## Built-in help
 
-You shouldn't need this README to use the CLI. Three discovery modes:
-
 ```bash
-opena2a ?                              # Recommendations for THIS project
-opena2a ~shadow ai                     # Semantic search ("ai" finds AI-related commands)
-opena2a "find leaked credentials"      # Natural language → matched command
-opena2a                                # Interactive guided wizard (no args)
+opena2a ?                              # recommendations for THIS project
+opena2a ~shadow ai                     # semantic search ("ai" finds AI-related commands)
+opena2a "find leaked credentials"      # natural language to matched command
+opena2a                                # interactive guided wizard (no args)
 ```
-
----
 
 ## Commands
 
-Three job categories — assess, protect, operate. Run any with `--help` for full flags.
+Three job categories: assess, protect, operate. Run any with `--help` for full flags.
 
 ### Assess
 
 | Command | What it does |
 |---|---|
-| `opena2a review` | Full security dashboard. 6-phase assessment, HTML report. The most common entry point. |
+| `opena2a review` | Full security dashboard. 6-phase assessment, HTML report. Most common entry point. |
+| `opena2a init` | Read-only first-time security assessment with a trust score for your project. |
 | `opena2a detect` | Shadow AI discovery. Finds undeclared agents, MCP servers, AI configs. Returns a governance score. |
 | `opena2a scan <target>` | 209 static + 29 semantic + 164 adversarial-payload checks via HackMyAgent. Targets: local repo, npm package, GitHub repo, MCP server, skill, or standalone SOUL.md. |
-| `opena2a scan-soul <path>` | 72 governance controls across 9 domains, 6 profiles. |
-| `opena2a init` | Read-only first-time security assessment with a trust score for your project. |
-| `opena2a trust <pkg>` | Query the public Registry for an npm or PyPI package's trust posture. |
-| `opena2a benchmark` | Run the OASB 222-attack-scenario benchmark against your security tool. |
+| `opena2a check <target>` | Pre-install trust check. Queries the OpenA2A Registry and runs HMA locally. |
+| `opena2a scan-soul <path>` | 72 governance controls across 9 domains, profile-aware. |
+| `opena2a trust <pkg>` | Read-only Registry lookup for an npm or PyPI package. |
+| `opena2a benchmark` | Run the OASB 222-scenario benchmark against your security tool. |
 
 ### Protect
 
 | Command | What it does |
 |---|---|
-| `opena2a protect` | Auto-fix everything review found. Hardcoded credentials → env-var refs + masked previews + rollback manifest. Adds `.gitignore` patterns. Signs configs. |
+| `opena2a protect` | Migrate hardcoded credentials to env-var references, masked previews, rollback manifest. Adds `.gitignore` patterns. Signs configs. |
 | `opena2a harden-soul` | Generate a `SOUL.md` governance file from your project state. |
-| `opena2a harden-skill <path>` | Frontmatter validation + permission scoping + integrity pinning on a Claude/Cursor skill. |
-| `opena2a guard` | Sign + watch config files (`mcp.json`, `claude_desktop_config.json`, etc.). Alerts on unauthorized changes. |
-| `opena2a shield init` | One-shot: review + protect + identity + guard + secrets + arp-runtime in one command. The "do the secure thing for me" front door. |
+| `opena2a harden-skill <path>` | Frontmatter validation, permission scoping, integrity pinning on a Claude or Cursor skill. |
+| `opena2a guard sign` | Sign and watch config files (`mcp.json`, `claude_desktop_config.json`, etc.). Alerts on unauthorized changes. |
+| `opena2a shield init` | One-shot 11-step setup: review, protect, identity, guard, secrets, runtime, policy, hooks. |
 
 ### Operate
 
 | Command | What it does |
 |---|---|
-| `opena2a identity create --name X` | Generate an Ed25519 keypair locally — no server. Writes `~/.opena2a/aim-core/identity.json`. |
-| `opena2a identity attach --all` | Wire up cross-tool bridges so Secretless / HMA / ConfigGuard / Shield / ARP events flow into one unified audit log. |
-| `opena2a identity audit [--limit N]` | Read back the unified audit log. The thing your security team queries when an incident happens. |
+| `opena2a identity create --name X` | Generate an Ed25519 keypair locally. Writes `~/.opena2a/aim-core/identity.json`. |
+| `opena2a identity integrate` | Wire up cross-tool bridges so Secretless, HMA, ConfigGuard, Shield, and ARP events flow into one unified audit log. |
+| `opena2a identity audit [--limit N]` | Read back the unified audit log. The query path for incident response. |
 | `opena2a identity trust` | Local 8-factor posture score. |
 | `opena2a identity sign --data X` | Sign arbitrary bytes with the agent's Ed25519 key. |
 | `opena2a runtime tail [-c N]` | Tail the HMA ARP runtime event stream for the current project. |
 | `opena2a secrets ...` | Credential management via Secretless. `add`, `list`, `run`, `revoke`. |
-| `opena2a mcp ...` | MCP server lifecycle: audit, sign, verify, register. |
+| `opena2a mcp ...` | MCP server lifecycle: `audit`, `sign`, `verify`. |
 | `opena2a status` | What's running, what's protected, what's missing. |
 | `opena2a login` | OAuth 2.0 device flow against AIM Cloud or your self-hosted server. |
 | `opena2a whoami` | Current auth status. |
-| `opena2a create <name>` | Scaffold a new secure skill with signing and heartbeat. |
-| `opena2a train` | Boot DVAA — the deliberately vulnerable AI agent — for security training. |
+| `opena2a skill create <name>` | Scaffold a new secure skill with signing and heartbeat. |
+| `opena2a train` | Boot DVAA, the deliberately vulnerable AI agent, for security training. |
 
 Full command reference: [opena2a.org/docs](https://opena2a.org/docs).
 
----
+## Post-incident review
 
-## Post-incident review (local-first, no server needed)
-
-The most underrated feature: after you've run `opena2a identity attach --all` once, every event the OpenA2A toolchain captures is auto-bridged into a single local audit log. No decorator in your agent code, no server. When something goes wrong:
+Once `opena2a identity integrate` runs once, every event the OpenA2A toolchain captures auto-bridges into a single local audit log. No decorator in your agent code. No server. When something goes wrong:
 
 ```bash
 opena2a identity audit --limit 200
-# → 200 most recent events: credential injections, file accesses, config
-#   changes, scan findings, ARP runtime events — all in one timestamp-
-#   ordered JSON-lines view, sourced from Secretless, HackMyAgent,
-#   ConfigGuard, Shield, and ARP.
+# 200 most recent events: credential injections, file accesses, config
+# changes, scan findings, ARP runtime events. All in one timestamp-
+# ordered JSON-lines view, sourced from Secretless, HackMyAgent,
+# ConfigGuard, Shield, and ARP.
 
 opena2a identity audit | jq 'select(.result == "denied")'
-# → just the denies
+# just the denies
 ```
 
-The audit log lives at `~/.opena2a/aim-core/audit.jsonl`. Append-only. Rotation at 50 MB, last 5 generations kept. Bring your own log aggregator if you want it shipped to Splunk or Sentinel.
+The audit log lives at `~/.opena2a/aim-core/audit.jsonl`. Append-only. Rotation at 50 MB, last 5 generations kept. Forward to Splunk or Sentinel via the standard tail-and-forward pattern.
 
-**Encryption at rest is the user's call.** The JSONL is stored unencrypted by default so `grep` and `jq` work without ceremony. For compliance use cases, encrypt `~/.opena2a/` with filesystem-level encryption (FileVault on macOS, LUKS on Linux, BitLocker on Windows) or ship the JSONL to a KMS-backed log aggregator via the standard \"tail and forward\" pattern.
-
-This is what makes `opena2a-cli` valuable on a solo dev machine, no server.
-
----
-
-## Use cases
-
-| Guide | Time |
-|---|---|
-| [Developer using AI coding tools](docs/use-cases/developer.md) | 5 minutes |
-| [Security team assessing AI risk across a fleet](docs/use-cases/security-team.md) | 10 minutes |
-| [MCP server author shipping safely](docs/use-cases/mcp-server-author.md) | 15 minutes |
-| [CI/CD pipeline integration](docs/use-cases/ci-cd.md) | 20 minutes |
-| [Post-incident audit walkthrough](docs/use-cases/incident-review.md) | 10 minutes |
-
----
+Encryption at rest is filesystem-level. The JSONL stores unencrypted so `grep` and `jq` work without ceremony. For compliance use cases, encrypt `~/.opena2a/` with FileVault on macOS, LUKS on Linux, or BitLocker on Windows, or ship to a KMS-backed log aggregator.
 
 ## Self-host or AIM Cloud
 
 `opena2a-cli` works offline by default. The optional server path:
 
-- **AIM Cloud** — managed at [aim.opena2a.org](https://aim.opena2a.org). `opena2a login` and you're done.
-- **Self-hosted AIM** — Docker stack from [`agent-identity-management`](https://github.com/opena2a-org/agent-identity-management). REST API, dashboard, Postgres-backed audit log, OAuth, 9-factor real-time trust scoring with NanoMind, and the 5-step Fine-Grained Authorization pipeline. Run `bash quickstart.sh` to bring it up.
+- **AIM Cloud.** Managed at [aim.opena2a.org](https://aim.opena2a.org). `opena2a login` and you're done.
+- **Self-hosted AIM.** Docker stack from [`agent-identity-management`](https://github.com/opena2a-org/agent-identity-management). REST API, dashboard, Postgres-backed audit log, OAuth, 9-factor real-time trust scoring with NanoMind, 5-step Fine-Grained Authorization pipeline. Run `bash quickstart.sh` to bring it up.
 
-Local-only mode covers identity, audit, capability policies, and trust scoring. Server adds real-time enforcement, multi-machine fleet management, the dashboard, and MCP attestation. The CLI is the same in both modes — `--server` switches it.
+Local-only mode covers identity, audit, capability policies, and trust scoring. Server adds real-time enforcement, multi-machine fleet management, the dashboard, and MCP attestation. The CLI is the same in both modes. `--server` switches it.
 
----
+## Use cases
 
-## Docs
+| Guide | Time |
+|---|---|
+| [Developer using AI coding tools](docs/use-cases/developer.md) | 5 min |
+| [Security team assessing AI risk across a fleet](docs/use-cases/security-team.md) | 10 min |
+| [MCP server author shipping safely](docs/use-cases/mcp-server-author.md) | 15 min |
+| [CI/CD pipeline integration](docs/use-cases/ci-cd.md) | 20 min |
 
-Full command reference, Shield subcommands, scope drift detection, behavioral governance, credential patterns, and CI/CD examples: [opena2a.org/docs](https://opena2a.org/docs).
+Full index: [docs/USE-CASES.md](docs/USE-CASES.md).
 
----
+## Contributing
+
+Apache 2.0. PRs from outside the org welcome. [CONTRIBUTING.md](CONTRIBUTING.md) has the dev loop, test conventions, and pre-push review gates.
+
+```bash
+git clone https://github.com/opena2a-org/opena2a.git
+cd opena2a && npm install && npm run build && npm test
+```
+
+Security issues: `security@opena2a.org` (coordinated disclosure, response within 24 hours).
+
+## Links
+
+- [Website](https://opena2a.org)
+- [Documentation](https://opena2a.org/docs)
+- [Demos](https://opena2a.org/demos)
+- [AIM](https://github.com/opena2a-org/agent-identity-management)
+- [HackMyAgent](https://github.com/opena2a-org/hackmyagent)
+- [Secretless](https://github.com/opena2a-org/secretless-ai)
+- [Research](https://research.opena2a.org)
+
+Part of the [OpenA2A](https://opena2a.org) security platform.
 
 ## License
 
-Apache-2.0 — see [LICENSE](LICENSE).
-
----
-
-[Website](https://opena2a.org) · [Docs](https://opena2a.org/docs) · [Discord](https://discord.gg/uRZa3KXgEn) · [GitHub](https://github.com/opena2a-org/opena2a)
+Apache-2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Reworks `README.md` to match the OpenA2A reference template (AIM
README, merged via PR #124 in `agent-identity-management`). Same
content, restructured so a new reader can move from "what is this"
to "how do I install it" to "how do I use it" in the same shape as
every other OpenA2A repo.

### What changed

- Title and one-line description above the breadcrumb links row.
- Badges row: npm version + license.
- Website / Docs / Demos / Discord links row directly under badges.
- Quick start surfaces a single command and a realistic sample output, then the existing `docs/images/review-demo.gif`.
- Install split into npm, Homebrew, From source as their own H3.
- New "Verifying what was installed" section points at the SLSA v1 attestation lookup (`npm view opena2a-cli dist.attestations --json`).
- "Which OpenA2A CLI do I want" decision table retained (the differentiator vs HMA/Secretless/AIM/ai-trust READMEs).
- Commands tightened across Assess / Protect / Operate.
- Dead link `docs/use-cases/incident-review.md` (file does not exist) removed.
- "Encryption at rest is the user's call" phrasing removed per the no-marketing-slogan rule. Encryption guidance kept, framing made declarative.
- All em dashes removed.

### Verified before push

- Every command in the README parses against `packages/cli/dist/index.js` (`review`, `init`, `detect`, `scan`, `check`, `scan-soul`, `harden-soul`, `harden-skill`, `benchmark`, `trust`, `protect`, `guard`, `shield`, `identity`, `runtime`, `secrets`, `mcp`, `status`, `login`, `whoami`, `skill`, `train`).
- Stats unchanged: 209 static + 29 semantic + 164 adversarial (HMA); 222 OASB scenarios; 72 SOUL controls across 9 domains; 8-factor local trust; 9-factor server trust; 5-step FGA.
- All four `docs/use-cases/*.md` files referenced exist.
- 992/992 tests pass across 20 workspaces.
- No code changes. README only.

## Test plan

- [x] `grep -P "—" README.md` returns nothing
- [x] Every `opena2a <command> --help` cited parses
- [x] `npm test` clean (992/992)
- [x] Pre-push gate marker valid
- [x] Sensitive-file scan clean