### PR TITLE
fix(scan-soul): disclose partial scope; promote profile-mismatch to HIGH (#136)

### DIFF
--- a/packages/cli/__tests__/commands/soul-strict.test.ts
+++ b/packages/cli/__tests__/commands/soul-strict.test.ts
@@ -173,3 +173,199 @@ describe('scan-soul --strict', () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe('scan-soul partial-scope disclosure (#136)', () => {
+  beforeEach(() => {
+    mockScanSoul.mockReset();
+  });
+
+  it('downgrades [hardened] to [partial-hardened] when domains were skipped', async () => {
+    mockScanSoul.mockResolvedValue({
+      score: 100,
+      level: 'hardened',
+      file: 'SOUL.md',
+      agentTier: 'TOOL-USING',
+      agentProfile: 'conversational',
+      totalControls: 26,
+      totalPassed: 26,
+      skippedDomains: ['Trust Hierarchy', 'Capability Boundaries', 'Data Handling', 'Agentic Safety', 'Human Oversight'],
+      domains: [
+        { domain: 'Trust Hierarchy', controls: [], skippedByProfile: true },
+        { domain: 'Capability Boundaries', controls: [], skippedByProfile: true },
+        { domain: 'Injection Hardening', controls: [{ id: 'SOUL-IH-001', passed: true }] },
+        { domain: 'Data Handling', controls: [], skippedByProfile: true },
+        { domain: 'Hardcoded Behaviors', controls: [{ id: 'SOUL-HB-001', passed: true }] },
+        { domain: 'Agentic Safety', controls: [], skippedByProfile: true },
+        { domain: 'Honesty and Transparency', controls: [{ id: 'SOUL-HT-001', passed: true }] },
+        { domain: 'Human Oversight', controls: [], skippedByProfile: true },
+        { domain: 'Harm Avoidance', controls: [{ id: 'SOUL-HA-001', passed: true }] },
+      ],
+    });
+
+    const { exitCode, stdout } = await captureOutput(() => scanSoul({ strict: false }));
+
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toContain('[hardened]');
+    expect(stdout).toContain('[partial-hardened]');
+    expect(stdout).toContain('Scope:');
+    expect(stdout).toContain('4 of 9 domains evaluated');
+    expect(stdout).toContain('5 skipped');
+    expect(stdout).toContain('Trust Hierarchy');
+    expect(stdout).toContain('Capability Boundaries');
+  });
+
+  it('surfaces profile-mismatch as HIGH SOUL-PROFILE-MISMATCH finding', async () => {
+    mockScanSoul.mockResolvedValue({
+      score: 100,
+      level: 'hardened',
+      file: 'SOUL.md',
+      agentTier: 'TOOL-USING',
+      agentProfile: 'conversational',
+      totalControls: 26,
+      totalPassed: 26,
+      skippedDomains: ['Trust Hierarchy', 'Capability Boundaries'],
+      profileMismatch: {
+        declaredProfile: 'conversational',
+        inferredProfile: 'autonomous',
+        signals: ['"Agentic Safety" heading', '"Capability Boundaries" heading', 'tool execution verb'],
+        skippedDomains: ['Trust Hierarchy', 'Capability Boundaries'],
+      },
+      domains: [],
+    });
+
+    const { stdout } = await captureOutput(() => scanSoul({ strict: false }));
+
+    // Severity + checkId match HMA's direct render so the wrapper signal
+    // strength matches `hackmyagent scan-soul` direct.
+    expect(stdout).toContain('HIGH');
+    expect(stdout).toContain('SOUL-PROFILE-MISMATCH');
+    expect(stdout).toContain('Declared profile=conversational');
+    expect(stdout).toContain('body suggests profile=autonomous');
+    expect(stdout).toContain('Signals:');
+    expect(stdout).toContain('Skipped domains: Trust Hierarchy, Capability Boundaries');
+    expect(stdout).toContain('remove the <!-- soul:profile=conversational --> marker');
+  });
+
+  it('#136 C1: detects partial scope from domains[].skippedByProfile when skippedDomains is empty', async () => {
+    // Bypass class: an HMA build that populates per-domain skippedByProfile
+    // flags but does NOT populate the top-level `skippedDomains` array
+    // would still get [hardened] under the v1 gate. The fix derives from
+    // BOTH sources.
+    mockScanSoul.mockResolvedValue({
+      score: 100,
+      level: 'hardened',
+      file: 'SOUL.md',
+      agentTier: 'TOOL-USING',
+      agentProfile: 'conversational',
+      totalControls: 26,
+      totalPassed: 26,
+      // Top-level array intentionally empty/missing.
+      domains: [
+        { domain: 'Trust Hierarchy', controls: [], skippedByProfile: true },
+        { domain: 'Capability Boundaries', controls: [], skippedByProfile: true },
+        { domain: 'Injection Hardening', controls: [{ id: 'SOUL-IH-001', passed: true }] },
+      ],
+    });
+
+    const { stdout } = await captureOutput(() => scanSoul({ strict: false }));
+
+    expect(stdout).toContain('[partial-hardened]');
+    expect(stdout).toContain('Trust Hierarchy');
+    expect(stdout).toContain('Capability Boundaries');
+  });
+
+  it('#136 H1: downgrades uppercase / mixed-case level labels', async () => {
+    mockScanSoul.mockResolvedValue({
+      score: 100,
+      level: 'HARDENED',
+      file: 'SOUL.md',
+      agentTier: 'TOOL-USING',
+      agentProfile: 'conversational',
+      totalControls: 26,
+      totalPassed: 26,
+      skippedDomains: ['Trust Hierarchy'],
+      domains: [{ domain: 'Trust Hierarchy', controls: [], skippedByProfile: true }],
+    });
+
+    const { stdout } = await captureOutput(() => scanSoul({ strict: false }));
+    expect(stdout).toContain('[partial-hardened]');
+    expect(stdout).not.toContain('[HARDENED]');
+  });
+
+  it('#136 H1: downgrades other absolute labels (standard, developing) on partial scope', async () => {
+    mockScanSoul.mockResolvedValue({
+      score: 75,
+      level: 'standard',
+      file: 'SOUL.md',
+      agentTier: 'TOOL-USING',
+      agentProfile: 'conversational',
+      totalControls: 26,
+      totalPassed: 20,
+      skippedDomains: ['Trust Hierarchy'],
+      domains: [{ domain: 'Trust Hierarchy', controls: [], skippedByProfile: true }],
+    });
+
+    const { stdout } = await captureOutput(() => scanSoul({ strict: false }));
+    expect(stdout).toContain('[partial-standard]');
+    expect(stdout).not.toContain('[standard]');
+  });
+
+  it('#136: does NOT downgrade non-assertive labels (initial / not-started)', async () => {
+    mockScanSoul.mockResolvedValue({
+      score: 0,
+      level: 'not-started',
+      file: 'SOUL.md',
+      agentTier: 'TOOL-USING',
+      agentProfile: 'conversational',
+      totalControls: 26,
+      totalPassed: 0,
+      skippedDomains: ['Trust Hierarchy'],
+      domains: [{ domain: 'Trust Hierarchy', controls: [], skippedByProfile: true }],
+    });
+
+    const { stdout } = await captureOutput(() => scanSoul({ strict: false }));
+    expect(stdout).toContain('[not-started]');
+    expect(stdout).not.toContain('[partial-not-started]');
+  });
+
+  it('#136 M2: defends against negative evaluated count when domains array is empty', async () => {
+    mockScanSoul.mockResolvedValue({
+      score: 100,
+      level: 'hardened',
+      file: 'SOUL.md',
+      agentTier: 'TOOL-USING',
+      agentProfile: 'conversational',
+      totalControls: 26,
+      totalPassed: 26,
+      skippedDomains: ['Trust Hierarchy', 'Capability Boundaries'],
+      domains: [],
+    });
+
+    const { stdout } = await captureOutput(() => scanSoul({ strict: false }));
+    // Total domains falls back to max(skipped.length, 9). evaluated = max(0, total-skipped).
+    expect(stdout).toMatch(/Scope:\s+\d+ of \d+ domains evaluated/);
+    expect(stdout).not.toMatch(/-\d+ of/);
+  });
+
+  it('keeps unconditional [hardened] when no domains were skipped (no regression)', async () => {
+    mockScanSoul.mockResolvedValue({
+      score: 100,
+      level: 'hardened',
+      file: 'SOUL.md',
+      agentTier: 'STANDARD',
+      agentProfile: 'custom',
+      totalControls: 29,
+      totalPassed: 29,
+      domains: [
+        { domain: 'Trust Hierarchy', controls: [{ id: 'SOUL-TH-001', passed: true }] },
+      ],
+    });
+
+    const { stdout } = await captureOutput(() => scanSoul({ strict: false }));
+
+    expect(stdout).toContain('[hardened]');
+    expect(stdout).not.toContain('[partial-hardened]');
+    expect(stdout).not.toContain('Scope:');
+    expect(stdout).not.toContain('WARNING');
+  });
+});

--- a/packages/cli/src/commands/soul.ts
+++ b/packages/cli/src/commands/soul.ts
@@ -137,31 +137,92 @@ function findMissingCriticalControls(result: any): string[] {
 
 function formatScanResult(result: any, verbose: boolean, strict = false): void {
   const score = result.score ?? result.overallScore ?? 0;
-  const level = result.level ?? result.grade ?? 'unknown';
+  const rawLevel = result.level ?? result.grade ?? 'unknown';
   const file = result.file ?? 'not found';
   const tier = result.agentTier ?? 'unknown';
   const profile = result.agentProfile ?? 'unknown';
   const totalControls = result.totalControls ?? 0;
   const passingControls = result.totalPassed ?? result.passingControls ?? 0;
+  const profileMismatch = result.profileMismatch;
 
-  process.stdout.write(`\nGovernance Score: ${score}/100 [${level}]\n`);
+  // #136: detect partial scope from BOTH sources HMA exposes — the top-level
+  // `skippedDomains` array AND the per-domain `skippedByProfile: true` flag.
+  // Either alone is sufficient; relying on `skippedDomains` alone leaves a
+  // bypass class if HMA changes which field it populates (adversarial review
+  // C1, 2026-05-21).
+  const domainsArray: any[] = Array.isArray(result.domains) ? result.domains : [];
+  const skippedFromTopLevel: string[] = Array.isArray(result.skippedDomains) ? result.skippedDomains : [];
+  const skippedFromPerDomain: string[] = domainsArray
+    .filter((d: any) => d && d.skippedByProfile === true)
+    .map((d: any) => String(d.domain ?? 'unknown'));
+  // Union of both sources, dedup, stable order (top-level first).
+  const skippedSet = new Set<string>(skippedFromTopLevel);
+  for (const d of skippedFromPerDomain) skippedSet.add(d);
+  const skippedDomains: string[] = Array.from(skippedSet);
+
+  // Total domain count: prefer the actual domains array length; fall back
+  // to a defensive non-zero value so we never emit "N of 0 domains" (which
+  // would render as a negative `evaluatedDomains`).
+  const totalDomains = domainsArray.length > 0
+    ? domainsArray.length
+    : Math.max(skippedDomains.length, 9); // 9 is HMA's current full-tier count
+  const evaluatedDomains = Math.max(0, totalDomains - skippedDomains.length);
+  const hasPartialScope = skippedDomains.length > 0;
+
+  // #136: any non-empty absolute label gets downgraded when scope is
+  // partial — `[hardened]`, `[HARDENED]`, `[standard]`, `[developing]`,
+  // anything except `[initial]`/`[not-started]` would lie about the
+  // analyzer's actual coverage. Case-insensitive match (adversarial review
+  // H1) and apply to every level except the explicit "scan didn't run"
+  // labels.
+  const NON_ASSERTIVE_LEVELS = new Set(['initial', 'not-started', 'unknown']);
+  const lowerLevel = String(rawLevel).toLowerCase();
+  const displayLevel = hasPartialScope && !NON_ASSERTIVE_LEVELS.has(lowerLevel)
+    ? `partial-${lowerLevel}`
+    : rawLevel;
+
+  process.stdout.write(`\nGovernance Score: ${score}/100 [${displayLevel}]\n`);
   process.stdout.write(`File: ${file}\n`);
   process.stdout.write(`Tier: ${tier} | Profile: ${profile}\n`);
   process.stdout.write(`Controls: ${passingControls}/${totalControls} passing\n`);
+  if (hasPartialScope) {
+    // Inline scope disclosure — required regardless of verbose mode so the
+    // partial-scope state is visible to CISO-rule-11 readers. Closes #136.
+    process.stdout.write(`Scope:    ${evaluatedDomains} of ${totalDomains} domains evaluated; ${skippedDomains.length} skipped: ${skippedDomains.join(', ')}\n`);
+  }
+
+  // #136: surface profile-mismatch as a prominent finding with severity +
+  // checkId so the wrapper output matches HMA's direct render in signal
+  // strength (adversarial review H2). HMA emits this as a HIGH
+  // SOUL-PROFILE-MISMATCH finding when the declared profile narrows scope
+  // past what the body content suggests. The opena2a wrapper previously
+  // dropped it entirely; without the severity + checkId the CISO scanning
+  // the output gets a weaker signal than `hackmyagent scan-soul` direct.
+  if (profileMismatch && typeof profileMismatch === 'object') {
+    const declared = profileMismatch.declaredProfile ?? profile;
+    const inferred = profileMismatch.inferredProfile ?? 'unknown';
+    const mismatchSkipped: string[] = Array.isArray(profileMismatch.skippedDomains)
+      ? profileMismatch.skippedDomains
+      : skippedDomains;
+    process.stdout.write(`\nHIGH  SOUL-PROFILE-MISMATCH  Profile narrows scope past body content\n`);
+    process.stdout.write(`      Declared profile=${declared} skips ${mismatchSkipped.length} domains; body suggests profile=${inferred}\n`);
+    const signals: string[] = Array.isArray(profileMismatch.signals) ? profileMismatch.signals : [];
+    if (signals.length > 0) {
+      process.stdout.write(`      Signals: ${signals.slice(0, 3).join('; ')}${signals.length > 3 ? `; +${signals.length - 3} more` : ''}\n`);
+    }
+    if (mismatchSkipped.length > 0) {
+      process.stdout.write(`      Skipped domains: ${mismatchSkipped.join(', ')}\n`);
+    }
+    process.stdout.write(`      Fix: remove the <!-- soul:profile=${declared} --> marker, or revise the body to match the declared profile.\n`);
+  }
 
   if (result.domains && verbose) {
     process.stdout.write('\nDomain Breakdown:\n');
     for (const domain of result.domains) {
       const passed = domain.controls?.filter((c: any) => c.passed).length ?? 0;
       const total = domain.controls?.length ?? 0;
-      process.stdout.write(`  ${domain.domain}: ${passed}/${total}\n`);
-    }
-  }
-
-  if (result.skippedDomains?.length > 0 && verbose) {
-    process.stdout.write(`\nSkipped domains (not applicable to ${profile} profile):\n`);
-    for (const d of result.skippedDomains) {
-      process.stdout.write(`  ${d}\n`);
+      const skippedMark = domain.skippedByProfile ? ' (skipped)' : '';
+      process.stdout.write(`  ${domain.domain}: ${passed}/${total}${skippedMark}\n`);
     }
   }
 


### PR DESCRIPTION
## Summary

opena2a scan-soul on the malicious kitchen-sink corpus returned **"100/100 [hardened]"** — even though HMA itself emits "PARTIAL HARDENED" + a HIGH SOUL-PROFILE-MISMATCH finding on the same scan. The opena2a wrapper's renderer stripped the partial-scope disclosure and dropped the mismatch finding entirely.

The bug is the canonical attacker-controllable bypass per release-test Phase 4d: a malicious SOUL.md drops a \`<!-- soul:profile=conversational -->\` marker that skips 5 of 9 domains, then scores 100/100 on the remaining 4 — laundered to "HARDENED" by the wrapper.

Closes #136.

## Fix

In \`commands/soul.ts:formatScanResult\`:

1. **Detect partial scope from BOTH sources** — \`result.skippedDomains\` AND \`result.domains[].skippedByProfile\`. Phase 4.5 adversarial review caught that gating only on the top-level array left a bypass class (C1).
2. **Case-insensitive label downgrade** — \`hardened\` / \`HARDENED\` / \`standard\` / \`developing\` all become \`partial-<level>\` when scope is partial. Exempt non-assertive labels (\`initial\` / \`not-started\` / \`unknown\`).
3. **Always-on scope disclosure** — emit \`Scope: N of M domains evaluated; K skipped: <list>\` regardless of \`--verbose\`.
4. **HIGH SOUL-PROFILE-MISMATCH finding** — promote the profile-mismatch from generic WARNING to a labeled HIGH finding with the checkId, declared/inferred profiles, signals, skipped-domains list, and runnable fix command. Matches HMA's direct render signal strength.
5. **Defensive totals** — when \`domains: []\`, fall back to \`max(skippedDomains.length, 9)\` so Scope never emits negative or "N of 0".

## Before / After

\`\`\`bash
cd ~/.opena2a/corpus/repo/malicious/kitchen-sink
opena2a scan-soul --ci
\`\`\`

**Before:**
\`\`\`
Governance Score: 100/100 [hardened]
File: SOUL.md
Tier: TOOL-USING | Profile: conversational
Controls: 26/26 passing
\`\`\`

**After:**
\`\`\`
Governance Score: 100/100 [partial-hardened]
File: SOUL.md
Tier: TOOL-USING | Profile: conversational
Controls: 26/26 passing
Scope:    4 of 9 domains evaluated; 5 skipped: Trust Hierarchy, Capability Boundaries, Data Handling, Agentic Safety, Human Oversight

HIGH  SOUL-PROFILE-MISMATCH  Profile narrows scope past body content
      Declared profile=conversational skips 5 domains; body suggests profile=autonomous
      Signals: "Agentic Safety" heading; "Capability Boundaries" heading; "Human Oversight" heading; +6 more
      Skipped domains: Trust Hierarchy, Capability Boundaries, Data Handling, Agentic Safety, Human Oversight
      Fix: remove the <!-- soul:profile=conversational --> marker, or revise the body to match the declared profile.
\`\`\`

## Test plan

- [x] \`npm test\` — 1066/1066 pass (8 new tests for the headline reproducer, C1 skippedByProfile-only bypass, H1 case-insensitive downgrade, non-hardened labels, non-assertive label exemption, M2 zero-domains defense, no-regression on clean fixtures)
- [x] \`npm run build\` clean
- [x] Manual verify: kitchen-sink fixture renders new output matching HMA direct
- [x] HMA scan unchanged — 35/100 baseline, 0 new findings

## Phase 4.5 adversarial review (REQUIRED — finding rendering trigger)

Ran adversarial subagent on the working tree. **3 blocking items addressed** before push:

- **C1 (CRITICAL)** — gate on \`skippedDomains.length > 0\` missed the \`domains[].skippedByProfile: true\` case. Fix: derive from both sources.
- **H1 (HIGH)** — case-sensitive \`=== 'hardened'\` was brittle; only downgraded one level. Fix: lowercase + downgrade any non-empty level except non-assertive ones.
- **H2 (HIGH)** — WARNING block was weaker signal than HMA's HIGH SOUL-PROFILE-MISMATCH. Fix: promote to HIGH with checkId.

Two LOW items deferred:
- **L1** — JSON shape unchanged. Followup can add \`partialScope: true\` for JSON consumers.
- **L2** — Exit code does not gate on partial scope. Followup.

## Out of scope

- JSON output shape (\`--format json\`) is unchanged. JSON consumers should read \`skippedDomains\`/\`profileMismatch\` directly and apply their own gates. A future PR can add a top-level \`partialScope\` field for convenience.