### PR TITLE
feat(credential-patterns): add canonical AWS secret-key example to allowlist (#127 item 4)

### DIFF
--- a/packages/credential-patterns/src/match.test.ts
+++ b/packages/credential-patterns/src/match.test.ts
@@ -31,6 +31,15 @@ describe('isKnownExample (issue #50 — comment-marker precedence)', () => {
     const match = line.match(/AKIA[0-9A-Z]{16}/)!;
     expect(isKnownExample(line, match)).toBe(true);
   });
+
+  it('#127: treats the AWS canonical secret-key example wJalrXUtnFEMI... as a known example', () => {
+    // Paired with AKIAIOSFODNN7EXAMPLE in the AWS IAM User Guide canonical
+    // example. AWS docs reference verified 2026-05-21.
+    const line = 'const secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";';
+    const match = line.match(/wJalr[A-Za-z0-9/+]+EXAMPLEKEY/)!;
+    expect(match).not.toBeNull();
+    expect(isKnownExample(line, match)).toBe(true);
+  });
 });
 
 describe('isKnownExample (0.1.1 — block-comment markers)', () => {

--- a/packages/credential-patterns/src/patterns.ts
+++ b/packages/credential-patterns/src/patterns.ts
@@ -115,8 +115,16 @@ export const CREDENTIAL_PREFIX_QUICK_CHECK = new RegExp(
  */
 export const KNOWN_EXAMPLE_KEYS = new Set([
   // AWS (official docs)
+  // Access keys: from IAM User Guide / SigV4 references.
   'AKIAIOSFODNN7EXAMPLE',
   'AKIAI44QH8DHBEXAMPLE',
+  // Secret access key paired with AKIAIOSFODNN7EXAMPLE in the canonical
+  // AWS docs example. Source verified 2026-05-21 against
+  // docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+  // ("Access keys consist of two parts: an access key ID (for example,
+  // AKIAIOSFODNN7EXAMPLE) and a secret access key (for example,
+  // wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY).") Closes #127 item 4 (AWS leg).
+  'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
   // OpenAI (from docs)
   'sk-proj-abc123',
 ]);


### PR DESCRIPTION
## Summary

Issue #127 has four items. Items 1-3 landed in PR #134 (\`@opena2a/credential-patterns@0.1.1\`). Item 4 (allowlist additions) calls for ~6 well-known example credentials with the explicit constraint "Validate each addition against a real AWS/OpenAI/GitHub doc page; do NOT add unverified strings."

This PR adds **one** verifiable entry:

- **AWS secret-access-key canonical example** \`wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\` — the documented partner of the already-listed \`AKIAIOSFODNN7EXAMPLE\` per the AWS IAM User Guide:
  > "Access keys consist of two parts: an access key ID (for example, \`AKIAIOSFODNN7EXAMPLE\`) and a secret access key (for example, \`wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\`)."

  Source verified 2026-05-21 against \`docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html\`.

## Out of scope

- **OpenAI examples** — \`platform.openai.com/docs/quickstart\` returned 403 during verification; deferred until a verifiable docs page can be sourced.
- **GitHub PAT examples** — Official GitHub PAT docs use \`YOUR-PERSONAL-ACCESS-TOKEN\` placeholder text only, no literal example tokens to verify. Deferred.

## Test plan

- [x] \`npm test\` — credential-patterns 228/228 pass (1 new test for the AWS secret-key example)
- [x] Full repo \`npm test\` — 1058/1058 CLI tests still pass
- [x] HMA scan unchanged

## Release coordination

Source change lands at version **0.1.1** — no version bump in this PR. Acceptance criteria says \`secretless-ai 0.16.4\` should re-bump its exact pin and re-sync \`src/patterns.ts\` + \`KNOWN_EXAMPLE_KEYS\` against the next published version. That cycle is deferred to the next intentional release window per the publish-batching policy (max 3 publishes/day, lockstep update required).

## Notes

Phase 4.5 adversarial review SKIPPED — the change adds one entry to a strict-equality \`Set\` (\`KNOWN_EXAMPLE_KEYS\`), no regex/detection change, no severity/scoring change. The added value is the AWS canonical placeholder string; allowlisting it cannot weaken detection of real secrets (any real key would not exact-match this string).