### PR TITLE
ci(parity): bump SHA to pick up check-not-found fixture (opena2a-parity#7)

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -21,7 +21,7 @@ jobs:
   parity:
     # opena2a-parity moved from opena2a-org to opena2a-standards on 2026-05-24.
     # Pinned to the current main SHA; bumps require an explicit, reviewable PR.
-    uses: opena2a-standards/opena2a-parity/.github/workflows/parity.yml@093dbda7def691db3b2f860216a008b43f8affb0
+    uses: opena2a-standards/opena2a-parity/.github/workflows/parity.yml@1baab791b17880f44a927cb304c418ceb738988e
     with:
       hma_ref: main
       opena2a_ref: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
## Summary

Bumps the parity reusable workflow SHA pin from `093dbda` to `1baab79` to pick up the new `check-not-found` fixture added in [opena2a-standards/opena2a-parity#7](https://github.com/opena2a-standards/opena2a-parity/pull/7).

## Companion PRs (same lockstep bump)

- hackmyagent #193
- ai-trust #49