### PR TITLE
chore(parity): add workflow_dispatch trigger for manual reruns

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -12,6 +12,7 @@ on:
       - ".github/workflows/parity.yml"
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: parity-${{ github.ref }}


### PR DESCRIPTION
Tiny improvement to allow re-running parity.yml on demand (e.g. after access settings or fixture changes). Zero behavior change for the automatic push/PR triggers. The change touches a path already in the workflow's own paths filter so this PR also exercises the parity gate end-to-end as a validation of the recent organization-level access fix on opena2a-parity.