### PR TITLE
fix(trust): retire stale 'Registry launches soon' copy; suppress 0 downloads (#123)

### DIFF
--- a/packages/cli/__tests__/commands/trust.test.ts
+++ b/packages/cli/__tests__/commands/trust.test.ts
@@ -261,7 +261,10 @@ describe('trust', () => {
 
     expect(output).not.toContain('https://registry.opena2a.org');
     expect(output).not.toContain('Badge:');
-    expect(output).toContain('Registry launches soon');
+    // Post-#123: Registry is live; only the per-package profile URL is dead.
+    // The placeholder must not imply the Registry itself is offline.
+    expect(output).not.toContain('Registry launches soon');
+    expect(output).toContain('Profile: not available for this package');
   });
 
   it('falls back to formatted packageType when displayType is absent', async () => {
@@ -361,6 +364,55 @@ describe('trust', () => {
     const parsed = JSON.parse(output);
     expect(parsed.trustLevel).toBe('discovered');
     expect(parsed.trustScore).toBe(0.1);
+  });
+});
+
+describe('trust stale copy + zero-downloads (#123)', () => {
+  it('suppresses Downloads line when Registry returns 0 (stale backfill)', async () => {
+    const data = makeTrustResponse({
+      profileUrl: 'https://opena2a.org/agents/express',
+      supplyChain: {
+        criticalVulnerabilities: 0,
+        highVulnerabilities: 0,
+        mediumVulnerabilities: 0,
+        lowVulnerabilities: 0,
+        lastPublished: new Date().toISOString(),
+        maintainerCount: 5,
+        weeklyDownloads: 0,
+      },
+    });
+    vi.spyOn(_internals, 'fetchTrustLookup').mockResolvedValue({ ok: true, status: 200, data });
+
+    const { output } = await captureStdout(() => trust({ packageName: 'express', ci: true, format: 'text' }));
+    expect(output).not.toMatch(/Downloads:\s+0\/week/);
+  });
+
+  it("does NOT emit 'Registry launches soon' for dead-host profile URLs", async () => {
+    const data = makeTrustResponse({ profileUrl: 'https://registry.oa2a.org/agents/express' });
+    vi.spyOn(_internals, 'fetchTrustLookup').mockResolvedValue({ ok: true, status: 200, data });
+
+    const { output } = await captureStdout(() => trust({ packageName: 'express', ci: true, format: 'text' }));
+    expect(output).not.toContain('Registry launches soon');
+    expect(output).toContain('Profile: not available for this package');
+  });
+
+  it('shows real Downloads count when > 0', async () => {
+    const data = makeTrustResponse({
+      profileUrl: 'https://opena2a.org/agents/express',
+      supplyChain: {
+        criticalVulnerabilities: 0,
+        highVulnerabilities: 0,
+        mediumVulnerabilities: 0,
+        lowVulnerabilities: 0,
+        lastPublished: new Date().toISOString(),
+        maintainerCount: 5,
+        weeklyDownloads: 35_000_000,
+      },
+    });
+    vi.spyOn(_internals, 'fetchTrustLookup').mockResolvedValue({ ok: true, status: 200, data });
+
+    const { output } = await captureStdout(() => trust({ packageName: 'express', ci: true, format: 'text' }));
+    expect(output).toContain('35,000,000/week');
   });
 });
 

--- a/packages/cli/src/commands/trust.ts
+++ b/packages/cli/src/commands/trust.ts
@@ -358,7 +358,11 @@ function printTrustProfile(data: TrustLookupResponse, verbose: boolean, requestU
     if (sc.maintainerCount > 0) {
       process.stdout.write(`  Maintainers:  ${sc.maintainerCount}\n`);
     }
-    if (sc.weeklyDownloads !== undefined && sc.weeklyDownloads !== null) {
+    // Treat 0 as "not reported by Registry" rather than "this package has zero
+    // downloads" — popular packages (express, lodash) show 0 when the Registry
+    // backfill is incomplete; emitting "0/week" reads as a confidence signal
+    // about the package, which is the wrong signal. Closes #123.
+    if (sc.weeklyDownloads !== undefined && sc.weeklyDownloads !== null && sc.weeklyDownloads > 0) {
       process.stdout.write(`  Downloads:    ${formatNumber(sc.weeklyDownloads)}/week\n`);
     }
   } else {
@@ -393,13 +397,15 @@ function printTrustProfile(data: TrustLookupResponse, verbose: boolean, requestU
     if (data.lastScanned) process.stdout.write(`  Scanned:  ${dim(data.lastScanned)}\n`);
   }
 
-  // Links — the Registry website is not live yet (launches April 2026) and
-  // some responses embed legacy hostnames. Suppress the Profile/Badge lines
-  // when the host is known-dead so users don't see broken URLs, and show a
-  // dim placeholder instead.
+  // Links — some Registry responses embed legacy hostnames (registry.oa2a.org,
+  // api.opena2a.org) that 404. Suppress the Profile/Badge lines for known-dead
+  // hostnames so users don't see broken URLs. Closes #123 — the prior copy
+  // ("Registry launches soon") claimed the Registry was offline, which was
+  // misleading: the Registry is live, only the per-package profile URL is
+  // missing.
   process.stdout.write('\n');
   if (isDeadProfileHost(data.profileUrl)) {
-    process.stdout.write(dim('Profile: (Registry launches soon — opena2a.org)') + '\n');
+    process.stdout.write(dim('Profile: not available for this package') + '\n');
   } else {
     process.stdout.write(`Profile: ${cyan(data.profileUrl)}\n`);
     process.stdout.write(`Badge:   ${dim(`${data.profileUrl.replace('/agents/', '/v1/trust/')}/badge.svg`)}\n`);


### PR DESCRIPTION
## Summary

Two UX bugs in \`opena2a trust <pkg>\`:

1. **Stale copy** — When a Registry response embeds a dead-host profile URL (\`registry.opena2a.org\`, \`registry.oa2a.org\`, \`api.opena2a.org\`), the placeholder read \`Profile: (Registry launches soon — opena2a.org)\`. The Registry IS live; only the per-package profile URL is missing. The old copy claimed the wrong root cause **and** was calendar-stale. New copy: \`Profile: not available for this package\`.

2. **Downloads=0 on popular packages** — Registry returns \`weeklyDownloads=0\` when the npm-download backfill hasn't landed yet (e.g. \`express\`). The CLI rendered \`Downloads: 0/week\` — which reads as a confidence signal about the package, the wrong signal. Treat 0 same as null/undefined: suppress the Downloads line. Real downloads > 0 still render correctly.

Closes #123.

## Before / After

\`\`\`
$ opena2a trust express --ci
\`\`\`

| Line | Before | After |
|---|---|---|
| Profile | \`(Registry launches soon — opena2a.org)\` | \`not available for this package\` |
| Downloads | \`0/week\` | (suppressed) |

## Test plan

- [x] \`npm test\` — 1058/1058 pass (3 new regression tests + 1 existing test updated to assert the new placeholder)
- [x] \`npm run build\` clean
- [x] Manual: \`opena2a trust express --ci\` shows new copy and no Downloads line
- [x] HMA scan unchanged — 35/100 baseline, 0 new findings

## Notes

Phase 4.5 SKIP — pure copy/display changes in \`commands/trust.ts\`, not on the detection/scoring trigger list.

The underlying Registry-side problem (express weeklyDownloads should not be 0) is tracked separately in opena2a-registry. The CLI-side fix here makes the display honest rather than misleading until the Registry backfill catches up.