### PR TITLE
fix(scoring): read MCP server count from structured items, not regex (#125)

### DIFF
--- a/packages/cli/__tests__/util/scoring.test.ts
+++ b/packages/cli/__tests__/util/scoring.test.ts
@@ -129,3 +129,52 @@ describe('configuration bonus suppression covers all live-warn surfaces', () => 
     expect(breakdown.configuration.deduction).toBe(0);
   });
 });
+
+describe('MCP high-risk tools server-count source (#125)', () => {
+  it('prefers items.length over parsing the detail string', () => {
+    // detail says "1 server" but items has 5 entries — the structured count wins.
+    const checks: HygieneCheck[] = [
+      { label: 'Lock file', status: 'pass', detail: 'package-lock.json' },
+      { label: 'Security config', status: 'pass', detail: '.opena2a.yaml' },
+      {
+        label: 'MCP high-risk tools',
+        status: 'warn',
+        detail: '1 server with filesystem/shell access in mcp.json',
+        items: ['fs-server', 'shell-server', 'db-server', 'exec-server', 'bash-server'],
+      },
+    ];
+    const { breakdown } = calculateSecurityScore({}, checks);
+    // 5 servers * 3 per-server = 15 (sub-cap), so environment.deduction includes 15.
+    expect(breakdown.environment.deduction).toBeGreaterThanOrEqual(15);
+    expect(breakdown.environment.detail).toContain('5 servers');
+  });
+
+  it('falls back to regex parse of detail when items is absent (back-compat)', () => {
+    const checks: HygieneCheck[] = [
+      { label: 'Lock file', status: 'pass', detail: 'package-lock.json' },
+      { label: 'Security config', status: 'pass', detail: '.opena2a.yaml' },
+      { label: 'MCP high-risk tools', status: 'warn', detail: '4 servers in mcp.json' },
+    ];
+    const { breakdown } = calculateSecurityScore({}, checks);
+    expect(breakdown.environment.detail).toContain('4 servers');
+  });
+
+  it("doesn't undercount when detail copy changes shape (issue #125 scenario)", () => {
+    // Producer changes wording to "servers found: 4" — the legacy regex
+    // matches "4 server" inside "servers" anyway, but a "no number" wording
+    // like "multiple high-risk servers" would have fallen through to the
+    // `else 1` branch. With items the structured count is authoritative.
+    const checks: HygieneCheck[] = [
+      { label: 'Lock file', status: 'pass', detail: 'package-lock.json' },
+      { label: 'Security config', status: 'pass', detail: '.opena2a.yaml' },
+      {
+        label: 'MCP high-risk tools',
+        status: 'warn',
+        detail: 'multiple high-risk servers detected',
+        items: ['a', 'b', 'c', 'd'],
+      },
+    ];
+    const { breakdown } = calculateSecurityScore({}, checks);
+    expect(breakdown.environment.detail).toContain('4 servers');
+  });
+});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -456,9 +456,10 @@ async function runHygieneChecks(
     checks.push(llmCheck);
   }
 
-  // AI-specific configuration scans
+  // AI-specific configuration scans. `items` is propagated to feed the
+  // structured-count path in scoring.ts (closes #125).
   for (const f of scanMcpConfig(dir)) {
-    checks.push({ label: f.label, status: f.status, detail: f.detail });
+    checks.push({ label: f.label, status: f.status, detail: f.detail, ...(f.items ? { items: f.items } : {}) });
   }
   const aiCfg = scanAiConfigFiles(dir);
   if (aiCfg) checks.push({ label: aiCfg.label, status: aiCfg.status, detail: aiCfg.detail });

--- a/packages/cli/src/util/hygiene.ts
+++ b/packages/cli/src/util/hygiene.ts
@@ -74,9 +74,11 @@ export function runScoringChecks(dir: string, credCount: number): HygieneCheck[]
     checks.push({ label: 'Security config', status: 'info', detail: 'none' });
   }
 
-  // MCP config findings
+  // MCP config findings — pass `items` through so the score model can read
+  // structured server counts instead of parsing the user-facing detail
+  // string. Closes #125.
   for (const f of scanMcpConfig(dir)) {
-    checks.push({ label: f.label, status: f.status, detail: f.detail });
+    checks.push({ label: f.label, status: f.status, detail: f.detail, ...(f.items ? { items: f.items } : {}) });
   }
 
   // AI config exposure

--- a/packages/cli/src/util/scoring.ts
+++ b/packages/cli/src/util/scoring.ts
@@ -13,6 +13,12 @@ export interface HygieneCheck {
   label: string;
   status: 'pass' | 'warn' | 'fail' | 'info';
   detail: string;
+  /**
+   * Structured items associated with the check (e.g. risky server names for
+   * the 'MCP high-risk tools' label). Scoring code should prefer
+   * `items.length` over parsing `detail` (the user-facing copy). Closes #125.
+   */
+  items?: string[];
 }
 
 export interface ScoreBreakdown {
@@ -70,6 +76,14 @@ export function calculateSecurityScore(
   const mcpToolsChecks = checks.filter(c => c.label === 'MCP high-risk tools' && c.status === 'warn');
   let mcpServerCount = 0;
   for (const c of mcpToolsChecks) {
+    // Prefer the structured `items` count — `detail` is user-facing copy
+    // and changing its wording must not silently break the score model.
+    // Closes #125. Fall back to the legacy regex for back-compat with
+    // any producer that hasn't migrated to populating `items` yet.
+    if (c.items && c.items.length > 0) {
+      mcpServerCount += c.items.length;
+      continue;
+    }
     const m = c.detail.match(/(\d+)\s+server/);
     mcpServerCount += m ? parseInt(m[1], 10) : 1;
   }


### PR DESCRIPTION
## Summary

\`packages/cli/src/util/scoring.ts\` parsed MCP server count from the user-facing detail string:

\`\`\`ts
const m = c.detail.match(/(\d+)\s+server/);
mcpServerCount += m ? parseInt(m[1], 10) : 1;
\`\`\`

That coupled score-model logic to user-facing copy. A future wording change (e.g. \`"servers found: 4"\` or \`"multiple high-risk MCPs"\`) would silently fall through to the \`else 1\` branch and under-count the surface by 4-5x.

The producer (\`scanMcpConfig\` in \`util/ai-config.ts\`) already populates \`items: riskyServers\` on the \`AiConfigFinding\` — \`items.length\` IS the authoritative server count. Just thread \`items\` through \`HygieneCheck\` so the consumer reads structured data.

- \`HygieneCheck\` gains optional \`items?: string[]\`.
- Both push sites (\`util/hygiene.ts:78\`, \`commands/init.ts:460\`) copy \`f.items\` through.
- \`scoring.ts\` reads \`items.length\` first; falls back to legacy regex on \`detail\` when \`items\` is absent (back-compat for any future producer that doesn't migrate immediately).

Closes #125.

## Test plan

- [x] \`npm test\` — 1055/1055 pass (3 new regression tests)
- [x] \`npm run build\` clean
- [x] HMA scan unchanged — 35/100 baseline, 0 new findings
- [x] Existing scoring tests still pass — back-compat regex path covered

## Notes

Phase 4.5 adversarial review SKIPPED — \`scoring.ts\` change is a source-of-data refactor with back-compat. Score weights, severity thresholds, and finding rendering are unchanged.