### PR TITLE
feat(telemetry): semanticSuccessCodes per [CHIEF-CSR-018] + [CHIEF-CPO-022] (0.3.0)

### DIFF
--- a/packages/telemetry/CHANGELOG.md
+++ b/packages/telemetry/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.3.0 — 2026-05-24
+
+### Added
+
+- **`successFromExitCode(exitCode, semanticSuccessCodes?)`** — optional second argument lets each dispatcher declare exit codes ≥ 2 that represent semantic outcomes rather than crashes. Per [CHIEF-CSR-018] + [CHIEF-CPO-022] (`briefs/cli-telemetry-success-semantics.md`), invocation telemetry's `success` field follows **crash-rate semantics**: a `success: false` event means the command itself failed to execute (config error, network failure, exception, integrity violation), not "the user got a result they didn't want." Tools whose exit codes ≥ 2 represent working outcomes — `ai-trust check <not-found-pkg>` exits 2 to signal "I checked, the package isn't in the registry" — pass those codes via the new argument so the dashboard signal reflects actual crash rate.
+
+  Surfaced by the first 60-day rollup query on `/admin/cli-usage`: `ai-trust audit` showed a 50% "failure" rate driven almost entirely by exit-2 not-found events in `requirements.txt` audits. Real crash rate was ~0%.
+
+  Validation still wins. Out-of-range values (< 0 or > 255), non-finite numbers, and unparseable strings continue to return `false` even when listed in `semanticSuccessCodes` — a programming-bug-tier value is treated as a programming bug, not a semantic override.
+
+### Migration for consumer CLIs
+
+- **ai-trust** ships `tele.successFromExitCode(process.exitCode, [2])` consuming 0.3.0 on its next pin bump.
+- **hackmyagent** ships unchanged dispatcher (no `semanticSuccessCodes` — partial-scan exit 2 IS a degraded outcome per [CHIEF-CSR-018]; surface it). HMA's integrity-failure exit-3 path at `src/cli.ts:9494` migrates to `tele.error('startup', 'INTEGRITY_FAIL')` so integrity violations get their own dashboard event row.
+- **damn-vulnerable-ai-agent** — `browse.js:349` exit-2 site needs case-by-case classification before assigning a `semanticSuccessCodes` value. Default is no override.
+- **opena2a-cli**, **secretless-ai** — no production exit-≥2 sites; no migration needed.
+
+### Tests
+
+- 11 new tests in `index.test.ts` covering `semanticSuccessCodes` behavior, validation precedence, backward compatibility with the no-arg form, and the "empty array = no override" semantic.
+
+### Guardrails (set by [CHIEF-CPO-022])
+
+- New CLIs joining the OpenA2A fleet MUST declare `semanticSuccessCodes` at telemetry-wiring time or accept the default `[]` (treat exit ≥ 2 as failure).
+- Exit-code contract toward end-users is unchanged — no shipping CLI changes its `process.exit(...)` codes as part of this rollout. Splitting an existing exit code (e.g. HMA exit 2 → 2-or-4) is a breaking CLI contract change that requires Abdel escalation.
+- Third-party SDK consumers: 0.3.0 is backward-compatible with 0.2.0 call sites — the second argument is optional. Existing dispatchers compile and behave identically without changes.
+
 ## 0.2.0 — 2026-05-11
 
 ### Changed (behavioural)

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -26,8 +26,28 @@ tele.error("scan", "HMA_TIMEOUT");
 - `track(name, fields?)` fires a `command` event with the command name and optional `success` / `durationMs`.
 - `error(name, code)` fires an `error` event with the failure code.
 - `status()` returns `{ enabled, configPath, policyURL, installId }` for tools to build their own `--version` line and `telemetry` subcommand (see `@opena2a/cli-ui` helpers).
