### PR TITLE
ci(parity): bump SHA to pick up check-registered-ai-pypi fixture (opena2a-parity#10)

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -21,7 +21,7 @@ jobs:
   parity:
     # opena2a-parity moved from opena2a-org to opena2a-standards on 2026-05-24.
     # Pinned to the current main SHA; bumps require an explicit, reviewable PR.
-    uses: opena2a-standards/opena2a-parity/.github/workflows/parity.yml@0c2a98f0fd4572652ba3955caf6b4b6536e24260
+    uses: opena2a-standards/opena2a-parity/.github/workflows/parity.yml@1d7b792a65985e0f9449f3895d1a86e22b218e9c
     with:
       hma_ref: main
       opena2a_ref: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Bumps the opena2a-parity workflow SHA to `1d7b792` ([opena2a-standards/opena2a-parity#10](https://github.com/opena2a-standards/opena2a-parity/pull/10)).

Adds the `check-registered-ai-pypi` 2-way fixture (hma + ai-trust + opena2a.skip). opena2a is currently skipped via sentinel until `opena2a-cli 0.10.4` publishes (it pins `hackmyagent: 0.23.4` per [#169](https://github.com/opena2a-org/opena2a/pull/169) which just landed). A follow-up fixture-extension PR on opena2a-parity will replace the skip sentinel with a real opena2a golden once 0.10.4 ships.