### PR TITLE
fix(cli-ui): telemetry --help + toggle-hint direction (0.5.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2483,6 +2483,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/hackmyagent/node_modules/@opena2a/cli-ui": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.5.0.tgz",
+      "integrity": "sha512-c90/pOe/JiFe6WZnn9a8HVqOoaZ4cguI7Dkslh88FZM3Pqx8wP/9eaeoHFTKs/PrV9RYLj4GBC2OJ8srj7R7+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0"
+      }
+    },
     "node_modules/hackmyagent/node_modules/@opena2a/telemetry": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@opena2a/telemetry/-/telemetry-0.1.2.tgz",
@@ -3969,7 +3978,7 @@
     },
     "packages/cli-ui": {
       "name": "@opena2a/cli-ui",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0"
@@ -3988,6 +3997,15 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "packages/cli/node_modules/@opena2a/cli-ui": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.5.0.tgz",
+      "integrity": "sha512-c90/pOe/JiFe6WZnn9a8HVqOoaZ4cguI7Dkslh88FZM3Pqx8wP/9eaeoHFTKs/PrV9RYLj4GBC2OJ8srj7R7+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0"
       }
     },
     "packages/cli/node_modules/@opena2a/contribute": {

--- a/packages/cli-ui/package.json
+++ b/packages/cli-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/cli-ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Shared terminal UI primitives for OpenA2A CLIs (score meter, trust level legend, verdict colors, observations + verdict block, analyst-render, check block, check rich-block (skill+mcp), not-found block, next-steps, version-line, telemetry-command)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli-ui/src/telemetry-command.test.ts
+++ b/packages/cli-ui/src/telemetry-command.test.ts
@@ -37,6 +37,22 @@ describe("runTelemetryCommand", () => {
     expect(input.setOptOut).not.toHaveBeenCalled();
   });
 
+  it("status hint suggests 'off' when telemetry is on", () => {
+    const out = runTelemetryCommand("status", makeInput({ enabled: true }));
+    expect(out).toContain("dvaa telemetry off");
+    expect(out).toContain("OPENA2A_TELEMETRY=off");
+    expect(out).not.toContain("dvaa telemetry on'");
+    expect(out).not.toContain("OPENA2A_TELEMETRY=on");
+  });
+
+  it("status hint suggests 'on' when telemetry is off (papercut from DVAA 0.9.0 release-test)", () => {
+    const out = runTelemetryCommand("status", makeInput({ enabled: false }));
+    expect(out).toContain("dvaa telemetry on");
+    expect(out).toContain("OPENA2A_TELEMETRY=on");
+    expect(out).not.toContain("dvaa telemetry off'");
+    expect(out).not.toContain("OPENA2A_TELEMETRY=off");
+  });
+
   it("'status' action behaves the same as no action", () => {
     const a = runTelemetryCommand(undefined, makeInput());
     const b = runTelemetryCommand("status", makeInput());
@@ -64,5 +80,29 @@ describe("runTelemetryCommand", () => {
     expect(out).toContain("Unknown action 'nuke'");
     expect(out).toContain("[on|off|status]");
     expect(input.setOptOut).not.toHaveBeenCalled();
+  });
+
+  it("'--help' prints usage instead of error (papercut from DVAA 0.9.0 release-test)", () => {
+    const input = makeInput();
+    const out = runTelemetryCommand("--help", input);
+    expect(out).not.toContain("Unknown action");
+    expect(out).toContain("dvaa telemetry [on|off|status]");
+    expect(out).toContain("Inspect or toggle");
+    expect(out).toContain("Actions:");
+    expect(out).toContain("on        Enable telemetry");
+    expect(out).toContain("off       Disable telemetry");
+    expect(out).toContain("status    Show current state");
+    expect(out).toContain("OPENA2A_TELEMETRY=off dvaa");
+    expect(input.setOptOut).not.toHaveBeenCalled();
+  });
+
+  it("'-h' is an alias for '--help'", () => {
+    const inputA = makeInput();
+    const inputB = makeInput();
+    const a = runTelemetryCommand("--help", inputA);
+    const b = runTelemetryCommand("-h", inputB);
+    expect(a).toBe(b);
+    expect(inputA.setOptOut).not.toHaveBeenCalled();
+    expect(inputB.setOptOut).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli-ui/src/telemetry-command.ts
+++ b/packages/cli-ui/src/telemetry-command.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import type { TelemetryStatusLike } from "./version-line.js";
 
-export type TelemetryAction = "on" | "off" | "status" | undefined;
+export type TelemetryAction = "on" | "off" | "status" | "--help" | "-h" | undefined;
 
 export interface TelemetryCommandInput {
   /** Tool name — only used in the printed output. */
@@ -37,11 +37,36 @@ export function runTelemetryCommand(
     case "status":
     case undefined:
       return renderStatus("current", input);
+    case "--help":
+    case "-h":
+      return renderHelp(input);
     default:
       return chalk.red(
         `Unknown action '${action}'. Try '${input.tool} telemetry [on|off|status]'.`,
       );
   }
+}
+
+function renderHelp(input: TelemetryCommandInput): string {
+  const tool = input.tool;
+  return [
+    chalk.bold(`${tool} telemetry [on|off|status]`),
+    "",
+    `Inspect or toggle the persisted anonymous-telemetry opt-out for ${tool}.`,
+    "Default action (no args) is 'status'.",
+    "",
+    chalk.bold("Actions:"),
+    `  on        Enable telemetry persistently for ${tool}.`,
+    `  off       Disable telemetry persistently for ${tool}.`,
+    `  status    Show current state, install_id, config file, and policy URL.`,
+    `  --help    Show this message.`,
+    "",
+    chalk.bold("Per-invocation override (does not persist):"),
+    `  OPENA2A_TELEMETRY=off ${tool} <cmd>`,
+    "",
+    chalk.bold("Debug:"),
+    `  OPENA2A_TELEMETRY_DEBUG=print ${tool} <cmd>    Print payloads to stderr.`,
+  ].join("\n");
 }
 
 function renderStatus(
@@ -64,9 +89,14 @@ function renderStatus(
     `  policy:      ${chalk.cyan(status.policyURL)}`,
   ];
   if (framing === "current") {
+    // Suggest the OPPOSITE of the current state — telling someone whose
+    // telemetry is already off how to "turn it off" is useless. The
+    // env-var hint mirrors the same flip.
+    const nextAction = status.enabled ? "off" : "on";
+    const envOverride = status.enabled ? "OPENA2A_TELEMETRY=off" : "OPENA2A_TELEMETRY=on";
     lines.push(
       "",
-      chalk.dim(`  toggle: '${input.tool} telemetry off'  or  OPENA2A_TELEMETRY=off`),
+      chalk.dim(`  toggle: '${input.tool} telemetry ${nextAction}'  or  ${envOverride}`),
     );
   }
   return lines.join("\n");


### PR DESCRIPTION
## Summary

Two UX papercuts caught by DVAA 0.9.0's release-test, both inside `runTelemetryCommand`. Fix at root so all CLI consumers (dvaa, hackmyagent, ai-trust, opena2a-cli) benefit.

### 1. \`<tool> telemetry --help\` was printing an error
Previously fell into the \`Unknown action\` default branch and printed:
\`\`\`
Unknown action '--help'. Try 'dvaa telemetry [on|off|status]'.
\`\`\`
Now: explicit \`--help\` / \`-h\` cases print a proper usage block listing the actions, the \`OPENA2A_TELEMETRY=...\` per-invocation override, and the \`OPENA2A_TELEMETRY_DEBUG=print\` debug knob.

### 2. \`<tool> telemetry status\` always hinted "off"
The toggle hint was hardcoded to \`toggle: '<tool> telemetry off' or OPENA2A_TELEMETRY=off\` regardless of current state. Telling someone whose telemetry is already off how to turn it off is useless. The hint now flips based on \`status.enabled\`:

| Current state | Hint |
|---|---|
| on | \`toggle: '<tool> telemetry off' or OPENA2A_TELEMETRY=off\` |
| off | \`toggle: '<tool> telemetry on' or OPENA2A_TELEMETRY=on\` |

## Why fix at root

Memory \`[[feedback_cli_ui_consumers_exact_pinned]]\` and CLAUDE.md \`Exact version pins (not caret) across the CLI consolidation\` — every consumer pins \`@opena2a/cli-ui\` exactly. Fixing at root means one library patch, one publish, and each consumer bumps their pin via a focused PR or Renovate.

## Tests

- 9 in \`telemetry-command.test.ts\` (was 5; +4 covering both fixes including \`-h\` alias)
- All 235 cli-ui tests pass (\`npm test\` in \`packages/cli-ui\`)
- Typecheck clean

## Consumer plan

- DVAA pin bump to 0.5.1 ships in damn-vulnerable-ai-agent v0.9.1 immediately after this PR merges (drains the 0.9.0 known-issues block).
- hackmyagent, ai-trust, opena2a-cli get bumped via Renovate or focused PRs in their respective release windows.

## Test plan

- [x] \`npm test\` in packages/cli-ui → 235 pass
- [x] \`npm run typecheck\` clean
- [x] Pre-push gate PASS

Tagged as \`cli-ui-v0.5.1\` after merge (per the per-package tag convention in this monorepo).