### PR TITLE
fix(guard): emit absolute paths from guard.watch tamper events (#110)

### DIFF
--- a/packages/cli/__tests__/shield/findings-path-scoping.test.ts
+++ b/packages/cli/__tests__/shield/findings-path-scoping.test.ts
@@ -75,10 +75,12 @@ describe('filterEventsToTarget — configguard scoping', () => {
     expect(filtered).toHaveLength(1);
   });
 
-  it('keeps configguard events whose target is empty or relative (guard watch case)', () => {
-    // guard.ts:493,522 emits target: sig.filePath (relative, e.g. "package.json").
-    // We can't reliably scope these without writer-side changes, so they
-    // pass through. Documented as residual in the helper docstring.
+  it('keeps configguard events whose target is empty or relative (defensive — writer-side fix in #110)', () => {
+    // guard.ts no longer emits sig.filePath (relative) as the target — #110
+    // landed the fix to emit `path.join(targetDir, sig.filePath)` (absolute).
+    // The filter still cannot scope relative paths reliably, so it keeps
+    // them defensively. Any future writer that emits relative is filed as
+    // its own bug.
     const events = [
       makeEvent({ target: '' }),
       makeEvent({ target: 'package.json' }),
@@ -86,6 +88,27 @@ describe('filterEventsToTarget — configguard scoping', () => {
     ];
     const filtered = filterEventsToTarget(events, '/Users/foo/projectA');
     expect(filtered).toHaveLength(3);
+  });
+
+  it('#110: guard.watch absolute-path events scope correctly to the scan target', () => {
+    // After #110, guard.ts:handleFileChange emits `path.join(targetDir, sig.filePath)`
+    // as the event target. Verify that a tamper event recorded against project A
+    // is dropped when reviewing project B.
+    const events = [
+      makeEvent({
+        action: 'guard.watch',
+        target: '/Users/foo/projectA/package.json',
+        category: 'config.tampered',
+      }),
+      makeEvent({
+        action: 'guard.watch',
+        target: '/Users/foo/projectB/package.json',
+        category: 'config.tampered',
+      }),
+    ];
+    const filtered = filterEventsToTarget(events, '/Users/foo/projectB');
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]!.target).toBe('/Users/foo/projectB/package.json');
   });
 
   it('normalizes the scan target so trailing slashes and . segments do not change the result', () => {

--- a/packages/cli/src/commands/guard.ts
+++ b/packages/cli/src/commands/guard.ts
@@ -490,7 +490,10 @@ async function handleFileChange(targetDir: string, sig: ConfigSignature, isJson:
   if (!fs.existsSync(fullPath)) {
     if (isJson) { process.stdout.write(JSON.stringify({ time: timestamp, file: sig.filePath, status: 'missing' }) + '\n'); }
     else { process.stdout.write(`${dim(timestamp.slice(11, 19))}  ${red('MISSING')}   ${sig.filePath}\n`); }
-    await emitEvent('config.tampered', 'guard.watch', sig.filePath, 'high', enforce ? 'blocked' : 'monitored', { reason: 'file_deleted' });
+    // Emit absolute path so the Shield path-scoping filter (#109 sub-item 1)
+    // can drop these events when an unrelated `opena2a review <dir>` runs.
+    // Relative paths leak across targets — see #110.
+    await emitEvent('config.tampered', 'guard.watch', fullPath, 'high', enforce ? 'blocked' : 'monitored', { reason: 'file_deleted' });
     return;
   }
 
@@ -519,7 +522,7 @@ async function handleFileChange(targetDir: string, sig: ConfigSignature, isJson:
     }
     process.stdout.write('\n');
   }
-  await emitEvent('config.tampered', 'guard.watch', sig.filePath, enforce ? 'high' : 'medium', enforce ? 'blocked' : 'monitored', { currentHash, expectedHash: sig.hash, diff });
+  await emitEvent('config.tampered', 'guard.watch', fullPath, enforce ? 'high' : 'medium', enforce ? 'blocked' : 'monitored', { currentHash, expectedHash: sig.hash, diff });
 }
 
 // --- Diff ---


### PR DESCRIPTION
## Summary

\`handleFileChange\` emitted \`sig.filePath\` (relative, e.g. \`package.json\`) as the Shield event target at two call sites in \`guard.ts:493,522\`. Other ConfigGuard emitters (\`guard.ts:310\`, \`guard-policy.ts\`, \`guard-snapshots.ts:247\`) already pass the resolved absolute \`targetDir\`.

The Shield path-scoping filter (\`filterEventsToTarget\`, #109 sub-item 1) cannot reliably scope relative-path events without writer context, so it kept them. Result: a tamper event recorded by \`guard watch /path/to/A\` would surface as \`SHIELD-INT-001\` critical when running \`opena2a review /tmp/unrelated\` — same cross-target bleed #109 set out to fix, from a different writer.

\`fullPath = path.join(targetDir, sig.filePath)\` was already in scope at \`guard.ts:487\`. Both \`emitEvent\` calls now pass \`fullPath\`. No filter changes required.

Closes #110.

## Test plan

- [x] \`npm test\` — 1049/1049 pass (+1 regression test asserting absolute-path scoping)
- [x] \`npm run build\` clean
- [x] Updated docstring on the existing relative-path test to reflect the writer-side fix landed in this PR
- [x] HMA scan unchanged — 35/100 baseline, 0 new findings

## Notes

Phase 4.5 adversarial review SKIPPED — \`commands/guard.ts\` is not on the project CLAUDE.md trigger list (\`review.ts\` / \`credential-patterns.ts\` / \`report/**\` / \`scanners/**\` / \`shield/findings.ts\` / severity / scoring). The change tightens (not weakens) cross-target scoping by aligning \`guard watch\` with the absolute-path convention every other ConfigGuard emitter already uses.