### PR TITLE
fix(check): route ./path, ., /abs, ~/path to scan adapter (#120)

### DIFF
--- a/packages/cli/__tests__/router.test.ts
+++ b/packages/cli/__tests__/router.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isRichTarget } from '../src/router.js';
+import { isRichTarget, isLocalPath } from '../src/router.js';
 
 describe('isRichTarget — rich-block dispatch gate', () => {
   it('matches skill: prefix with slash-bearing name', () => {
@@ -28,5 +28,42 @@ describe('isRichTarget — rich-block dispatch gate', () => {
 
   it('rejects flag-style args', () => {
     expect(isRichTarget('--verbose')).toBe(false);
+  });
+});
+
+describe('isLocalPath — local-directory dispatch gate (#120)', () => {
+  it('matches relative dot forms', () => {
+    expect(isLocalPath('.')).toBe(true);
+    expect(isLocalPath('..')).toBe(true);
+    expect(isLocalPath('./test')).toBe(true);
+    expect(isLocalPath('./packages/cli')).toBe(true);
+    expect(isLocalPath('../sibling')).toBe(true);
+  });
+
+  it('matches absolute paths', () => {
+    expect(isLocalPath('/Users/me/project')).toBe(true);
+    expect(isLocalPath('/tmp')).toBe(true);
+  });
+
+  it('matches home-relative paths', () => {
+    expect(isLocalPath('~')).toBe(true);
+    expect(isLocalPath('~/workspace')).toBe(true);
+  });
+
+  it('rejects npm package names', () => {
+    expect(isLocalPath('express')).toBe(false);
+    expect(isLocalPath('@scope/pkg')).toBe(false);
+    expect(isLocalPath('left-pad')).toBe(false);
+  });
+
+  it('rejects rich-target prefixes', () => {
+    expect(isLocalPath('skill:my-skill')).toBe(false);
+    expect(isLocalPath('mcp:server')).toBe(false);
+    expect(isLocalPath('pip:requests')).toBe(false);
+  });
+
+  it('rejects github-style shorthand and hostnames', () => {
+    expect(isLocalPath('owner/repo')).toBe(false);
+    expect(isLocalPath('example.com')).toBe(false);
   });
 });

--- a/packages/cli/src/router.ts
+++ b/packages/cli/src/router.ts
@@ -306,17 +306,23 @@ export async function dispatchCommand(
       if (isNpmTarget(target)) {
         return spawnHmaCheckFromRouter(target, args.slice(1), globalOptions);
       }
-      // Unrecognized target format -- show helpful error
-      process.stderr.write(`Unknown target: ${target}\n`);
-      process.stderr.write(`Accepted formats:\n`);
-      process.stderr.write(`  opena2a check express                  npm package\n`);
-      process.stderr.write(`  opena2a check @scope/pkg               scoped npm package\n`);
-      process.stderr.write(`  opena2a check skill:<name>             registered skill (rich block)\n`);
-      process.stderr.write(`  opena2a check mcp:<name>               registered MCP server (rich block)\n`);
-      process.stderr.write(`  opena2a check pip:requests             PyPI package\n`);
-      process.stderr.write(`  opena2a check owner/repo               GitHub repository\n`);
-      process.stderr.write(`  opena2a check ./path                   local directory\n`);
-      return 1;
+      // Local path (./path, ../path, /abs, ~/path, or .) — fall through
+      // to the scan adapter (hackmyagent secure <dir>). --help and the
+      // unknown-target error advertise this form; closes #120.
+      if (!isLocalPath(target)) {
+        // Unrecognized target format -- show helpful error
+        process.stderr.write(`Unknown target: ${target}\n`);
+        process.stderr.write(`Accepted formats:\n`);
+        process.stderr.write(`  opena2a check express                  npm package\n`);
+        process.stderr.write(`  opena2a check @scope/pkg               scoped npm package\n`);
+        process.stderr.write(`  opena2a check skill:<name>             registered skill (rich block)\n`);
+        process.stderr.write(`  opena2a check mcp:<name>               registered MCP server (rich block)\n`);
+        process.stderr.write(`  opena2a check pip:requests             PyPI package\n`);
+        process.stderr.write(`  opena2a check owner/repo               GitHub repository\n`);
+        process.stderr.write(`  opena2a check ./path                   local directory\n`);
+        return 1;
+      }
+      // Local path: fall through to INTENT_MAP['check'] -> scan adapter.
     }
   }
 
@@ -446,6 +452,22 @@ function getInstallHint(config: AdapterConfig): string {
 export function isRichTarget(target: string): boolean {
   if (target.startsWith('skill:') && target.length > 'skill:'.length) return true;
   if (target.startsWith('mcp:') && target.length > 'mcp:'.length) return true;
+  return false;
+}
+
+/**
+ * Detect whether a target is a local filesystem path the `check` command
+ * should treat as a directory scan (delegates to scan adapter).
+ *
+ * Accepted forms: `.`, `./path`, `../path`, `/abs/path`, `~/path`.
+ * Mirrors the documented forms in --help and the unknown-target error.
+ * Closes #120.
+ */
+export function isLocalPath(target: string): boolean {
+  if (target === '.' || target === '..') return true;
+  if (target.startsWith('./') || target.startsWith('../')) return true;
+  if (target.startsWith('/')) return true;
+  if (target.startsWith('~/') || target === '~') return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary

\`dispatchCommand\`'s check branch rejected every local-path form despite \`--help\` AND the unknown-target error advertising them. The clearest UX gap is help text promising a form the parser refused.

Add \`isLocalPath\` (recognizes \`.\`, \`..\`, \`./*\`, \`../*\`, \`/*\`, \`~\`, \`~/*\`) and let local-path targets fall through to the existing INTENT_MAP['check'] → scan adapter (\`hackmyagent secure <dir>\`) instead of hitting "Unknown target".

Closes #120.

## Before / After

| Command | Before | After |
|---|---|---|
| \`opena2a check ./path\` | Unknown target ./path | scans ./path via HMA |
| \`opena2a check .\` | Unknown target . | scans cwd via HMA |
| \`opena2a check /abs/path\` | Unknown target | scans absolute path |
| \`opena2a check ~/workspace\` | Unknown target | scans home-relative |
| \`opena2a check totally-bogus.com\` | Unknown target | Unknown target (unchanged) |

## Test plan

- [x] \`npm test\` — 1034/1034 pass (added 6 new unit tests for \`isLocalPath\`)
- [x] \`npm run build\` clean
- [x] Phase 6 surface coverage verified: \`./nonexistent\` (exit 1, error), \`.\` (exit 1, baseline findings), \`/tmp/empty\` (exit 0), \`totally-bogus.dot\` (exit 1, unknown)
- [x] HMA scan unchanged — same 35/100 baseline, 0 new findings introduced

## Notes

Phase 4.5 adversarial review SKIPPED per project CLAUDE.md trigger list — \`router.ts\` is not a detection rule, scanner, scoring weight, or rendering primitive. Pure dispatch classifier.