### PR TITLE
chore(cli): pin hackmyagent to exact 0.22.3 — remove caret range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2358,17 +2358,22 @@
       }
     },
     "node_modules/hackmyagent": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/hackmyagent/-/hackmyagent-0.17.0.tgz",
-      "integrity": "sha512-fiKfp5L9FPwCCHRgEG//S+oPWlKwZw18OR0DxTlDSTSuPj2Yr1PP/bYz3temnnuzj6HkVh9+bIGGLGGRibnbuQ==",
+      "version": "0.22.3",
+      "resolved": "https://registry.npmjs.org/hackmyagent/-/hackmyagent-0.22.3.tgz",
+      "integrity": "sha512-uWKgRuh5eMZiUYKY6SfPIJ9V0z5Z7nMCyE9INj3/93pm3BayZaMudZhNh3Z722133KJNWQlg9vZGjgAtIw6yfg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@noble/ed25519": "^2.3.0",
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/aim-core": "^0.1.2",
+        "@opena2a/check-core": "0.2.0",
+        "@opena2a/cli-ui": "0.5.0",
         "@opena2a/contribute": "^0.1.0",
+        "@opena2a/credential-patterns": "0.1.1",
+        "@opena2a/registry-client": "0.1.0",
         "@opena2a/shared": "^0.1.0",
+        "@opena2a/telemetry": "0.1.2",
         "ai-trust": "^0.2.6",
         "commander": "^12.0.0",
         "js-yaml": "^4.1.1",
@@ -2390,6 +2395,15 @@
         "js-yaml": "^4.1.1",
         "tweetnacl": "^1.0.3"
       },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/hackmyagent/node_modules/@opena2a/telemetry": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@opena2a/telemetry/-/telemetry-0.1.2.tgz",
+      "integrity": "sha512-lMbNtwDfrXvrPWyEMXBY3ttU/RXWhQ2/xzSfCaosVvujFbqxtWuyq8YY725IEpQ9owa7uJ+PCp4mkxZ8UKW3wA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -3921,7 +3935,7 @@
     },
     "packages/cli": {
       "name": "opena2a-cli",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
@@ -3932,7 +3946,7 @@
         "@opena2a/telemetry": "0.2.0",
         "ai-trust": "^0.2.23",
         "commander": "^13.1.0",
-        "hackmyagent": "^0.17.0",
+        "hackmyagent": "0.22.3",
         "secretless-ai": "^0.14.1"
       },
       "bin": {
@@ -4002,7 +4016,7 @@
     },
     "packages/credential-patterns": {
       "name": "@opena2a/credential-patterns",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "@opena2a/telemetry": "0.2.0",
     "ai-trust": "^0.2.23",
     "commander": "^13.1.0",
-    "hackmyagent": "^0.17.0",
+    "hackmyagent": "0.22.3",
     "secretless-ai": "^0.14.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## Summary

opena2a-cli was pinning hackmyagent as `^0.17.0`, which:
1. Was several minor versions behind the latest published release (0.22.3)
2. Used a caret range against the org convention that all opena2a-org packages be pinned exactly

Bump to `"hackmyagent": "0.22.3"`. 0.23.0 is intentionally held from the registry until the matching PyPI daemon installer ships, so 0.22.3 is the correct target.

## Replaces #133

#133 targeted 0.22.0 (now two patch releases behind) with a caret range. After the recent main movement (PR #146 README rework, PR #145 telemetry 0.2.0 adoption), #133 also went CONFLICTING. Closing it in favor of this clean PR against current main.

## Verification

- `packages/cli`: 996/996 tests pass
- `packages/cli`: build + lint clean
- Scan delegation smoke test: `opena2a scan` against an empty tmp dir produces the expected output with the new alias-aware Next Steps block (`opena2a secure --fix`, `opena2a check . --nanomind`).

## Out of scope

`ai-trust` and `secretless-ai` are still on caret ranges; they're separate workstreams.
