### PR TITLE
fix(protect): anchored CLI self-exemption — replace substring marker check (closes #77)

### DIFF
--- a/packages/cli/__tests__/util/credential-patterns-fixture-exclusion.test.ts
+++ b/packages/cli/__tests__/util/credential-patterns-fixture-exclusion.test.ts
@@ -162,3 +162,51 @@ describe('quickCredentialScan: fixture/demo files are silently skipped', () => {
     expect(matches).toHaveLength(0);
   });
 });
+
+// Regression: the walker's self-exemption previously used dir.includes(marker)
+// on "packages/cli/src" and "packages/cli/dist", which silently skipped ANY
+// user project whose path contained those substrings. The anchored fix
+// resolves the CLI's own package root at module load and compares with
+// path.startsWith, so user directories are scanned even when they share
+// the path fragment.
+describe('walkFiles self-exemption is anchored, not substring', () => {
+  it('scans a user directory whose path contains "packages/cli/src"', async () => {
+    const { walkFiles } = await import('../../src/util/credential-patterns.js');
+    const userDir = path.join(tmpDir, 'packages', 'cli', 'src');
+    fs.mkdirSync(userDir, { recursive: true });
+    const file = path.join(userDir, 'app.ts');
+    fs.writeFileSync(file, 'const x = 1;', 'utf-8');
+
+    const visited: string[] = [];
+    walkFiles(tmpDir, (p: string) => { visited.push(p); });
+
+    expect(visited).toContain(file);
+  });
+
+  it('still skips the CLI\'s own source tree', async () => {
+    const { walkFiles } = await import('../../src/util/credential-patterns.js');
+    let dir = __dirname;
+    while (dir !== path.parse(dir).root) {
+      const pkgPath = path.join(dir, 'package.json');
+      if (fs.existsSync(pkgPath)) {
+        try {
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+          if (pkg.name === 'opena2a-cli') break;
+        } catch {
+          // ignore
+        }
+      }
+      dir = path.dirname(dir);
+    }
+    const cliRoot = dir;
+    const srcDir = path.join(cliRoot, 'src');
+    // Vitest always runs from the dev tree, where src/ must exist. If it
+    // doesn't, the test is running in an unexpected environment and we
+    // want a loud failure rather than a silent no-op pass.
+    expect(fs.existsSync(srcDir)).toBe(true);
+
+    const visited: string[] = [];
+    walkFiles(srcDir, (p: string) => { visited.push(p); });
+    expect(visited.length).toBe(0);
+  });
+});

--- a/packages/cli/src/util/credential-patterns.ts
+++ b/packages/cli/src/util/credential-patterns.ts
@@ -136,17 +136,39 @@ export const SKIP_FILENAME_PATTERNS: RegExp[] = [
   /^demo[-_].*\.(?:sh|ts|js|py)$/i,
 ];
 
+const CASE_INSENSITIVE_FS = process.platform === 'darwin' || process.platform === 'win32';
+
 /**
- * Path segments that identify the CLI's own source files.
- * These are excluded from credential scanning to prevent false positives
- * caused by the scanner's own code containing credential pattern examples
- * in comments, docstrings, and replacement logic.
+ * Absolute path of the opena2a-cli package root, resolved at module load.
+ * Used to skip the CLI's own source tree during scanning so that regex
+ * pattern examples and replacement templates don't trigger self-scan findings.
+ *
+ * Resolved by walking up from this file's __dirname looking for a package.json
+ * whose name is "opena2a-cli". Returns null if the walk fails, in which case
+ * no self-exemption is applied (false positives on dev scans are preferable
+ * to a silent substring-match bypass that skips user code sharing the path).
  */
