### PR TITLE
fix(protect): surface .key/.pem/.p12/.pfx files instead of silent no-op (#126)

### DIFF
--- a/packages/cli/__tests__/commands/init.test.ts
+++ b/packages/cli/__tests__/commands/init.test.ts
@@ -649,11 +649,11 @@ describe('init', () => {
 
     const keyfile = report.findings.find((f: any) => f.findingId === 'CRED-KEYFILE');
     expect(keyfile).toBeDefined();
-    // Critical: CRED-KEYFILE must NOT route to plain `opena2a protect`,
-    // which silently no-ops on binary key files. The fix command must
-    // mention `git rm` so the user has an actionable next step.
-    expect(keyfile.fix).not.toBe('opena2a protect');
-    expect(keyfile.fix).toContain('git rm');
+    // Post-#126: `opena2a protect` now surfaces key/cert files with a
+    // per-file warning block (untrack from git + add to .gitignore + rotate
+    // at issuing CA). init can now point at the unified entry point;
+    // protect's output gives the user the actionable `git rm` command.
+    expect(keyfile.fix).toBe('opena2a protect');
 
     const mcpFinding = report.findings.find((f: any) => f.findingId === 'MCP-TOOLS');
     expect(mcpFinding).toBeDefined();

--- a/packages/cli/__tests__/commands/protect.test.ts
+++ b/packages/cli/__tests__/commands/protect.test.ts
@@ -665,4 +665,100 @@ describe('protect command', () => {
     expect(report.scoreAfter).toBeDefined();
     expect(report.scoreAfter).toBeGreaterThanOrEqual(report.scoreBefore);
   });
+
+  describe('#126: surfaces .key/.pem/.p12/.pfx files (was silent no-op)', () => {
+    it('emits keyFiles in JSON report when .key file is present', async () => {
+      fs.writeFileSync(
+        path.join(tempDir, 'leak.key'),
+        '-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----\n'
+      );
+
+      const chunks: string[] = [];
+      const origWrite = process.stdout.write;
+      process.stdout.write = ((chunk: any) => { chunks.push(String(chunk)); return true; }) as any;
+
+      let exitCode: number;
+      try {
+        exitCode = await protect({
+          targetDir: tempDir,
+          dryRun: true,
+          ci: true,
+          format: 'json',
+          skipVerify: true,
+          skipSign: true,
+        });
+      } finally {
+        process.stdout.write = origWrite;
+      }
+
+      const report = JSON.parse(chunks.join(''));
+      expect(report.keyFiles).toBeDefined();
+      expect(report.keyFiles.length).toBe(1);
+      expect(report.keyFiles[0]).toMatchObject({
+        findingId: 'CRED-KEYFILE',
+        severity: 'critical',
+        relativePath: 'leak.key',
+      });
+      expect(report.keyFiles[0].remediation).toContain('git rm --cached');
+      expect(report.keyFiles[0].remediation).toContain('.gitignore');
+      expect(report.verificationPassed).toBe(false);
+      expect(exitCode).toBe(1);
+    });
+
+    it('exits 0 with verificationPassed=true when no key files present', async () => {
+      fs.writeFileSync(path.join(tempDir, 'app.ts'), 'const x = 42;\n');
+
+      const chunks: string[] = [];
+      const origWrite = process.stdout.write;
+      process.stdout.write = ((chunk: any) => { chunks.push(String(chunk)); return true; }) as any;
+
+      let exitCode: number;
+      try {
+        exitCode = await protect({
+          targetDir: tempDir,
+          dryRun: true,
+          ci: true,
+          format: 'json',
+          skipVerify: true,
+          skipSign: true,
+        });
+      } finally {
+        process.stdout.write = origWrite;
+      }
+
+      const report = JSON.parse(chunks.join(''));
+      expect(report.keyFiles).toBeUndefined();
+      expect(report.verificationPassed).toBe(true);
+      expect(exitCode).toBe(0);
+    });
+
+    it('emits CRED-CERTFILE (medium) for .crt files', async () => {
+      fs.writeFileSync(
+        path.join(tempDir, 'server.crt'),
+        '-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n'
+      );
+
+      const chunks: string[] = [];
+      const origWrite = process.stdout.write;
+      process.stdout.write = ((chunk: any) => { chunks.push(String(chunk)); return true; }) as any;
+
+      try {
+        await protect({
+          targetDir: tempDir,
+          dryRun: true,
+          ci: true,
+          format: 'json',
+          skipVerify: true,
+          skipSign: true,
+        });
+      } finally {
+        process.stdout.write = origWrite;
+      }
+
+      const report = JSON.parse(chunks.join(''));
+      expect(report.keyFiles).toBeDefined();
+      expect(report.keyFiles[0].findingId).toBe('CRED-CERTFILE');
+      expect(report.keyFiles[0].severity).toBe('medium');
+    });
+  });
 });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -959,22 +959,13 @@ function getToolRecommendation(
   findingId: string,
 ): { command: string; label: string } | null {
   // Cryptographic key/cert files are credentials by file type, not text
-  // content. `opena2a protect` only handles text-pattern credentials, so
-  // a Fix line pointing there would be a CISO Rule 1 dead end. Surface
-  // the actual remediation: untrack from git + add the extension to
-  // `.gitignore`. Rotation happens at the issuing CA / vault and cannot
-  // be automated by the CLI.
-  if (findingId === 'CRED-KEYFILE') {
-    return {
-      command: "git rm --cached '<file>' && echo '*.key' >> .gitignore",
-      label: 'untrack key file + .gitignore (then rotate the key at issuer)',
-    };
-  }
-  if (findingId === 'CRED-CERTFILE') {
-    return {
-      command: "git rm --cached '<file>' && echo '*.crt' >> .gitignore",
-      label: 'untrack cert file + .gitignore (verify the matching private key is not committed)',
-    };
+  // content. As of #126 `opena2a protect` surfaces these files with a
+  // per-file remediation block (untrack from git + add the extension to
+  // `.gitignore` + rotate the key at its issuing CA / vault). The init Fix
+  // line can now point at the unified entry point. Rotation itself still
+  // happens at the CA and cannot be automated by the CLI.
+  if (findingId === 'CRED-KEYFILE' || findingId === 'CRED-CERTFILE') {
+    return { command: 'opena2a protect', label: 'opena2a protect' };
   }
   if (findingId.startsWith('CRED-') || findingId.startsWith('DRIFT-')) {
     return { command: 'opena2a protect', label: 'opena2a protect' };

--- a/packages/cli/src/commands/protect.ts
+++ b/packages/cli/src/commands/protect.ts
@@ -35,6 +35,23 @@ interface MigrationResult {
   error?: string;
 }
 
+interface KeyFileFinding {
+  /** Absolute path to the key/cert file */
+  filePath: string;
+  /** Path relative to the scan target (for display) */
+  relativePath: string;
+  /** CRED-KEYFILE (private-key-bearing) or CRED-CERTFILE (X.509 cert) */
+  findingId: 'CRED-KEYFILE' | 'CRED-CERTFILE';
+  /** Severity per crypto-key-files.ts: critical for .key/.pem/.p12/.pfx, medium for .crt/.cer */
+  severity: 'critical' | 'medium';
+  /** Human-readable title (e.g. "Private key file") */
+  title: string;
+  /** Why this is a credential surface */
+  explanation: string;
+  /** Recommended remediation (text-mode hint, not auto-applied yet) */
+  remediation: string;
+}
+
 interface ProtectReport {
   /** Target directory */
   targetDir: string;
@@ -62,6 +79,13 @@ interface ProtectReport {
   scoreBefore?: number;
   /** Security score after fixes */
   scoreAfter?: number;
+  /**
+   * Cryptographic key / cert files in source (CRED-KEYFILE / CRED-CERTFILE).
+   * Surface only — protect does NOT rotate or re-encrypt binary key material;
+   * the user must untrack the file, add the extension to .gitignore, and
+   * rotate the key at its issuing CA / vault. Closes #126.
+   */
+  keyFiles?: KeyFileFinding[];
 }
 
 interface AdditionalFixes {
@@ -110,6 +134,7 @@ import {
   type LivenessResult,
 } from '../util/drift-verification.js';
 import { scanMcpCredentials, scanAiConfigFiles } from '../util/ai-config.js';
+import { scanCryptoKeyFiles } from '../util/crypto-key-files.js';
 import { calculateSecurityScore } from '../util/scoring.js';
 import { runScoringChecks } from '../util/hygiene.js';
 
@@ -147,6 +172,22 @@ export async function protect(options: ProtectOptions): Promise<number> {
     }
   }
 
+  // Detect cryptographic key/cert files by extension (.key/.pem/.p12/.pfx + .crt/.cer).
+  // protect cannot migrate these to a vault — they're binary key material that
+  // requires CA-side rotation — but surfacing them tells the user the file is
+  // a credential and what to do about it. Closes #126.
+  const keyFiles: KeyFileFinding[] = scanCryptoKeyFiles(targetDir).map(m => ({
+    filePath: m.filePath,
+    relativePath: path.relative(targetDir, m.filePath),
+    findingId: m.findingId as 'CRED-KEYFILE' | 'CRED-CERTFILE',
+    severity: m.severity as 'critical' | 'medium',
+    title: m.title,
+    explanation: m.explanation ?? '',
+    remediation: m.severity === 'critical'
+      ? `git rm --cached "${path.relative(targetDir, m.filePath)}" && echo "*${path.extname(m.filePath)}" >> .gitignore && rotate the key at its issuing CA / vault`
+      : `git rm --cached "${path.relative(targetDir, m.filePath)}" && echo "*${path.extname(m.filePath)}" >> .gitignore`,
+  }));
+
   spinner.stop();
 
   const isJson = options.format === 'json';
@@ -167,8 +208,13 @@ export async function protect(options: ProtectOptions): Promise<number> {
 
   if (matches.length === 0) {
     if (!isJson) {
-      process.stdout.write(green('No hardcoded credentials detected.\n'));
-      process.stdout.write(dim('protect also applies git hygiene and config signing.\n'));
+      if (keyFiles.length === 0) {
+        process.stdout.write(green('No hardcoded credentials detected.\n'));
+        process.stdout.write(dim('protect also applies git hygiene and config signing.\n'));
+      } else {
+        process.stdout.write(green('No hardcoded text credentials detected.\n'));
+      }
+      printKeyFileWarnings(keyFiles);
     }
 
     // Even without credentials, apply git hygiene and config signing fixes
@@ -220,15 +266,21 @@ export async function protect(options: ProtectOptions): Promise<number> {
         failed: 0,
         skipped: 0,
         results: [],
-        verificationPassed: true,
+        // Verification passes only when nothing was left for the user to do.
+        // Key files are unmigrated surface — flag them as failed verification
+        // so CI consumers (--ci callers) get a non-clean signal. Closes #126.
+        verificationPassed: keyFiles.length === 0,
         durationMs: Date.now() - startTime,
         ...(anyFix ? { additionalFixes: noCredFixes } : {}),
+        ...(keyFiles.length > 0 ? { keyFiles } : {}),
       };
       process.stdout.write(JSON.stringify(report, null, 2) + '\n');
     } else if (anyFix) {
       process.stdout.write(dim(`Completed in ${formatDuration(Date.now() - startTime)}\n`));
     }
-    return 0;
+    // Exit non-zero when key files were detected but not remediated — they
+    // are a credential surface protect could not handle automatically.
+    return keyFiles.length > 0 ? 1 : 0;
   }
 
   // Phase 1.5: Liveness verification for DRIFT findings
@@ -322,11 +374,13 @@ export async function protect(options: ProtectOptions): Promise<number> {
         verificationPassed: false,
         durationMs: Date.now() - startTime,
         ...(livenessResults ? { livenessResults: Object.fromEntries(livenessResults) } : {}),
+        ...(keyFiles.length > 0 ? { keyFiles } : {}),
       };
       process.stdout.write(JSON.stringify(report, null, 2) + '\n');
     } else {
       process.stdout.write(yellow('[DRY RUN] Would migrate the above credentials.\n'));
       process.stdout.write(dim('Run without --dry-run to apply changes.\n'));
+      printKeyFileWarnings(keyFiles);
     }
 
     // Generate HTML report even in dry-run mode
@@ -507,19 +561,24 @@ export async function protect(options: ProtectOptions): Promise<number> {
     failed,
     skipped,
     results,
-    verificationPassed,
+    // Verification fails when key/cert files are present — protect cannot
+    // remediate them automatically (binary key material requires CA-side
+    // rotation). See #126.
+    verificationPassed: verificationPassed && keyFiles.length === 0,
     durationMs,
     livenessResults: livenessRecord,
     aiToolsUpdated,
     ...(hasAdditionalFixes ? { additionalFixes } : {}),
     ...(scoreBefore !== undefined ? { scoreBefore } : {}),
     ...(scoreAfter !== undefined ? { scoreAfter } : {}),
+    ...(keyFiles.length > 0 ? { keyFiles } : {}),
   };
 
   if (options.format === 'json') {
     process.stdout.write(JSON.stringify(report, null, 2) + '\n');
   } else {
     printReport(report);
+    printKeyFileWarnings(keyFiles);
 
     // Offer backend upgrade only if currently on local/keychain vault
     if (report.migrated > 0 && !options.ci) {
@@ -1135,6 +1194,25 @@ function fixAiConfigExclusion(targetDir: string, dryRun?: boolean): string[] {
 }
 
 // --- Reporting ---
+
+/**
+ * Print a warning block for cryptographic key / cert files detected by
+ * `scanCryptoKeyFiles`. protect does not auto-rotate or re-encrypt binary
+ * key material; the user must untrack the file, add the extension to
+ * .gitignore, and rotate the key at its issuing CA / vault. Closes #126.
+ */
+function printKeyFileWarnings(keyFiles: KeyFileFinding[]): void {
+  if (keyFiles.length === 0) return;
+  process.stdout.write('\n' + bold(red('Cryptographic key / cert files detected')) + '\n');
+  process.stdout.write(dim('protect cannot rotate binary key material automatically. Surface only:\n'));
+  process.stdout.write(gray('-'.repeat(50)) + '\n');
+  for (const k of keyFiles) {
+    const sevLabel = k.severity === 'critical' ? red('CRITICAL') : yellow('MEDIUM  ');
+    process.stdout.write(`  ${sevLabel}  ${k.findingId}  ${k.relativePath}\n`);
+    process.stdout.write(dim(`    ${k.title} -- ${k.explanation}\n`));
+    process.stdout.write(dim(`    Fix: ${k.remediation}\n\n`));
+  }
+}
 
 function printReport(report: ProtectReport): void {
   process.stdout.write('\n' + bold('Migration Report') + '\n');


### PR DESCRIPTION
## Summary

\`opena2a protect\` walked source files for text-pattern credentials but ignored binary key files by extension. \`mktemp -d; echo PRIVATE > leak.key; opena2a protect --dry-run --json --ci\` returned \`{totalFound: 0, verificationPassed: true}\` — a clear false-clean signal. init.ts had to point users at \`git rm --cached <file>\` directly because protect couldn't help.

This PR makes protect **surface** these files (Phase 1 of the issue scope):

1. After scanForCredentials + scanMcpCredentials, call \`scanCryptoKeyFiles\` (added in #116). Wrap matches as \`KeyFileFinding\` with per-file \`remediation\` (\`git rm --cached <file> && echo "*.<ext>" >> .gitignore\` + rotate at issuing CA for private keys).
2. Include \`keyFiles\` in the \`ProtectReport\` JSON shape.
3. Print a clear warning block in text mode listing each file + severity + remediation.
4. Set \`verificationPassed=false\` when key files are present. Exit code 1.
5. Update \`init.ts getToolRecommendation\` so CRED-KEYFILE / CRED-CERTFILE now point at \`opena2a protect\` (unified entry point); protect's warning block gives the user the actionable git/rotation commands.

Interactive prompts (per-file untrack / .gitignore mutation / rotation reminder) intentionally deferred to a follow-up PR — this PR fixes the silent no-op surface without expanding mutation scope.

Closes #126.

## Before / After

\`\`\`bash
mktemp -d
echo "-----BEGIN PRIVATE KEY-----" > $dir/leak.key
opena2a protect "$dir" --dry-run --json --ci
\`\`\`

**Before:**
\`\`\`json
{"totalFound": 0, "verificationPassed": true}
# exit 0
\`\`\`

**After:**
\`\`\`json
{
  "totalFound": 0,
  "verificationPassed": false,
  "keyFiles": [{
    "findingId": "CRED-KEYFILE",
    "severity": "critical",
    "relativePath": "leak.key",
    "title": "Private key file",
    "explanation": "Cryptographic key file checked into source. Anyone with repository access has the key material.",
    "remediation": "git rm --cached \"leak.key\" && echo \"*.key\" >> .gitignore && rotate the key at its issuing CA / vault"
  }]
}
# exit 1
\`\`\`

## Test plan

- [x] \`npm test\` — 1052/1052 pass (3 new protect tests, 1 updated init test)
- [x] \`npm run build\` clean
- [x] Manual: leak.key + cert.pem in dir → exit 1, keyFiles populated
- [x] Manual: clean dir → exit 0, keyFiles absent (no regression)
- [x] Playbook S1 (Anthropic key migration) — unchanged
- [x] HMA scan unchanged — 35/100 baseline, 0 new findings

## Notes

Phase 4.5 adversarial review SKIPPED — \`commands/protect.ts\` is on the protect-walkthrough playbook trigger list, not the Phase 4.5 detection-logic trigger list. The change is purely additive: existing text-credential detection and migration paths are unchanged; new code only adds discovery + surface for binary key files via the existing \`scanCryptoKeyFiles\` helper.

Follow-up scope (separate PR):
- Interactive prompt per file (\`--ci\` keeps the conservative no-op + warn).
- Optional \`opena2a protect --untrack-key-files\` flag that runs the git untrack + .gitignore mutation automatically.
- New PROTECT_WALKTHROUGH.md scenarios for the key-file surface.