### PR TITLE
chore(deps): bump packages/cli hackmyagent pin to 0.23.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2442,9 +2442,9 @@
       }
     },
     "node_modules/hackmyagent": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/hackmyagent/-/hackmyagent-0.22.3.tgz",
-      "integrity": "sha512-uWKgRuh5eMZiUYKY6SfPIJ9V0z5Z7nMCyE9INj3/93pm3BayZaMudZhNh3Z722133KJNWQlg9vZGjgAtIw6yfg==",
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/hackmyagent/-/hackmyagent-0.23.4.tgz",
+      "integrity": "sha512-TjzNXtnwQIp5tSGM7y1bcRjshQ5Yz8MukrN8PqRA0Z65magvWzo9Z2yB8nRyklgQODyWNktArjh+JtT3c0R4lA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
@@ -2457,7 +2457,7 @@
         "@opena2a/credential-patterns": "0.1.1",
         "@opena2a/registry-client": "0.1.0",
         "@opena2a/shared": "^0.1.0",
-        "@opena2a/telemetry": "0.1.2",
+        "@opena2a/telemetry": "0.3.0",
         "ai-trust": "^0.2.6",
         "commander": "^12.0.0",
         "js-yaml": "^4.1.1",
@@ -2479,24 +2479,6 @@
         "js-yaml": "^4.1.1",
         "tweetnacl": "^1.0.3"
       },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/hackmyagent/node_modules/@opena2a/cli-ui": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.5.0.tgz",
-      "integrity": "sha512-c90/pOe/JiFe6WZnn9a8HVqOoaZ4cguI7Dkslh88FZM3Pqx8wP/9eaeoHFTKs/PrV9RYLj4GBC2OJ8srj7R7+g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "chalk": "^5.3.0"
-      }
-    },
-    "node_modules/hackmyagent/node_modules/@opena2a/telemetry": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@opena2a/telemetry/-/telemetry-0.1.2.tgz",
-      "integrity": "sha512-lMbNtwDfrXvrPWyEMXBY3ttU/RXWhQ2/xzSfCaosVvujFbqxtWuyq8YY725IEpQ9owa7uJ+PCp4mkxZ8UKW3wA==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -3944,7 +3926,7 @@
     },
     "packages/cli": {
       "name": "opena2a-cli",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
@@ -3955,7 +3937,7 @@
         "@opena2a/telemetry": "0.3.0",
         "ai-trust": "^0.2.23",
         "commander": "^13.1.0",
-        "hackmyagent": "0.22.3",
+        "hackmyagent": "0.23.4",
         "secretless-ai": "^0.14.1"
       },
       "bin": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.10.4
