### PR TITLE
chore: opena2a-cli pin to @opena2a/cli-ui 0.5.1 + Node 24 actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,13 @@ permissions:
   contents: write
   id-token: write
 
+# Opt the v4-line JavaScript actions (checkout, setup-node, action-gh-release)
+# into Node 24 today. They run on Node 20 by default and emit a deprecation
+# warning on every release; the runner forces Node 24 on 2026-06-02. Setting
+# this env now silences the warning AND avoids surprise breakage in June.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -2483,6 +2483,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/hackmyagent/node_modules/@opena2a/cli-ui": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.5.0.tgz",
+      "integrity": "sha512-c90/pOe/JiFe6WZnn9a8HVqOoaZ4cguI7Dkslh88FZM3Pqx8wP/9eaeoHFTKs/PrV9RYLj4GBC2OJ8srj7R7+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0"
+      }
+    },
     "node_modules/hackmyagent/node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -3930,7 +3939,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
-        "@opena2a/cli-ui": "0.5.0",
+        "@opena2a/cli-ui": "0.5.1",
         "@opena2a/contribute": "0.1.0",
         "@opena2a/registry-client": "0.1.0",
         "@opena2a/shared": "0.1.0",
@@ -3979,15 +3988,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "packages/cli/node_modules/@opena2a/cli-ui": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.5.0.tgz",
-      "integrity": "sha512-c90/pOe/JiFe6WZnn9a8HVqOoaZ4cguI7Dkslh88FZM3Pqx8wP/9eaeoHFTKs/PrV9RYLj4GBC2OJ8srj7R7+g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "chalk": "^5.3.0"
       }
     },
     "packages/cli/node_modules/@opena2a/contribute": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^7.0.0",
-    "@opena2a/cli-ui": "0.5.0",
+    "@opena2a/cli-ui": "0.5.1",
     "@opena2a/contribute": "0.1.0",
     "@opena2a/registry-client": "0.1.0",
     "@opena2a/shared": "0.1.0",


### PR DESCRIPTION
## Summary

Two unrelated maintenance bumps batched into one PR (both zero-behavior, workflow + lockfile only).

### 1. Bump opena2a-cli's @opena2a/cli-ui pin 0.5.0 → 0.5.1

cli-ui 0.5.1 fixes two telemetry-command papercuts (caught by DVAA 0.9.0's release-test, fixed at root in #170):

- \`opena2a telemetry --help\` now prints proper usage instead of \`Unknown action '--help'\`.
- \`opena2a telemetry status\` toggle hint now flips based on state instead of always suggesting \`off\`.

No opena2a-cli API depends on the patch diff; 1066 vitest tests still pass after the bump.

### 2. Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true to release.yml

\`actions/checkout@v4\`, \`actions/setup-node@v4\`, and \`softprops/action-gh-release@v2\` are JavaScript actions that run on Node 20 by default. GitHub forces them to Node 24 on **2026-06-02**; until then they emit a deprecation warning on every release. Setting the env at workflow level silences the warning today AND avoids any small risk on June 2nd.

No behavior change to the publish-step — \`setup-node\` already installs \`node-version: 24\` for the release itself; this is purely about the actions' internal Node runtime.

## Companion PRs

Same Node 24 fix in damn-vulnerable-ai-agent (#50), hackmyagent, ai-trust. Same cli-ui 0.5.1 bump in hackmyagent + ai-trust (in flight).

## Test plan

- [x] \`npm test\` in packages/cli → 1066 pass
- [x] \`npm run typecheck\` → clean
- [x] YAML parses cleanly
- [ ] On next opena2a-cli or cli-ui tag-push, deprecation warning gone from workflow log