-const SELF_SOURCE_MARKERS = [
-  // Matches the CLI source tree (both src/ and compiled dist/)
-  path.join('packages', 'cli', 'src'),
-  path.join('packages', 'cli', 'dist'),
-];
+const CLI_SELF_ROOT: string | null = (() => {
+  try {
+    let dir = __dirname;
+    const root = path.parse(dir).root;
+    while (dir && dir !== root) {
+      const pkgPath = path.join(dir, 'package.json');
+      if (fs.existsSync(pkgPath)) {
+        try {
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+          if (pkg && pkg.name === 'opena2a-cli') return dir;
+        } catch {
+          // unreadable package.json — keep walking
+        }
+      }
+      dir = path.dirname(dir);
+    }
+  } catch {
+    // __dirname unavailable or fs error — fall through
+  }
+  return null;
+})();
 
 export const SKIP_EXTENSIONS = new Set([
   '.png', '.jpg', '.jpeg', '.gif', '.ico', '.svg', '.webp',
@@ -168,11 +190,19 @@ export function walkFiles(dir: string, callback: (filePath: string) => void): vo
     return;
   }
 
-  // Skip the CLI's own source/dist directories to prevent false positives.
-  // The scanner's source code contains credential pattern examples in comments,
-  // docstrings, and replacement templates that would otherwise trigger findings.
-  for (const marker of SELF_SOURCE_MARKERS) {
-    if (dir.includes(marker)) return;
+  // Skip the CLI's own source/dist tree to prevent false positives from
+  // regex pattern examples and replacement templates. The exemption matches
+  // only when `dir` is physically inside the opena2a-cli install directory
+  // (anchored absolute-path prefix), not via substring — a substring check
+  // would silently skip any user project whose path contains "packages/cli/src".
+  // On case-insensitive filesystems (APFS/HFS+ on darwin, NTFS on win32) the
+  // comparison is also case-insensitive so that a user-typed lowercase path
+  // still matches the real install location.
+  if (CLI_SELF_ROOT) {
+    const abs = path.resolve(dir);
+    const a = CASE_INSENSITIVE_FS ? abs.toLowerCase() : abs;
+    const r = CASE_INSENSITIVE_FS ? CLI_SELF_ROOT.toLowerCase() : CLI_SELF_ROOT;
+    if (a === r || a.startsWith(r + path.sep)) return;
   }
 
   // Dot-files to scan (credential sources)


### PR DESCRIPTION
## Summary

Backward-port the **anchored self-exemption** fix from orphaned PR #77 onto current main. The other two fixes from #77 are intentionally omitted (see "What's not included" below).

## The bug being fixed

`walkFiles` in `packages/cli/src/util/credential-patterns.ts` previously skipped any directory whose path contained `"packages/cli/src"` or `"packages/cli/dist"` as a literal substring:

```ts
const SELF_SOURCE_MARKERS = [
  path.join('packages', 'cli', 'src'),
  path.join('packages', 'cli', 'dist'),
];
// ...
for (const marker of SELF_SOURCE_MARKERS) {
  if (dir.includes(marker)) return;  // ← substring match, not anchored
}
```

This silently exempts **any user project** whose path happens to contain that fragment — e.g. a monorepo with its own `packages/cli/` subdirectory. Real credentials in such a project would be missed entirely. CRITICAL: silent detection bypass on user code.

## What this PR does

- Replaces `SELF_SOURCE_MARKERS` with `CLI_SELF_ROOT`, resolved at module load by walking up from `__dirname` looking for a `package.json` named `opena2a-cli`.
- `walkFiles` now skips a directory only when its absolute path **is** the install root or an **anchored descendant** of it (`abs === root || abs.startsWith(root + path.sep)`).
- On case-insensitive filesystems (APFS/HFS+ on darwin, NTFS on win32) the comparison is case-insensitive so a user-typed lowercase path still matches the real install location.
- If `CLI_SELF_ROOT` can't be resolved (walk fails, `package.json` unreadable), no self-exemption is applied. Fail-open-detection is safer than a silent bypass.

## What's not included

The original #77 included two other fixes; both are omitted here for reasons confirmed during this port:

1. **`isDottedIdentifier` guard for CRED-004 false positives** — Omitted. PR #77-era CRED-004 regex was `['"]{0,2}\s*[:=]\s*['"]{0,2}([A-Za-z0-9_\-/.]{20,})['"]?` (admitted unquoted matches → guard was protective). Current main's regex is `\s*[:=]\s*['"]([A-Za-z0-9_\-/.]{20,})['"]` (mandatory quotes). The unquoted source-code-reference FP class the guard targeted cannot fire against current main's tighter regex. An adversarial review verified the guard would be dead code if landed.
2. **`backupFailures` per-file backup safety** — Not portable. The per-file backup/rollback mechanism (`backupDir`, `copyFileSync`, rollback refs) was removed from `protect.ts` on main; the buggy code no longer exists.

## Regression tests

`packages/cli/__tests__/util/credential-patterns-fixture-exclusion.test.ts` gains a new describe block with two tests:

1. A user directory whose path contains `packages/cli/src` **is** scanned (the failure mode of the substring check).
2. The CLI's own source tree is **still** skipped (non-vacuous assertion — fails loudly if `src/` is missing rather than silently no-op'ing).

## Verification

- 994/994 tests pass across 61 test files in `packages/cli`
- `tsc --noEmit` clean
- Pre-push 8-phase review: PASS (sensitive-file scan, build/test/lint, code review, HMA static scan, adversarial subagent, new-user walkthrough)
- New-user walkthrough confirmed the fix end-to-end against `/tmp/.../packages/cli/src/inner.ts` containing a hardcoded AWS key — file is now correctly scanned (HIGH DRIFT-002 detected) where it would have been silently skipped before.

## Why a new branch instead of resurrecting #77

#77's branch `fix/protect-credential-migration-bugs` has no merge base with current main (history rewrite — 42 commits on main vs 296 on #77). Standard rebase fails. This PR is a clean re-application onto current `origin/main`.

Closes #77.