+
+### Dependencies
+- **Bundled `hackmyagent` bumped `0.22.3` -> `0.23.4`** ([opena2a-org/hackmyagent#198](https://github.com/opena2a-org/hackmyagent/pull/198)). Three releases of HMA fixes are now reflected in `opena2a check` end-to-end behavior:
+  - **`0.23.2`** ([hackmyagent#197](https://github.com/opena2a-org/hackmyagent/pull/197)) — `check pip:<pkg> --no-scan` no longer silently does a full PyPI download + scan; emits Registry-shape JSON identical to the npm path.
+  - **`0.23.3`** ([hackmyagent#192](https://github.com/opena2a-org/hackmyagent/pull/192)) — Scanner NEMO-009 + AST-CRED-* false-positive suppressions (string-literal gating, integrity-manifest carve-outs, corpus-tier carve-out). Preserved-detection FP-suppress per the score-jump classification rule.
+  - **`0.23.4`** ([hackmyagent#198](https://github.com/opena2a-org/hackmyagent/pull/198)) — `check pip:<pkg>` Registry lookups now use the bare PyPI package name (Registry stores PyPI under bare names; pre-fix `opena2a check pip:anthropic --format json` returned `found:false` for Registry-indexed PyPI packages despite the canonical record being live).
+- End-to-end effect: `opena2a check pip:anthropic --no-scan --json` and `opena2a check pip:anthropic --format json` both return the canonical Registry record (`found:true`, `packageType:"ai_tool"`, `trustLevel:2`).
+
 ## 0.10.3
 
 ### Bug Fixes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
     "@opena2a/telemetry": "0.3.0",
     "ai-trust": "^0.2.23",
     "commander": "^13.1.0",
-    "hackmyagent": "0.23.3",
+    "hackmyagent": "0.23.4",
     "secretless-ai": "^0.14.1"
   },
   "optionalDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opena2a-cli",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Unified CLI for the OpenA2A security platform",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
     "@opena2a/telemetry": "0.3.0",
     "ai-trust": "^0.2.23",
     "commander": "^13.1.0",
-    "hackmyagent": "0.22.3",
+    "hackmyagent": "0.23.3",
     "secretless-ai": "^0.14.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## Summary

- Two-commit pin bump: `packages/cli/package.json` `hackmyagent` pin → `"0.23.4"`.
- DRAFT until `hackmyagent 0.23.4` publishes to npm (latest is currently `0.23.3`, which was the scanner-FP release, not the pip-prefix fix).
- Branch name (`chore/bump-hma-0.23.3-pin`) is now slightly stale — kept as-is to preserve the PR's identity; PR title + body are the source of truth.

## Why this is needed

`opena2a check` spawn-delegates to `hackmyagent`. The published `opena2a-cli` (`0.10.3`) pins `hackmyagent: "0.22.3"`, which predates three HMA fixes the published `opena2a-cli` needs:

| HMA PR | Released as | What it fixes |
|---|---|---|
| [hackmyagent#197](https://github.com/opena2a-org/hackmyagent/pull/197) | `0.23.2` | `check pip:<pkg> --no-scan` no longer silently does a full PyPI download + scan. |
| [hackmyagent#192](https://github.com/opena2a-org/hackmyagent/pull/192) | `0.23.3` | Scanner NEMO-009 + AST-CRED-* false-positive suppressions (string-literal gating, integrity-manifest carve-outs, corpus-tier carve-out). |
| [hackmyagent#198](https://github.com/opena2a-org/hackmyagent/pull/198) | `0.23.4` (in flight) | `check pip:<pkg>` Registry lookups now use the bare package name (Registry stores PyPI under bare names). |

End-to-end effect once this lands: `opena2a check pip:anthropic --no-scan --json` and `opena2a check pip:anthropic --format json` both return the canonical Registry record (`found:true`, `packageType:"ai_tool"`, `trustLevel:2`), AND the bundled scanner is on the FP-suppressed v3 cred-analyzer.

## Why DRAFT

`hackmyagent@0.23.4` has not published yet. Today:

```
$ npm view hackmyagent dist-tags
{ latest: '0.23.3' }
```

`npm ci` against this branch's `package.json` will fail (`EUSAGE`, no candidate for `hackmyagent@0.23.4`) until the HMA tag-push publishes. CI failures on this PR before that publish are expected and document the blocker. Marking as draft so the PR isn't accidentally merged ahead of the publish.

## To make this ready (at merge time)

1. Confirm `npm view hackmyagent dist-tags.latest` returns `0.23.4`.
2. Run `npm install` at repo root to refresh `package-lock.json` (regenerates the `hackmyagent` entry in the workspace).
3. Bump `packages/cli/package.json` version: `0.10.3` → `0.10.4`.
4. Add a `## 0.10.4` entry to `packages/cli/CHANGELOG.md` noting the bundled HMA bump and what it unblocks (PyPI Registry lookups via `pip:` prefix + scanner FP suppressions inherited from #192).
5. Push the additional commits + flip to "ready for review".

## Dependency-chain context

Once both this PR and [opena2a-standards/opena2a-parity#10](https://github.com/opena2a-standards/opena2a-parity/pull/10) land:

- `opena2a-cli 0.10.4` ships with `hackmyagent@0.23.4` bundled.
- A follow-up fixture-extension PR on `opena2a-parity` replaces `opena2a.skip` with a real golden, expanding `check-registered-ai-pypi` from 2-way to 3-way.
- The three caller `parity-gate.yml` workflows bump their SHA pin one more time.

## Test plan

- [x] Local pre-push hook green (turbo build/test/lint 14/14)
- [ ] After HMA 0.23.4 publishes: `npm install` + lockfile refresh + version bump + CHANGELOG entry + ready-for-review
- [ ] After merge + opena2a-cli 0.10.4 publish: open the fixture-extension PR on `opena2a-parity`