### PR TITLE
fix(trust): show 'never' instead of 'NaN months ago' for unscanned packages (#122)

### DIFF
--- a/packages/cli/__tests__/commands/trust.test.ts
+++ b/packages/cli/__tests__/commands/trust.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { trust, _internals } from '../../src/commands/trust.js';
+import { trust, _internals, formatRelativeTime } from '../../src/commands/trust.js';
 import type { TrustOptions } from '../../src/commands/trust.js';
 import type { TrustLookupResponse } from '../../src/commands/atp-types.js';
 
@@ -361,5 +361,36 @@ describe('trust', () => {
     const parsed = JSON.parse(output);
     expect(parsed.trustLevel).toBe('discovered');
     expect(parsed.trustScore).toBe(0.1);
+  });
+});
+
+describe('formatRelativeTime (#122)', () => {
+  it("returns 'never' for null", () => {
+    expect(formatRelativeTime(null)).toBe('never');
+  });
+
+  it("returns 'never' for undefined", () => {
+    expect(formatRelativeTime(undefined)).toBe('never');
+  });
+
+  it("returns 'never' for empty string", () => {
+    expect(formatRelativeTime('')).toBe('never');
+  });
+
+  it("returns 'never' for unparseable date", () => {
+    expect(formatRelativeTime('not-a-date')).toBe('never');
+  });
+
+  it("never returns 'NaN months ago' (regression for #122)", () => {
+    expect(formatRelativeTime(null)).not.toContain('NaN');
+    expect(formatRelativeTime(undefined)).not.toContain('NaN');
+    expect(formatRelativeTime('garbage')).not.toContain('NaN');
+  });
+
+  it("formats a valid recent timestamp as 'today' or 'N days ago'", () => {
+    const now = new Date().toISOString();
+    expect(formatRelativeTime(now)).toBe('today');
+    const threeDaysAgo = new Date(Date.now() - 3 * 86400_000).toISOString();
+    expect(formatRelativeTime(threeDaysAgo)).toBe('3 days ago');
   });
 });

--- a/packages/cli/src/commands/trust.ts
+++ b/packages/cli/src/commands/trust.ts
@@ -441,9 +441,11 @@ function printTrustNextSteps(packageName: string): void {
   process.stdout.write('\n');
 }
 
-function formatRelativeTime(isoDate: string): string {
+export function formatRelativeTime(isoDate: string | null | undefined): string {
+  if (!isoDate) return 'never';
   try {
     const then = new Date(isoDate).getTime();
+    if (!Number.isFinite(then)) return 'never';
     const now = Date.now();
     const diffMs = now - then;
     const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
@@ -458,7 +460,7 @@ function formatRelativeTime(isoDate: string): string {
     if (months === 1) return '1 month ago';
     return `${months} months ago`;
   } catch {
-    return isoDate;
+    return 'never';
   }
 }
 


### PR DESCRIPTION
## Summary

- `formatRelativeTime` was typed as accepting `string`, but Registry returns nullish `lastScannedAt` for unscanned packages. `new Date(undefined).getTime()` → `NaN` → `"NaN months ago"`.
- Three defensive guards: nullish input → `'never'`, non-finite parse → `'never'`, catch fallback → `'never'`.
- Exports the helper for unit testing.

Closes #122.

## Before / After

`opena2a trust express --ci` on an unscanned package:

| Before | After |
|---|---|
| `Last Scanned: NaN months ago` | `Last Scanned: never` |

## Test plan

- [x] `npm test` — 1028/1028 pass (added 6 new tests for the helper)
- [x] Manual: `opena2a trust express --ci` shows `Last Scanned: never`
- [x] HMA scan unchanged — 35/100 baseline, 0 new findings introduced by this diff (existing 3 critical + 7 high are test-fixture and shield-architecture findings pre-existing on `main`)

## Notes

This is a pure UX/correctness fix. No security implications, no rendering primitive changes, no detection logic touched.