+- `successFromExitCode(exitCode, semanticSuccessCodes?)` translates `process.exitCode` to the `success` boolean. Default behavior follows POSIX security-tool convention (exit 0 and 1 = success; ≥ 2 = failure). The optional second argument lets dispatchers declare exit codes ≥ 2 that represent semantic outcomes (not crashes). See [crash-rate semantics](#crash-rate-semantics-for-success) below.
 
 All methods are fire-and-forget. Network failures, rate-limiting (429), and timeouts are swallowed. Telemetry never blocks the calling tool.
+
+## Crash-rate semantics for `success`
+
+Per [CHIEF-CSR-018] + [CHIEF-CPO-022], the `success` field in invocation telemetry follows **crash-rate semantics**: `success: false` means the command itself failed to execute (config error, network failure, exception, integrity violation) — NOT "the user got a result they didn't want."
+
+Some CLIs use exit codes ≥ 2 for semantic outcomes the command achieved correctly. Example: `ai-trust check <not-found-pkg>` exits 2 to signal "I checked, the package isn't in the registry." That's the command doing its job, not a crash. Pass those codes as the optional second argument so the dashboard signal reflects actual crash rate:
+
+```ts
+// POSIX default — exit 2 is a failure
+success: tele.successFromExitCode(process.exitCode),
+
+// ai-trust — exit 2 is a not-found outcome, not a crash
+success: tele.successFromExitCode(process.exitCode, [2]),
+
+// Multiple semantic codes are supported
+success: tele.successFromExitCode(process.exitCode, [2, 3]),
+```
+
+Validation always wins. Out-of-range values (< 0 or > 255), non-finite numbers, and unparseable strings continue to return `false` even when listed in `semanticSuccessCodes`. A programming-bug-tier value (e.g. `[256]`) is treated as a programming bug, not a semantic override.
 
 ## Disclosure surfaces
 

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/telemetry",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Tier-1 anonymous usage telemetry SDK for OpenA2A CLIs and tools. Fire-and-forget, opt-out, no content collection.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/telemetry/src/index.test.ts
+++ b/packages/telemetry/src/index.test.ts
@@ -233,6 +233,64 @@ describe("successFromExitCode", () => {
   });
 });
 
