### PR TITLE
fix(cli): per-subcommand --help for guard/shield/identity/runtime/skill/mcp (#132)

### DIFF
--- a/packages/cli/__tests__/util/subcommand-help.test.ts
+++ b/packages/cli/__tests__/util/subcommand-help.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  isHelpRequest,
+  printSubcommandHelp,
+  GUARD_HELP,
+  SHIELD_HELP,
+  IDENTITY_HELP,
+  RUNTIME_HELP,
+  SKILL_HELP,
+  MCP_HELP,
+} from '../../src/util/subcommand-help.js';
+
+function captureStdout(fn: () => boolean): { result: boolean; output: string } {
+  const chunks: string[] = [];
+  const origWrite = process.stdout.write;
+  process.stdout.write = ((chunk: any) => { chunks.push(String(chunk)); return true; }) as any;
+  try {
+    const result = fn();
+    return { result, output: chunks.join('') };
+  } finally {
+    process.stdout.write = origWrite;
+  }
+}
+
+describe('isHelpRequest (#132)', () => {
+  it('matches --help in the explicit args array', () => {
+    expect(isHelpRequest(['sign', '--help'])).toBe(true);
+    expect(isHelpRequest(['--help'])).toBe(true);
+    expect(isHelpRequest(['-h'])).toBe(true);
+  });
+
+  it('returns false when no help flag present', () => {
+    expect(isHelpRequest(['sign'])).toBe(false);
+    expect(isHelpRequest(['--verbose'])).toBe(false);
+    expect(isHelpRequest([])).toBe(false);
+  });
+
+  it('falls back to process.argv when args omitted', () => {
+    const origArgv = process.argv;
+    try {
+      process.argv = ['node', 'cli', 'guard', 'sign', '--help'];
+      expect(isHelpRequest()).toBe(true);
+      process.argv = ['node', 'cli', 'guard', 'sign'];
+      expect(isHelpRequest()).toBe(false);
+    } finally {
+      process.argv = origArgv;
+    }
+  });
+});
+
+describe('printSubcommandHelp (#132)', () => {
+  it('prints a per-subcommand help block for a known subcommand', () => {
+    const { result, output } = captureStdout(() => printSubcommandHelp('guard', 'sign', GUARD_HELP));
+    expect(result).toBe(true);
+    expect(output).toContain('Usage: opena2a guard sign');
+    expect(output).toContain('Sign config files for integrity verification');
+    expect(output).toContain('--files <files...>');
+    expect(output).toContain('Examples:');
+  });
+
+  it('returns false for an unknown subcommand without printing', () => {
+    const { result, output } = captureStdout(() => printSubcommandHelp('guard', 'unknown-sub', GUARD_HELP));
+    expect(result).toBe(false);
+    expect(output).toBe('');
+  });
+
+  it('prints help without an Options section when none are declared', () => {
+    const { result, output } = captureStdout(() => printSubcommandHelp('guard', 'watch', GUARD_HELP));
+    expect(result).toBe(true);
+    expect(output).toContain('Usage: opena2a guard watch');
+    expect(output).not.toContain('Options:');
+    expect(output).toContain('Examples:');
+  });
+});
+
+describe('subcommand help registries (#132)', () => {
+  it('GUARD_HELP covers all 10 documented guard subcommands', () => {
+    const expected = ['sign', 'verify', 'status', 'watch', 'diff', 'policy', 'hook', 'resign', 'snapshot', 'harden'];
+    for (const sub of expected) {
+      expect(GUARD_HELP[sub], `missing GUARD_HELP entry for ${sub}`).toBeDefined();
+      expect(GUARD_HELP[sub].summary.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('SHIELD_HELP covers all 13 documented shield subcommands', () => {
+    const expected = ['init', 'status', 'log', 'selfcheck', 'policy', 'evaluate', 'recover', 'report', 'session', 'baseline', 'suggest', 'explain', 'triage'];
+    for (const sub of expected) {
+      expect(SHIELD_HELP[sub], `missing SHIELD_HELP entry for ${sub}`).toBeDefined();
+    }
+  });
+
+  it('RUNTIME_HELP covers all 4 documented runtime subcommands', () => {
+    const expected = ['start', 'status', 'tail', 'init'];
+    for (const sub of expected) {
+      expect(RUNTIME_HELP[sub]).toBeDefined();
+    }
+  });
+
+  it('SKILL_HELP covers the create subcommand', () => {
+    expect(SKILL_HELP.create).toBeDefined();
+  });
+
+  it('MCP_HELP covers audit, sign, verify', () => {
+    expect(MCP_HELP.audit).toBeDefined();
+    expect(MCP_HELP.sign).toBeDefined();
+    expect(MCP_HELP.verify).toBeDefined();
+  });
+
+  it('IDENTITY_HELP covers every subcommand listed in the parent description', () => {
+    const expected = ['list', 'init', 'create', 'trust', 'audit', 'log', 'policy', 'check', 'sign', 'verify', 'integrate', 'detach', 'sync', 'connect', 'disconnect', 'tag', 'mcp', 'activity', 'suspend', 'reactivate'];
+    for (const sub of expected) {
+      expect(IDENTITY_HELP[sub], `missing IDENTITY_HELP entry for ${sub}`).toBeDefined();
+    }
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,16 @@ import { getVersion } from './util/version.js';
 import { printFooter } from './util/footer.js';
 import { checkMinHmaVersion } from './util/hma-version.js';
 import { HMA_CHECK_COUNT } from './util/canonical.js';
+import {
+  isHelpRequest,
+  printSubcommandHelp,
+  GUARD_HELP,
+  SHIELD_HELP,
+  IDENTITY_HELP,
+  RUNTIME_HELP,
+  SKILL_HELP,
+  MCP_HELP,
+} from './util/subcommand-help.js';
 
 const VERSION = getVersion();
 // Wire-format tool name (analytics key in tool_usage_events). Matches the
@@ -356,6 +366,8 @@ analysis runs and results can be shared with the community.
   program
     .command('guard [subcommand] [args...]')
     .description('Config file integrity signing and verification (sign|verify|status|watch|diff|policy|hook|resign|snapshot|harden)')
+    .allowUnknownOption(true)
+    .helpOption(false)
     .option('--files <files...>', 'Specific files to guard')
     .option('--dir <path>', 'Target directory')
     .option('--enforce', 'Quarantine on tampering (exit code 3)')
@@ -363,8 +375,16 @@ analysis runs and results can be shared with the community.
     .option('--heartbeats', 'Include HEARTBEAT.md files in signing/verification')
     .option('--fix', 'Auto-fix fixable issues (harden subcommand)')
     .option('--dry-run', 'Preview fixes without applying (harden subcommand)')
-    .action(async (subcommand: string | undefined, args: string[], opts) => {
+    .action(async (subcommand: string | undefined, args: string[], opts, cmd) => {
       const validSubs = ['sign', 'verify', 'status', 'watch', 'diff', 'policy', 'hook', 'resign', 'snapshot', 'harden'];
+      // Per-subcommand --help intercept (closes #132)
+      if (subcommand && isHelpRequest()) {
+        if (printSubcommandHelp('guard', subcommand, GUARD_HELP)) return;
+      }
+      if (subcommand === '--help' || subcommand === '-h' || (!subcommand && isHelpRequest())) {
+        process.stdout.write(cmd.helpInformation());
+        return;
+      }
       if (!subcommand) {
         process.stderr.write('Usage: opena2a guard <subcommand> [directory]\n\n');
         process.stderr.write('Subcommands:\n');
@@ -421,11 +441,21 @@ analysis runs and results can be shared with the community.
   program
     .command('runtime [subcommand] [directory]')
     .description('Agent runtime protection (start|status|tail|init)')
+    .allowUnknownOption(true)
+    .helpOption(false)
     .option('--config <path>', 'Path to ARP config file')
     .option('--count <n>', 'Number of events to show (tail) [default: 20]')
     .option('--dir <path>', 'Target directory')
     .option('--force', 'Overwrite existing config (init)')
-    .action(async (subcommand: string | undefined, directory: string | undefined, opts) => {
+    .action(async (subcommand: string | undefined, directory: string | undefined, opts, cmd) => {
+      // Per-subcommand --help intercept (#132)
+      if (subcommand && isHelpRequest()) {
+        if (printSubcommandHelp('runtime', subcommand, RUNTIME_HELP)) return;
+      }
+      if (subcommand === '--help' || subcommand === '-h' || (!subcommand && isHelpRequest())) {
+        process.stdout.write(cmd.helpInformation());
+        return;
+      }
       if (!subcommand) {
         process.stderr.write('Usage: opena2a runtime <subcommand> [directory]\n\n');
         process.stderr.write('Subcommands:\n');
@@ -500,6 +530,8 @@ analysis runs and results can be shared with the community.
   program
     .command('identity [subcommand] [args...]')
     .description('Agent identity management (list|init|create|trust|audit|log|policy|check|sign|verify|integrate|detach|sync|connect|disconnect|tag|mcp|activity|suspend|reactivate)')
+    .allowUnknownOption(true)
+    .helpOption(false)
     .option('--name <name>', 'Agent name (for create)')
     .option('--limit <n>', 'Number of audit events to show')
     .option('--dir <path>', 'Target directory')
@@ -517,7 +549,15 @@ analysis runs and results can be shared with the community.
     .option('--tools <list>', 'Comma-separated tools to enable (attach)')
     .option('--all', 'Enable all detected tools (attach)')
     .option('--auto-sync', 'Auto-sync events on trust calculation (attach)')
-    .action(async (subcommand: string | undefined, args: string[], opts) => {
+    .action(async (subcommand: string | undefined, args: string[], opts, cmd) => {
+      // Per-subcommand --help intercept (#132)
+      if (subcommand && isHelpRequest()) {
+        if (printSubcommandHelp('identity', subcommand, IDENTITY_HELP)) return;
+      }
+      if (subcommand === '--help' || subcommand === '-h' || (!subcommand && isHelpRequest())) {
+        process.stdout.write(cmd.helpInformation());
+        return;
+      }
       if (!subcommand) {
         subcommand = 'list';
       }
@@ -557,6 +597,7 @@ analysis runs and results can be shared with the community.
     .command('shield [subcommand] [args...]')
     .description('Unified security orchestration ("shield init" runs full 11-step setup; also:|status|log|selfcheck|policy|evaluate|recover|report|session|baseline|suggest|explain|triage)')
     .allowUnknownOption(true)
+    .helpOption(false)
     .option('--dir <path>', 'Target directory')
     .option('--agent <name>', 'Agent name filter')
     .option('--count <n>', 'Event count (log)')
@@ -571,7 +612,15 @@ analysis runs and results can be shared with the community.
     .option('--report <path>', 'Write HTML posture report to file')
     .option('--shell-hook', 'Install shell preexec hook (shield init only)')
     .option('--ai-tools', 'Configure AI tool settings (shield init only)')
-    .action(async (subcommand: string | undefined, args: string[], opts) => {
+    .action(async (subcommand: string | undefined, args: string[], opts, cmd) => {
+      // Per-subcommand --help intercept (#132)
+      if (subcommand && isHelpRequest()) {
+        if (printSubcommandHelp('shield', subcommand, SHIELD_HELP)) return;
+      }
+      if (subcommand === '--help' || subcommand === '-h' || (!subcommand && isHelpRequest())) {
+        process.stdout.write(cmd.helpInformation());
+        return;
+      }
       if (!subcommand) {
         process.stderr.write('Usage: opena2a shield <subcommand>\n\n');
         process.stderr.write('Subcommands:\n');
@@ -1000,10 +1049,20 @@ Valid actions:
   program
     .command('skill [subcommand] [name]')
     .description('Skill management: create secure skills with signing and heartbeat')
+    .allowUnknownOption(true)
+    .helpOption(false)
     .option('--template <name>', 'Template: basic, mcp-tool, data-processor (default: basic)')
     .option('--output <dir>', 'Output directory (default: current)')
     .option('--no-sign', 'Skip auto-signing of skill files')
-    .action(async (subcommand: string | undefined, name: string | undefined, opts) => {
+    .action(async (subcommand: string | undefined, name: string | undefined, opts, cmd) => {
+      // Per-subcommand --help intercept (#132)
+      if (subcommand && isHelpRequest()) {
+        if (printSubcommandHelp('skill', subcommand, SKILL_HELP)) return;
+      }
+      if (subcommand === '--help' || subcommand === '-h' || (!subcommand && isHelpRequest())) {
+        process.stdout.write(cmd.helpInformation());
+        return;
+      }
       if (!subcommand) {
         process.stderr.write('Usage: opena2a skill <subcommand> [name]\n\n');
         process.stderr.write('Subcommands:\n');
@@ -1057,8 +1116,18 @@ Valid actions:
   program
     .command('mcp [subcommand] [server]')
     .description('MCP server identity management (audit|sign|verify)')
+    .allowUnknownOption(true)
+    .helpOption(false)
     .option('--dir <path>', 'Target directory')
-    .action(async (subcommand: string | undefined, server: string | undefined, opts) => {
+    .action(async (subcommand: string | undefined, server: string | undefined, opts, cmd) => {
+      // Per-subcommand --help intercept (#132)
+      if (subcommand && isHelpRequest()) {
+        if (printSubcommandHelp('mcp', subcommand, MCP_HELP)) return;
+      }
+      if (subcommand === '--help' || subcommand === '-h' || (!subcommand && isHelpRequest())) {
+        process.stdout.write(cmd.helpInformation());
+        return;
+      }
       if (!subcommand) subcommand = 'audit';
       const { mcpCommand } = await import('./commands/mcp-audit.js');
       const globalOpts = program.opts();

--- a/packages/cli/src/util/subcommand-help.ts
+++ b/packages/cli/src/util/subcommand-help.ts
@@ -1,0 +1,397 @@
+/**
+ * Per-subcommand --help support for opena2a subtree commands
+ * (guard, shield, identity, runtime, skill, mcp).
+ *
+ * Each parent registers as a single Commander command with manual
+ * subcommand routing, so Commander's auto-help only knows about the
+ * parent. Without intercept, `opena2a guard sign --help` prints the
+ * `guard` parent help instead of `sign`-specific help — CISO Rule 7
+ * (discoverability) violation flagged in #132.
+ *
+ * Each parent's action calls `printSubcommandHelp(parent, sub)` after
+ * detecting `--help` / `-h` in the incoming args.
+ */
+
+export interface SubcommandHelp {
+  /** One-line summary printed on the Usage line. */
+  summary: string;
+  /** Optional usage string after `opena2a <parent> <sub>`. */
+  usage?: string;
+  /** Option flag descriptions. */
+  options?: Array<{ flag: string; description: string }>;
+  /** Concrete invocations users can copy/paste. */
+  examples?: string[];
+}
+
+export type SubcommandHelpRegistry = Record<string, SubcommandHelp>;
+
+/**
+ * Print per-subcommand --help text. Returns true if a subcommand-specific
+ * block was printed; false if `sub` is unknown (caller should fall back
+ * to parent help).
+ */
+export function printSubcommandHelp(
+  parent: string,
+  sub: string,
+  registry: SubcommandHelpRegistry,
+): boolean {
+  const help = registry[sub];
+  if (!help) return false;
+
+  const usage = help.usage ?? '';
+  process.stdout.write(`Usage: opena2a ${parent} ${sub}${usage ? ' ' + usage : ''}\n\n`);
+  process.stdout.write(`${help.summary}\n`);
+
+  if (help.options && help.options.length > 0) {
+    process.stdout.write(`\nOptions:\n`);
+    const maxFlagWidth = Math.max(...help.options.map(o => o.flag.length));
+    for (const o of help.options) {
+      process.stdout.write(`  ${o.flag.padEnd(maxFlagWidth + 2)}${o.description}\n`);
+    }
+  }
+
+  if (help.examples && help.examples.length > 0) {
+    process.stdout.write(`\nExamples:\n`);
+    for (const ex of help.examples) {
+      process.stdout.write(`  ${ex}\n`);
+    }
+  }
+  return true;
+}
+
+/**
+ * Detect a help request. Treats `--help` / `-h` anywhere in the raw
+ * `process.argv` as a help request, mirroring Commander's behavior.
+ *
+ * Uses argv directly because subtree commands have varied arg shapes
+ * ([args...] vs [directory] vs [name]) and `--help` may not surface in
+ * the action's parameters under `allowUnknownOption(true)`.
+ */
+export function isHelpRequest(args?: ReadonlyArray<string>): boolean {
+  const source = args ?? process.argv.slice(2);
+  for (const a of source) {
+    if (a === '--help' || a === '-h') return true;
+  }
+  return false;
+}
+
+// --- Registries per parent command ---
+
+export const GUARD_HELP: SubcommandHelpRegistry = {
+  sign: {
+    summary: 'Sign config files for integrity verification.',
+    usage: '[directory]',
+    options: [
+      { flag: '--files <files...>', description: 'Sign specific files (defaults to scanning the directory)' },
+      { flag: '--skills', description: 'Include SKILL.md files in the signing set' },
+      { flag: '--heartbeats', description: 'Include HEARTBEAT.md files in the signing set' },
+    ],
+    examples: [
+      'opena2a guard sign',
+      'opena2a guard sign --files package.json tsconfig.json',
+      'opena2a guard sign --skills',
+    ],
+  },
+  verify: {
+    summary: 'Verify signed config files have not been tampered with.',
+    usage: '[directory]',
+    options: [
+      { flag: '--enforce', description: 'Exit with code 3 on any tampered file (quarantine mode)' },
+    ],
+    examples: [
+      'opena2a guard verify',
+      'opena2a guard verify --enforce',
+    ],
+  },
+  status: {
+    summary: 'Show current guard status (signed / unsigned / tampered file counts).',
+    usage: '[directory]',
+    examples: [
+      'opena2a guard status',
+      'opena2a guard status --format json',
+    ],
+  },
+  watch: {
+    summary: 'Watch for config file changes and emit tamper events on the shield event log.',
+    usage: '[directory]',
+    examples: ['opena2a guard watch'],
+  },
+  diff: {
+    summary: 'Show changes since last signing for each tracked file.',
+    usage: '[directory]',
+    examples: ['opena2a guard diff'],
+  },
+  policy: {
+    summary: 'Manage guard policies (which files to track, severity, etc.).',
+    usage: '[action]',
+    examples: [
+      'opena2a guard policy show',
+      'opena2a guard policy set strict',
+    ],
+  },
+  hook: {
+    summary: 'Install / manage git hooks (pre-commit verification).',
+    usage: '[action]',
+    examples: [
+      'opena2a guard hook install',
+      'opena2a guard hook uninstall',
+    ],
+  },
+  resign: {
+    summary: 'Re-sign tracked files after intentional changes.',
+    usage: '[directory]',
+    examples: ['opena2a guard resign'],
+  },
+  snapshot: {
+    summary: 'Take a config snapshot for later diff / rollback.',
+    usage: '[action]',
+    examples: [
+      'opena2a guard snapshot take',
+      'opena2a guard snapshot list',
+    ],
+  },
+  harden: {
+    summary: 'Auto-fix config security issues (file permissions, missing signatures, etc.).',
+    usage: '[directory]',
+    options: [
+      { flag: '--fix', description: 'Apply fixes (default is dry-run)' },
+      { flag: '--dry-run', description: 'Preview fixes without applying' },
+    ],
+    examples: [
+      'opena2a guard harden --dry-run',
+      'opena2a guard harden --fix',
+    ],
+  },
+};
+
+export const SHIELD_HELP: SubcommandHelpRegistry = {
+  init: {
+    summary: 'Run the full 11-step Shield setup for the current project.',
+    options: [
+      { flag: '--shell-hook', description: 'Install the shell preexec hook' },
+      { flag: '--ai-tools', description: 'Configure AI tool settings' },
+    ],
+    examples: ['opena2a shield init', 'opena2a shield init --shell-hook --ai-tools'],
+  },
+  status: {
+    summary: 'Show current Shield protection status (sessions, policies, integrity).',
+    examples: ['opena2a shield status', 'opena2a shield status --format json'],
+  },
+  log: {
+    summary: 'Query the Shield security event log.',
+    options: [
+      { flag: '--count <n>', description: 'Number of events to return' },
+      { flag: '--since <timespec>', description: 'Time filter: 7d, 1w, 1m, ISO 8601' },
+      { flag: '--severity <level>', description: 'Severity filter: low, medium, high, critical' },
+      { flag: '--source <source>', description: 'Source filter (agent, system, etc.)' },
+      { flag: '--category <cat>', description: 'Category filter (auth, integrity, policy, etc.)' },
+      { flag: '--agent <name>', description: 'Filter by agent name' },
+    ],
+    examples: [
+      'opena2a shield log --since 24h',
+      'opena2a shield log --severity high --count 50',
+    ],
+  },
+  selfcheck: {
+    summary: 'Verify Shield integrity (binary signatures, policy hashes, event-log chain).',
+    examples: ['opena2a shield selfcheck'],
+  },
+  policy: {
+    summary: 'View or update Shield policies.',
+    usage: '[action]',
+    examples: ['opena2a shield policy show', 'opena2a shield policy set strict'],
+  },
+  evaluate: {
+    summary: 'Evaluate the current project against active Shield policies.',
+    examples: ['opena2a shield evaluate'],
+  },
+  recover: {
+    summary: 'Recover from Shield lockdown (after a tamper event).',
+    options: [
+      { flag: '--verify', description: 'Verify before recovering' },
+      { flag: '--reset', description: 'Force exit lockdown without verification' },
+      { flag: '--forensic', description: 'Forensic mode (read-only, no changes)' },
+    ],
+    examples: ['opena2a shield recover --verify'],
+  },
+  report: {
+    summary: 'Write an HTML security posture report.',
+    options: [
+      { flag: '--report <path>', description: 'Output path (default: shield-report.html)' },
+    ],
+    examples: ['opena2a shield report --report ./out.html'],
+  },
+  session: {
+    summary: 'Show or manage the current local Ed25519 session identity.',
+    examples: ['opena2a shield session'],
+  },
+  baseline: {
+    summary: 'Establish a baseline for future drift detection.',
+    examples: ['opena2a shield baseline'],
+  },
+  suggest: {
+    summary: 'Suggest policy / configuration changes based on observed events.',
+    options: [
+      { flag: '--analyze', description: 'Enable LLM analysis of the event corpus' },
+    ],
+    examples: ['opena2a shield suggest --analyze'],
+  },
+  explain: {
+    summary: 'Explain a Shield event, finding, or policy decision.',
+    examples: ['opena2a shield explain <event-id>'],
+  },
+  triage: {
+    summary: 'Triage open security events into actionable groups.',
+    examples: ['opena2a shield triage'],
+  },
+};
+
+export const IDENTITY_HELP: SubcommandHelpRegistry = {
+  list: {
+    summary: 'List all known agent identities.',
+    examples: ['opena2a identity list', 'opena2a identity list --format json'],
+  },
+  init: {
+    summary: 'Initialize a new local agent identity (generates an Ed25519 keypair).',
+    examples: ['opena2a identity init'],
+  },
+  create: {
+    summary: 'Create a new named agent identity.',
+    options: [
+      { flag: '--name <name>', description: 'Identity name' },
+    ],
+    examples: ['opena2a identity create --name production-agent'],
+  },
+  trust: {
+    summary: 'Manage trust relationships between agent identities.',
+    usage: '[action]',
+    examples: ['opena2a identity trust add <agent>', 'opena2a identity trust list'],
+  },
+  audit: {
+    summary: 'Audit identity events and trust changes.',
+    examples: ['opena2a identity audit'],
+  },
+  log: {
+    summary: 'Show the identity event log.',
+    options: [
+      { flag: '--limit <n>', description: 'Maximum events to return' },
+    ],
+    examples: ['opena2a identity log --limit 100'],
+  },
+  policy: {
+    summary: 'Manage identity policies.',
+    examples: ['opena2a identity policy show'],
+  },
+  check: {
+    summary: 'Check identity status against active policies.',
+    examples: ['opena2a identity check'],
+  },
+  sign: {
+    summary: 'Sign an artifact with the current identity.',
+    examples: ['opena2a identity sign <file>'],
+  },
+  verify: {
+    summary: 'Verify an artifact signature against a known identity.',
+    examples: ['opena2a identity verify <file>'],
+  },
+  integrate: {
+    summary: 'Integrate the current identity with an external system.',
+    examples: ['opena2a identity integrate'],
+  },
+  detach: {
+    summary: 'Detach the current identity from an external integration.',
+    examples: ['opena2a identity detach'],
+  },
+  sync: {
+    summary: 'Sync identity state with the Registry.',
+    examples: ['opena2a identity sync'],
+  },
+  connect: {
+    summary: 'Connect to a remote agent identity.',
+    examples: ['opena2a identity connect <agent>'],
+  },
+  disconnect: {
+    summary: 'Disconnect from a remote agent identity.',
+    examples: ['opena2a identity disconnect <agent>'],
+  },
+  tag: {
+    summary: 'Tag an identity with arbitrary labels.',
+    examples: ['opena2a identity tag <agent> <label>'],
+  },
+  mcp: {
+    summary: 'Show or manage MCP server identities.',
+    examples: ['opena2a identity mcp'],
+  },
+  activity: {
+    summary: 'Show recent identity activity.',
+    examples: ['opena2a identity activity'],
+  },
+  suspend: {
+    summary: 'Suspend an agent identity (revoke trust temporarily).',
+    examples: ['opena2a identity suspend <agent>'],
+  },
+  reactivate: {
+    summary: 'Reactivate a suspended agent identity.',
+    examples: ['opena2a identity reactivate <agent>'],
+  },
+};
+
+export const RUNTIME_HELP: SubcommandHelpRegistry = {
+  start: {
+    summary: 'Start the runtime monitor for the current project.',
+    usage: '[directory]',
+    examples: ['opena2a runtime start'],
+  },
+  status: {
+    summary: 'Show runtime monitor status.',
+    usage: '[directory]',
+    examples: ['opena2a runtime status', 'opena2a runtime status --format json'],
+  },
+  tail: {
+    summary: 'Tail the runtime event stream.',
+    usage: '[directory]',
+    examples: ['opena2a runtime tail'],
+  },
+  init: {
+    summary: 'Initialize runtime configuration for a project.',
+    usage: '[directory]',
+    examples: ['opena2a runtime init'],
+  },
+};
+
+export const SKILL_HELP: SubcommandHelpRegistry = {
+  create: {
+    summary: 'Create a new secure skill (frontmatter + signing + heartbeat).',
+    usage: '[name]',
+    options: [
+      { flag: '--template <name>', description: 'Template: basic, mcp-tool, data-processor (default: basic)' },
+      { flag: '--output <dir>', description: 'Output directory (default: current)' },
+      { flag: '--no-sign', description: 'Skip auto-signing of skill files' },
+    ],
+    examples: [
+      'opena2a skill create my-skill',
+      'opena2a skill create my-skill --template mcp-tool',
+    ],
+  },
+};
+
+export const MCP_HELP: SubcommandHelpRegistry = {
+  audit: {
+    summary: 'Audit MCP server configurations for security issues.',
+    usage: '[server]',
+    options: [
+      { flag: '--dir <path>', description: 'Target directory' },
+    ],
+    examples: ['opena2a mcp audit', 'opena2a mcp audit my-server'],
+  },
+  sign: {
+    summary: 'Sign an MCP server configuration for integrity verification.',
+    usage: '[server]',
+    examples: ['opena2a mcp sign my-server'],
+  },
+  verify: {
+    summary: 'Verify a signed MCP server configuration.',
+    usage: '[server]',
+    examples: ['opena2a mcp verify my-server'],
+  },
+};


### PR DESCRIPTION
## Summary

50+ subtree subcommands silently printed the parent's \`--help\` (or the global \`--help\`) instead of their own — CISO Rule 7 (discoverability) violation across:

- \`guard\`: 10 subs (sign, verify, status, watch, diff, policy, hook, resign, snapshot, harden)
- \`shield\`: 13 subs (init, status, log, selfcheck, policy, evaluate, recover, report, session, baseline, suggest, explain, triage)
- \`identity\`: 20 subs (list, init, create, trust, audit, log, policy, check, sign, verify, integrate, detach, sync, connect, disconnect, tag, mcp, activity, suspend, reactivate)
- \`runtime\`: 4 subs (start, status, tail, init)
- \`skill\`: 1 sub (create)
- \`mcp\`: 3 subs (audit, sign, verify)

Tactical fix:
- New \`packages/cli/src/util/subcommand-help.ts\` with typed registries for each parent + shared \`printSubcommandHelp\` renderer.
- Each parent registration gets \`.allowUnknownOption(true)\` + \`.helpOption(false)\` so Commander stops eating \`--help\` before the action runs.
- Each action intercepts \`--help\` / \`-h\` via \`isHelpRequest()\` (reads \`process.argv\` directly to survive each parent's varied arg shape).
- Parent \`--help\` still prints \`cmd.helpInformation()\` (the existing Commander-generated parent help).
- Unknown subcommand + \`--help\` falls through to the existing "Unknown subcommand" error.

Closes #132.

## Before / After

| Command | Before | After |
|---|---|---|
| \`opena2a guard sign --help\` | guard parent help | \`Usage: opena2a guard sign [directory]\` + options + examples |
| \`opena2a shield status --help\` | shield parent help | shield status help |
| \`opena2a identity list --help\` | identity parent help | identity list help |
| \`opena2a runtime status --help\` | runtime parent help | runtime status help |
| \`opena2a mcp audit --help\` | mcp parent help | mcp audit help |
| \`opena2a skill create --help\` | skill parent help | skill create help |
| \`opena2a guard --help\` | guard parent help | guard parent help (unchanged) |
| \`opena2a guard bogus --help\` | guard parent help | "Unknown subcommand: bogus" + parent help |

## Sample output

\`\`\`
$ opena2a guard sign --help
Usage: opena2a guard sign [directory]

Sign config files for integrity verification.

Options:
  --files <files...>  Sign specific files (defaults to scanning the directory)
  --skills            Include SKILL.md files in the signing set
  --heartbeats        Include HEARTBEAT.md files in the signing set

Examples:
  opena2a guard sign
  opena2a guard sign --files package.json tsconfig.json
  opena2a guard sign --skills
\`\`\`

## Test plan

- [x] \`npm test\` — 1048/1048 pass (added 12 unit tests covering isHelpRequest, printSubcommandHelp, registry completeness)
- [x] \`npm run build\` clean
- [x] Verified end-to-end on all 6 parents (8 subcommands sampled) plus parent \`--help\` and unknown-subcommand fallback
- [x] HMA scan unchanged — 35/100 baseline, 0 new findings

## Notes

Phase 4.5 adversarial review SKIPPED per project CLAUDE.md trigger list — \`util/subcommand-help.ts\` is help-text-only, no detection / scanner / scoring / severity logic.

Future-work follow-ups (intentionally out of scope here):
- Some less-used subcommands have summary-only help. Future PRs can add options + examples as needed (the registry shape supports this without touching action handlers).
- A full Commander \`.command()\` refactor is the architecturally correct end-state. This PR is the tactical intermediate that ships the user-facing fix today.