### PR TITLE
ci(parity): point uses: at opena2a-standards/opena2a-parity (org move)

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -19,7 +19,9 @@ concurrency:
 
 jobs:
   parity:
-    uses: opena2a-org/opena2a-parity/.github/workflows/parity.yml@main
+    # opena2a-parity moved from opena2a-org to opena2a-standards on 2026-05-24.
+    # Pinned to the current main SHA; bumps require an explicit, reviewable PR.
+    uses: opena2a-standards/opena2a-parity/.github/workflows/parity.yml@093dbda7def691db3b2f860216a008b43f8affb0
     with:
       hma_ref: main
       opena2a_ref: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
## Summary

`opena2a-parity` was moved from `opena2a-org` to `opena2a-standards` on 2026-05-24 at ~14:10 UTC. opena2a monorepo's parity workflow stopped resolving at that exact window (runs 26363977310 push-to-main, 26363947234 PR both failed with empty `referenced_workflows` and "workflow file issue").

## Change

`.github/workflows/parity.yml`: `uses:` `opena2a-org/opena2a-parity@main` -> `opena2a-standards/opena2a-parity@093dbda7def691db3b2f860216a008b43f8affb0` (org change + SHA pin in one shot; SHA matches the current opena2a-standards main).

## Verification

After merge, the next parity run should resolve `referenced_workflows` and actually execute the parity job.