### PR TITLE
ci(parity): bump SHA to pick up check-registered-ai-pypi 3-way (opena2a-parity#11)

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -21,7 +21,7 @@ jobs:
   parity:
     # opena2a-parity moved from opena2a-org to opena2a-standards on 2026-05-24.
     # Pinned to the current main SHA; bumps require an explicit, reviewable PR.
-    uses: opena2a-standards/opena2a-parity/.github/workflows/parity.yml@1d7b792a65985e0f9449f3895d1a86e22b218e9c
+    uses: opena2a-standards/opena2a-parity/.github/workflows/parity.yml@5684cc3b0abfbf6eb1f1d66b637b095647f91830
     with:
       hma_ref: main
       opena2a_ref: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
## Summary
Bump the parity-gate reusable-workflow SHA pin to pick up [opena2a-standards/opena2a-parity#11](https://github.com/opena2a-standards/opena2a-parity/pull/11) — `check-registered-ai-pypi` expanded 2-way → 3-way (added `opena2a` as a participant).

## Why
opena2a-cli `0.10.4` published 2026-05-28 bundles `hackmyagent 0.23.4` which:
- Honors `--no-scan` on `pip:` / `pypi:` targets ([hackmyagent#197](https://github.com/opena2a-org/hackmyagent/pull/197), 0.23.2).
- Queries the Registry with the bare PyPI name ([hackmyagent#198](https://github.com/opena2a-org/hackmyagent/pull/198), 0.23.3).

That unblocked the opena2a participant on this fixture. opena2a `check pip:anthropic --no-scan --json` now emits byte-identical Registry JSON to standalone `hackmyagent check`.

## SHA pin
- New: `5684cc3b0abfbf6eb1f1d66b637b095647f91830`
- Prior: `1d7b792a65985e0f9449f3895d1a86e22b218e9c`

## Test plan
- [x] Local 3-way harness pass (`6 fixture(s) run, 0 fixture failure(s)`).
- [x] Companion PRs land in lockstep across hackmyagent, ai-trust, opena2a.