### PR TITLE
fix(monorepo): bump packages/cli pin to @opena2a/telemetry@0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3943,7 +3943,7 @@
         "@opena2a/contribute": "0.1.0",
         "@opena2a/registry-client": "0.1.0",
         "@opena2a/shared": "0.1.0",
-        "@opena2a/telemetry": "0.2.0",
+        "@opena2a/telemetry": "0.3.0",
         "ai-trust": "^0.2.23",
         "commander": "^13.1.0",
         "hackmyagent": "0.22.3",
@@ -4071,7 +4071,7 @@
     },
     "packages/telemetry": {
       "name": "@opena2a/telemetry",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
     "@opena2a/contribute": "0.1.0",
     "@opena2a/registry-client": "0.1.0",
     "@opena2a/shared": "0.1.0",
-    "@opena2a/telemetry": "0.2.0",
+    "@opena2a/telemetry": "0.3.0",
     "ai-trust": "^0.2.23",
     "commander": "^13.1.0",
     "hackmyagent": "0.22.3",


### PR DESCRIPTION
## Summary

Unblocks main CI after #161. Bumps `packages/cli` exact pin `@opena2a/telemetry` from "0.2.0" to "0.3.0" and regenerates the root lockfile so npm workspaces can resolve the in-tree version.

## Root cause

#161 bumped `packages/telemetry` from 0.2.0 to 0.3.0. `packages/cli/package.json` exact-pinned the prior version. npm workspaces could no longer find 0.2.0, so `npm ci` at root failed:

> npm error Missing: @opena2a/telemetry@0.2.0 from lock file

Broke Security workflow (sast), dependency-audit, license-check. Also would have broken the `.github/workflows/release.yml` publish pipeline on the next tag push.

## Diff

- `packages/cli/package.json`: 1 line (pin 0.2.0 -> 0.3.0)
- `package-lock.json`: 4 lines (auto-regenerated by `npm install`)

## Verification

- `npm ci` at root: clean (the exact CI failure path now passes)
- `npm run build`: 10/10 turbo tasks
- `npm test`: 20/20 turbo tasks (opena2a-cli 1066 tests pass)

## Backward compatibility

telemetry 0.3.0's `successFromExitCode` is a superset of 0.2.0's (optional second arg, default behavior unchanged). `packages/cli` is not yet a consumer of `semanticSuccessCodes` (no exit->=2 sites that need it).