+describe("successFromExitCode — semanticSuccessCodes ([CHIEF-CSR-018] + [CHIEF-CPO-022])", () => {
+  it("exit 2 with semanticSuccessCodes [2] = success (ai-trust not-found is a working outcome)", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(2, [2])).toBe(true);
+  });
+  it("exit 3 with semanticSuccessCodes [2] = failure (only listed codes are semantic)", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(3, [2])).toBe(false);
+  });
+  it("exit 1 with semanticSuccessCodes [2] = success (POSIX convention still applies)", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(1, [2])).toBe(true);
+  });
+  it("exit 0 with semanticSuccessCodes [2] = success", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(0, [2])).toBe(true);
+  });
+  it("multiple semantic codes: [2, 3, 4] honored independently", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(2, [2, 3, 4])).toBe(true);
+    expect(tele.successFromExitCode(3, [2, 3, 4])).toBe(true);
+    expect(tele.successFromExitCode(4, [2, 3, 4])).toBe(true);
+    expect(tele.successFromExitCode(5, [2, 3, 4])).toBe(false);
+  });
+  it("out-of-range value in semanticSuccessCodes is still rejected (validation wins)", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(256, [256])).toBe(false);
+    expect(tele.successFromExitCode(-1, [-1])).toBe(false);
+  });
+  it("non-finite value still rejected even if exit is otherwise listed (validation wins)", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(Number.POSITIVE_INFINITY, [Number.POSITIVE_INFINITY as number])).toBe(false);
+    expect(tele.successFromExitCode("oops", [2])).toBe(false);
+  });
+  it("empty semanticSuccessCodes [] = same as undefined (no override)", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(2, [])).toBe(false);
+    expect(tele.successFromExitCode(0, [])).toBe(true);
+    expect(tele.successFromExitCode(1, [])).toBe(true);
+  });
+  it("undefined exit code with semanticSuccessCodes still treats as 0 = success", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(undefined, [2])).toBe(true);
+    expect(tele.successFromExitCode(null, [2])).toBe(true);
+  });
+  it("string exit code with semanticSuccessCodes parses then checks", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode("2", [2])).toBe(true);
+    expect(tele.successFromExitCode("3", [2])).toBe(false);
+  });
+  it("backward compatibility: omitting the second arg is identical to passing undefined", async () => {
+    const tele = await freshSdk();
+    expect(tele.successFromExitCode(2)).toBe(tele.successFromExitCode(2, undefined));
+    expect(tele.successFromExitCode(0)).toBe(tele.successFromExitCode(0, undefined));
+    expect(tele.successFromExitCode(127)).toBe(tele.successFromExitCode(127, undefined));
+  });
+});
+
 describe("install_id stability", () => {
   it("status() returns the same install_id across processes for the same machine", async () => {
     const a = await freshSdk();

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -111,17 +111,40 @@ export function setOptOut(enabled: boolean): Status {
  * find something (success at its job); exit >=2 means the command itself
  * failed (config error, crash, network failure, invalid input).
  *
+ * Some tools use exit codes ≥ 2 for semantic outcomes that are NOT crashes
+ * — for example `ai-trust check <not-found-pkg>` exits 2 to signal "I
+ * checked, the package isn't in the registry," which is the command doing
+ * its job, not a failure. The optional `semanticSuccessCodes` argument
+ * lets each dispatcher declare its semantic-but-not-crash exit codes so
+ * the dashboard signal reflects actual crash rate. Validation (range,
+ * non-finite) always wins: an out-of-range value in `semanticSuccessCodes`
+ * is treated as a programming bug and still returns false. See
+ * [CHIEF-CSR-018] + [CHIEF-CPO-022] for the policy.
+ *
  * @param exitCode - Process exit code (0-255 per POSIX) or undefined/null
  *   for processes that haven't set one (treated as success). Strings are
  *   accepted because Node 22+ widened `process.exitCode` to
  *   `string | number | null | undefined`; unparseable strings return false.
- * @returns `true` if the exit code indicates success (0 or 1).
- *   `false` for any failure code (≥ 2), out-of-range value (< 0 or > 255),
- *   non-finite numbers, or unparseable strings.
+ * @param semanticSuccessCodes - Optional set of exit codes ≥ 2 that
+ *   should be treated as success (semantic outcomes, not crashes). Codes
+ *   outside the POSIX 0-255 range or that fail validation are still
+ *   rejected regardless of this set.
+ * @returns `true` if the exit code indicates success (0, 1, or any value
+ *   listed in `semanticSuccessCodes`). `false` for any other failure code
+ *   (≥ 2 and not listed), out-of-range value (< 0 or > 255), non-finite
+ *   numbers, or unparseable strings.
  *
  * @example
+ *   // POSIX-only (default): exit 2 is a failure
  *   tele.track(name, {
  *     success: tele.successFromExitCode(process.exitCode),
+ *     durationMs: Date.now() - startedAt,
+ *   });
+ *
+ * @example
+ *   // ai-trust: exit 2 is a not-found outcome, not a crash
+ *   tele.track(name, {
+ *     success: tele.successFromExitCode(process.exitCode, [2]),
  *     durationMs: Date.now() - startedAt,
  *   });
  *
@@ -129,11 +152,15 @@ export function setOptOut(enabled: boolean): Status {
  * but exit code still 0, etc.), pass `success` directly instead of using
  * this helper.
  */
-export function successFromExitCode(exitCode: number | string | undefined | null): boolean {
+export function successFromExitCode(
+  exitCode: number | string | undefined | null,
+  semanticSuccessCodes?: readonly number[],
+): boolean {
   if (exitCode === undefined || exitCode === null) return true;
   const n = typeof exitCode === "string" ? Number.parseInt(exitCode, 10) : exitCode;
   if (!Number.isFinite(n)) return false;
   if (n < 0 || n > 255) return false;
+  if (semanticSuccessCodes?.includes(n)) return true;
   return n <= 1;
 }
 


### PR DESCRIPTION
## Summary

Extends `successFromExitCode(exitCode, semanticSuccessCodes?)` with an optional second argument so dispatchers can declare exit codes >= 2 that represent semantic outcomes rather than crashes. Per the locked brief at `briefs/cli-telemetry-success-semantics.md`.

Crash-rate semantics for invocation telemetry `success`: a `success: false` event means the command failed to execute (config error, network failure, exception, integrity violation), not "the user got a result they didn't want."

Surfaced by the first 60-day rollup query on `/admin/cli-usage`: `ai-trust audit` showed a 50% "failure" rate driven almost entirely by exit-2 not-found events. Real crash rate was ~0%.

Backward-compatible. 0.2.0 callers compile and behave identically without changes.

## Test plan

- [x] 58 tests pass (11 new on semanticSuccessCodes matrix + validation precedence + backward-compat)
- [x] Runtime smoke confirms all six spec behaviors
- [x] Validation precedence verified: out-of-range / non-finite values are still rejected even when listed in semanticSuccessCodes
- [x] Empty array `[]` equivalent to undefined (no override)
- [ ] Reviewer: verify CHANGELOG references both chief decisions

## Downstream rollout

After 0.3.0 publishes via OIDC:
- `ai-trust@0.7.2` consumes with `[2]` (semantic not-found)
- `hackmyagent@0.23.1` consumes; integrity-failure path migrates to `tele.error('startup', 'INTEGRITY_FAIL')`
- `damn-vulnerable-ai-agent` stays on 0.2.0 (no semantic exit-2 sites, confirmed by grep)