### PR TITLE
feat(protect): add AAP --grant gate (first opena2a-cli AAP consumer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `protect --grant <grant-ref> --atx <path>`: opt-in Agent Authorization Protocol gate. Before any scan, `protect` presents an ATX to the local Secretless broker and proceeds only if the broker authorizes the grant. Hard-fails 3 with an actionable next step on a 403 opaque denial (AAP §6.6); 4 with a `secretless broker start` hint if the broker socket is unreachable. New `packages/cli/src/aap/` module (broker client) is the first TypeScript AAP consumer. Defends T-3002, T-3003, T-3006, T-8002 at the CLI surface.
 - `create skill [name]` command: secure skill scaffolding with 3 templates (basic, mcp-tool, data-processor), auto-signing via ConfigGuard, HEARTBEAT.md generation, vitest test file, and GitHub Action template
 - `guard harden` subcommand: scan SKILL.md and HEARTBEAT.md files for security issues using HackMyAgent HardeningScanner, with `--fix` (auto-fix) and `--dry-run` (preview) flags
 - Docker adapter configurable port mapping for `train` command (full DVAA port range)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- `protect --grant <grant-ref> --atx <path>`: opt-in Agent Authorization Protocol gate. Before any scan, `protect` presents an ATX to the local Secretless broker and proceeds only if the broker authorizes the grant. Hard-fails 3 with an actionable next step on a 403 opaque denial (AAP §6.6); 4 with a `secretless broker start` hint if the broker socket is unreachable. New `packages/cli/src/aap/` module (broker client) is the first TypeScript AAP consumer. Defends T-3002, T-3003, T-3006, T-8002 at the CLI surface.
+- `protect --grant <grant-ref> --atx <path>`: opt-in Agent Authorization Protocol gate. Before any scan, `protect` presents an ATX to the local Secretless broker and proceeds only if the broker authorizes the grant. New `packages/cli/src/aap/` module (broker client) is the first TypeScript AAP consumer. Defends T-3002, T-3003, T-3006, T-8002 at the CLI surface.
+  - Exit codes: 0 (broker authorized), 2 (--grant without --atx or invalid ATX), 3 (403 opaque denial, AAP §6.6), 4 (broker socket unreachable), 5 (unexpected error), 6 (broker returned non-403 non-200 status — body never echoed to user).
+  - Hardening: default-socket-path connections require socket-uid == process-uid (defense against same-box impostor brokers); ATX file capped at 256 KiB; response body capped at 1 MiB; ANSI/C0 control chars in user-supplied grant references are stripped before stderr output.
 - `create skill [name]` command: secure skill scaffolding with 3 templates (basic, mcp-tool, data-processor), auto-signing via ConfigGuard, HEARTBEAT.md generation, vitest test file, and GitHub Action template
 - `guard harden` subcommand: scan SKILL.md and HEARTBEAT.md files for security issues using HackMyAgent HardeningScanner, with `--fix` (auto-fix) and `--dry-run` (preview) flags
 - Docker adapter configurable port mapping for `train` command (full DVAA port range)

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Outcomes:
 - **Broker authorizes** -> protect proceeds.
 - **Broker denies (HTTP 403)** -> protect exits 3 with a one-line pointer to `~/.secretless-ai/policies/`. Per AAP §6.6 the denial is opaque; reasons live only in the broker's signed audit log.
 - **Broker unreachable** -> protect exits 4 with a `secretless broker start` hint.
+- **Broker returns an unexpected status** -> protect exits 6. The response body is never echoed to the user; reasons live only in the broker audit log.
 - **No `--grant` flag** -> protect runs exactly as before; the gate is opt-in.
 
 This integration newly defends **T-3002** (cross-tenant grant leakage), **T-3003** (over-broad credential scope), **T-3006** (credential leaking into agent context), and **T-8002** (audit attribution gap) at the CLI surface. The broker is the integrity-protected decision and audit point; the CLI carries no policy state.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,25 @@ Three job categories: assess, protect, operate. Run any with `--help` for full f
 | `opena2a guard sign` | Sign and watch config files (`mcp.json`, `claude_desktop_config.json`, etc.). Alerts on unauthorized changes. |
 | `opena2a shield init` | One-shot 11-step setup: review, protect, identity, guard, secrets, runtime, policy, hooks. |
 
+#### Optional AAP gate on `protect`
+
+`protect` can be gated by the [Agent Authorization Protocol](https://github.com/opena2a-standards/agent-authorization-protocol). When `--grant` is set, the CLI presents an ATX and a grant reference to the local Secretless broker before any scan runs. The broker is the policy decision point; the CLI proceeds only if the broker authorizes.
+
+```bash
+opena2a protect \
+  --grant grant://opena2a-protect \
+  --atx ~/.opena2a/atx.json
+```
+
+Outcomes:
+
+- **Broker authorizes** -> protect proceeds.
+- **Broker denies (HTTP 403)** -> protect exits 3 with a one-line pointer to `~/.secretless-ai/policies/`. Per AAP §6.6 the denial is opaque; reasons live only in the broker's signed audit log.
+- **Broker unreachable** -> protect exits 4 with a `secretless broker start` hint.
+- **No `--grant` flag** -> protect runs exactly as before; the gate is opt-in.
+
+This integration newly defends **T-3002** (cross-tenant grant leakage), **T-3003** (over-broad credential scope), **T-3006** (credential leaking into agent context), and **T-8002** (audit attribution gap) at the CLI surface. The broker is the integrity-protected decision and audit point; the CLI carries no policy state.
+
 ### Operate
 
 | Command | What it does |

--- a/packages/cli/__tests__/aap/client.test.ts
+++ b/packages/cli/__tests__/aap/client.test.ts
@@ -7,6 +7,7 @@ import * as path from 'node:path';
 import {
   BrokerClient,
   BrokerGrantError,
+  BrokerUnexpectedStatusError,
   GrantDeniedError,
 } from '../../src/aap/client.js';
 
@@ -170,6 +171,66 @@ describe('BrokerClient', () => {
         operation: { method: 'POST', path: '/scan' },
       }),
     ).rejects.toThrow(/rotate broker.token/);
+  });
+
+  it('throws BrokerUnexpectedStatusError on 5xx WITHOUT echoing the broker body (AAP §6.6)', async () => {
+    // A misbehaving / impostor broker leaks cross-tenant detail in the 500 body.
+    broker.next = { status: 500, body: { error: 'db: cross-tenant lookup for tenantA failed', secret_host: 'api.internal.example' } };
+    const client = new BrokerClient({
+      socketPath: broker.socketPath,
+      tokenPath: broker.tokenPath,
+    });
+
+    try {
+      await client.grant({
+        agentId: 'a',
+        atx: {},
+        grant: 'grant://opena2a-protect',
+        operation: { method: 'POST', path: '/scan' },
+      });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(BrokerUnexpectedStatusError);
+      const unexpected = err as BrokerUnexpectedStatusError;
+      expect(unexpected.status).toBe(500);
+      // The body MUST NOT be in the error message — AAP §6.6.
+      expect(unexpected.message).not.toContain('cross-tenant');
+      expect(unexpected.message).not.toContain('tenantA');
+      expect(unexpected.message).not.toContain('api.internal.example');
+    }
+  });
+
+  it('caps the response body at 1MiB instead of unbounded buffering', async () => {
+    // The broker is trusted, but an impostor could try to OOM the CLI with a 5GB body.
+    // Force-stream a >1MiB stub and assert the client doesn't accept it as a success.
+    broker.server.removeAllListeners('request');
+    broker.server.on('request', (req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        // 1.5 MiB of junk inside a fake JSON envelope.
+        const junk = Buffer.alloc(1.5 * 1024 * 1024, 0x41);
+        res.write(Buffer.from('{"result":"', 'utf-8'));
+        res.write(junk);
+        res.write(Buffer.from('"}', 'utf-8'));
+        res.end();
+      });
+    });
+
+    const client = new BrokerClient({
+      socketPath: broker.socketPath,
+      tokenPath: broker.tokenPath,
+    });
+
+    await expect(
+      client.grant({
+        agentId: 'a',
+        atx: {},
+        grant: 'grant://opena2a-protect',
+        operation: { method: 'POST', path: '/scan' },
+      }),
+    ).rejects.toBeInstanceOf(BrokerGrantError);
   });
 
   it('throws BrokerGrantError when the broker socket is unreachable', async () => {

--- a/packages/cli/__tests__/aap/client.test.ts
+++ b/packages/cli/__tests__/aap/client.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as http from 'node:http';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  BrokerClient,
+  BrokerGrantError,
+  GrantDeniedError,
+} from '../../src/aap/client.js';
+
+/**
+ * The tests stand up a minimal HTTP-over-Unix-socket server that imitates the
+ * Secretless broker's POST /grant contract (the real broker source is in the
+ * `secretless` repo; the wire format is the integration surface, not the
+ * implementation). This validates that the TS client speaks AAP §6 correctly
+ * and routes denials and transport errors to the right typed errors.
+ */
+
+interface FakeBroker {
+  socketPath: string;
+  tokenPath: string;
+  token: string;
+  server: http.Server;
+  /** Set by the test before each call to configure the next response. */
+  next: { status: number; body: unknown };
+  /** Recorded by the server for assertions. */
+  last?: { method: string; url: string; auth: string | undefined; body: string };
+  close(): Promise<void>;
+}
+
+async function startFakeBroker(): Promise<FakeBroker> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aap-client-'));
+  const socketPath = path.join(tmpDir, 'broker.sock');
+  const tokenPath = path.join(tmpDir, 'broker.token');
+  const token = 'test-broker-token-' + Math.random().toString(36).slice(2);
+  fs.writeFileSync(tokenPath, token, { mode: 0o600 });
+
+  const broker: FakeBroker = {
+    socketPath,
+    tokenPath,
+    token,
+    server: undefined as unknown as http.Server,
+    next: { status: 200, body: { result: { ok: true } } },
+    last: undefined,
+    async close() {
+      await new Promise<void>((resolve) => broker.server.close(() => resolve()));
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    },
+  };
+
+  broker.server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      broker.last = {
+        method: req.method ?? '',
+        url: req.url ?? '',
+        auth: req.headers.authorization,
+        body: Buffer.concat(chunks).toString('utf-8'),
+      };
+      const body = JSON.stringify(broker.next.body);
+      res.writeHead(broker.next.status, {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+      });
+      res.end(body);
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    broker.server.once('error', reject);
+    broker.server.listen(socketPath, () => resolve());
+  });
+
+  return broker;
+}
+
+describe('BrokerClient', () => {
+  let broker: FakeBroker;
+
+  beforeEach(async () => {
+    broker = await startFakeBroker();
+  });
+
+  afterEach(async () => {
+    await broker.close();
+  });
+
+  it('sends a well-formed POST /grant body and returns the result', async () => {
+    broker.next = { status: 200, body: { result: { status: 200, body: { rows: 3 } } } };
+    const client = new BrokerClient({
+      socketPath: broker.socketPath,
+      tokenPath: broker.tokenPath,
+    });
+
+    const result = await client.grant({
+      agentId: 'opena2a_protect_cli',
+      atx: { atcVersion: '1.0', agentId: 'opena2a_protect_cli', signatures: [] },
+      grant: 'grant://opena2a-protect',
+      operation: { method: 'POST', path: '/scan', query: { target: 'fixture' } },
+    });
+
+    expect(result).toEqual({ status: 200, body: { rows: 3 } });
+    expect(broker.last?.method).toBe('POST');
+    expect(broker.last?.url).toBe('/grant');
+    expect(broker.last?.auth).toBe(`Bearer ${broker.token}`);
+    const sent = JSON.parse(broker.last!.body);
+    expect(sent).toMatchObject({
+      agentId: 'opena2a_protect_cli',
+      grant: 'grant://opena2a-protect',
+      operation: { method: 'POST', path: '/scan' },
+    });
+    expect(sent.operation.query.target).toBe('fixture');
+  });
+
+  it('throws GrantDeniedError on 403 (uniform opaque denial per AAP §6.6)', async () => {
+    broker.next = { status: 403, body: { error: 'denied' } };
+    const client = new BrokerClient({
+      socketPath: broker.socketPath,
+      tokenPath: broker.tokenPath,
+    });
+
+    await expect(
+      client.grant({
+        agentId: 'a',
+        atx: {},
+        grant: 'grant://opena2a-protect',
+        operation: { method: 'POST', path: '/scan' },
+      }),
+    ).rejects.toBeInstanceOf(GrantDeniedError);
+  });
+
+  it('GrantDeniedError carries the grant reference but no broker-side detail', async () => {
+    broker.next = { status: 403, body: { error: 'denied', secret: 'should-not-be-read' } };
+    const client = new BrokerClient({
+      socketPath: broker.socketPath,
+      tokenPath: broker.tokenPath,
+    });
+
+    try {
+      await client.grant({
+        agentId: 'a',
+        atx: {},
+        grant: 'grant://opena2a-protect',
+        operation: { method: 'POST', path: '/scan' },
+      });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(GrantDeniedError);
+      const denied = err as GrantDeniedError;
+      expect(denied.grant).toBe('grant://opena2a-protect');
+      expect(denied.message).not.toContain('should-not-be-read');
+    }
+  });
+
+  it('throws BrokerGrantError on 401 (token rotation hint)', async () => {
+    broker.next = { status: 401, body: { error: 'Unauthorized' } };
+    const client = new BrokerClient({
+      socketPath: broker.socketPath,
+      tokenPath: broker.tokenPath,
+    });
+
+    await expect(
+      client.grant({
+        agentId: 'a',
+        atx: {},
+        grant: 'grant://opena2a-protect',
+        operation: { method: 'POST', path: '/scan' },
+      }),
+    ).rejects.toThrow(/rotate broker.token/);
+  });
+
+  it('throws BrokerGrantError when the broker socket is unreachable', async () => {
+    const client = new BrokerClient({
+      socketPath: path.join(os.tmpdir(), 'definitely-does-not-exist.sock'),
+      token: 'irrelevant',
+    });
+
+    await expect(
+      client.grant({
+        agentId: 'a',
+        atx: {},
+        grant: 'grant://opena2a-protect',
+        operation: { method: 'POST', path: '/scan' },
+      }),
+    ).rejects.toBeInstanceOf(BrokerGrantError);
+  });
+
+  it('throws BrokerGrantError when the token file is missing', async () => {
+    const client = new BrokerClient({
+      socketPath: broker.socketPath,
+      tokenPath: path.join(os.tmpdir(), 'absent.token'),
+    });
+
+    await expect(
+      client.grant({
+        agentId: 'a',
+        atx: {},
+        grant: 'grant://opena2a-protect',
+        operation: { method: 'POST', path: '/scan' },
+      }),
+    ).rejects.toThrow(/broker token not found/);
+  });
+
+  it('prefers an explicit token over the token file', async () => {
+    broker.next = { status: 200, body: { result: 'ok' } };
+    const client = new BrokerClient({
+      socketPath: broker.socketPath,
+      token: 'explicit-token',
+      tokenPath: path.join(os.tmpdir(), 'absent.token'),
+    });
+
+    const result = await client.grant({
+      agentId: 'a',
+      atx: {},
+      grant: 'grant://opena2a-protect',
+      operation: { method: 'POST', path: '/scan' },
+    });
+    expect(result).toBe('ok');
+    expect(broker.last?.auth).toBe('Bearer explicit-token');
+  });
+});

--- a/packages/cli/__tests__/aap/protect-grant-integration.test.ts
+++ b/packages/cli/__tests__/aap/protect-grant-integration.test.ts
@@ -1,0 +1,249 @@
+/**
+ * End-to-end integration test for `opena2a protect --grant`.
+ *
+ * The Secretless broker is the policy decision point for this command. The
+ * implementation lives in another repo (opena2a-org/secretless), so this test
+ * stands up a minimal fake broker that speaks AAP §6 over a Unix socket and
+ * proves the CLI:
+ *   1. Refuses to run --grant without --atx.
+ *   2. Proceeds when the broker authorizes (200).
+ *   3. Hard-fails 3 with an actionable message on uniform opaque denial (403).
+ *   4. Hard-fails 4 when the broker socket is unreachable.
+ *
+ * The broker test suite in secretless/src/broker/aap-conformance.test.ts runs
+ * the *real* broker; this test gates the wrapper. Both must pass before a
+ * release.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as http from 'node:http';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { protect } from '../../src/commands/protect.js';
+
+interface FakeBroker {
+  socketPath: string;
+  tokenPath: string;
+  token: string;
+  server: http.Server;
+  next: { status: number; body: unknown };
+  calls: number;
+  lastBody?: string;
+  close(): Promise<void>;
+}
+
+async function startFakeBroker(tmpDir: string): Promise<FakeBroker> {
+  const socketPath = path.join(tmpDir, 'broker.sock');
+  const tokenPath = path.join(tmpDir, 'broker.token');
+  const token = 'protect-integ-' + Math.random().toString(36).slice(2);
+  fs.writeFileSync(tokenPath, token, { mode: 0o600 });
+
+  const broker: FakeBroker = {
+    socketPath,
+    tokenPath,
+    token,
+    server: undefined as unknown as http.Server,
+    next: { status: 200, body: { result: { status: 200, body: { authorized: true } } } },
+    calls: 0,
+    async close() {
+      await new Promise<void>((resolve) => broker.server.close(() => resolve()));
+    },
+  };
+
+  broker.server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      broker.calls += 1;
+      broker.lastBody = Buffer.concat(chunks).toString('utf-8');
+      const body = JSON.stringify(broker.next.body);
+      res.writeHead(broker.next.status, {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+      });
+      res.end(body);
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    broker.server.once('error', reject);
+    broker.server.listen(socketPath, () => resolve());
+  });
+
+  return broker;
+}
+
+function writeAtxFixture(dir: string): string {
+  const atxPath = path.join(dir, 'atx.json');
+  fs.writeFileSync(
+    atxPath,
+    JSON.stringify({
+      atcVersion: '1.0',
+      agentId: 'opena2a_protect_cli',
+      agentDid: 'did:opena2a:agent:opena2a-org/opena2a-cli',
+      version: '0.10.5',
+      contentHash: 'sha256:test',
+      issuerDid: 'did:opena2a:authority:opena2a.org',
+      trustLevel: 4,
+      trustScore: 0.95,
+      issuedAt: '2026-05-25T00:00:00Z',
+      expiresAt: '2026-06-08T00:00:00Z',
+      capabilities: ['protect:scan'],
+      signatures: [],
+    }),
+  );
+  return atxPath;
+}
+
+describe('opena2a protect --grant', () => {
+  let tmpDir: string;
+  let scanDir: string;
+  let broker: FakeBroker;
+  let stderr: string;
+  let stdout: string;
+  const origStderrWrite = process.stderr.write.bind(process.stderr);
+  const origStdoutWrite = process.stdout.write.bind(process.stdout);
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aap-protect-'));
+    scanDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aap-scandir-'));
+    broker = await startFakeBroker(tmpDir);
+    stderr = '';
+    stdout = '';
+    // Suppress + capture protect's chatter so test logs stay legible.
+    (process.stderr.write as any) = (chunk: any) => {
+      stderr += typeof chunk === 'string' ? chunk : String(chunk);
+      return true;
+    };
+    (process.stdout.write as any) = (chunk: any) => {
+      stdout += typeof chunk === 'string' ? chunk : String(chunk);
+      return true;
+    };
+  });
+
+  afterEach(async () => {
+    (process.stderr.write as any) = origStderrWrite;
+    (process.stdout.write as any) = origStdoutWrite;
+    await broker.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(scanDir, { recursive: true, force: true });
+  });
+
+  it('refuses --grant without --atx (exit code 2)', async () => {
+    const exitCode = await protect({
+      targetDir: scanDir,
+      grant: 'grant://opena2a-protect',
+      ci: true,
+      skipVerify: true,
+      skipSign: true,
+      skipGit: true,
+    });
+    expect(exitCode).toBe(2);
+    expect(broker.calls).toBe(0); // Broker never contacted
+    expect(stderr).toMatch(/--grant requires --atx/);
+  });
+
+  it('proceeds with the scan when the broker returns 200', async () => {
+    broker.next = { status: 200, body: { result: { status: 200, body: { authorized: true } } } };
+    const atxPath = writeAtxFixture(tmpDir);
+
+    const exitCode = await protect({
+      targetDir: scanDir,
+      grant: 'grant://opena2a-protect',
+      atxPath,
+      brokerSocket: broker.socketPath,
+      brokerTokenPath: broker.tokenPath,
+      ci: true,
+      skipVerify: true,
+      skipSign: true,
+      skipGit: true,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(broker.calls).toBe(1);
+    // The body the broker received is well-formed and references our grant + ATX.
+    const sent = JSON.parse(broker.lastBody!);
+    expect(sent.agentId).toBe('opena2a_protect_cli');
+    expect(sent.grant).toBe('grant://opena2a-protect');
+    expect(sent.atx.agentId).toBe('opena2a_protect_cli');
+    expect(sent.operation.method).toBe('POST');
+    expect(sent.operation.path).toBe('/protect/scan');
+  });
+
+  it('hard-fails 3 with an actionable message on 403 (AAP §6.6 opaque denial)', async () => {
+    broker.next = { status: 403, body: { error: 'denied' } };
+    const atxPath = writeAtxFixture(tmpDir);
+
+    const exitCode = await protect({
+      targetDir: scanDir,
+      grant: 'grant://opena2a-protect',
+      atxPath,
+      brokerSocket: broker.socketPath,
+      brokerTokenPath: broker.tokenPath,
+      ci: true,
+      skipVerify: true,
+      skipSign: true,
+      skipGit: true,
+    });
+
+    expect(exitCode).toBe(3);
+    expect(broker.calls).toBe(1);
+    // User gets a concrete next step, not a stack trace.
+    expect(stderr).toMatch(/AAP broker denied/);
+    expect(stderr).toMatch(/Next step/);
+    expect(stderr).toMatch(/grant:\/\/opena2a-protect/);
+    expect(stderr).toMatch(/\.secretless-ai\/policies/);
+    // No internal broker detail leaked into the user message.
+    expect(stderr).not.toMatch(/policy.*reason|matched-rule|backend/i);
+  });
+
+  it('hard-fails 4 with a broker-start hint when the socket is unreachable', async () => {
+    // Stop the broker, then call protect with the dead socket path.
+    await broker.close();
+    const atxPath = writeAtxFixture(tmpDir);
+
+    const exitCode = await protect({
+      targetDir: scanDir,
+      grant: 'grant://opena2a-protect',
+      atxPath,
+      brokerSocket: broker.socketPath,
+      brokerTokenPath: broker.tokenPath,
+      ci: true,
+      skipVerify: true,
+      skipSign: true,
+      skipGit: true,
+    });
+
+    expect(exitCode).toBe(4);
+    expect(stderr).toMatch(/AAP broker unreachable/);
+    expect(stderr).toMatch(/secretless broker start/);
+  });
+
+  it('emits a JSON-shaped denial when --format json is set', async () => {
+    broker.next = { status: 403, body: { error: 'denied' } };
+    const atxPath = writeAtxFixture(tmpDir);
+
+    const exitCode = await protect({
+      targetDir: scanDir,
+      grant: 'grant://opena2a-protect',
+      atxPath,
+      brokerSocket: broker.socketPath,
+      brokerTokenPath: broker.tokenPath,
+      ci: true,
+      format: 'json',
+      skipVerify: true,
+      skipSign: true,
+      skipGit: true,
+    });
+
+    expect(exitCode).toBe(3);
+    // The JSON payload should be parseable and carry the grant + remediation.
+    const jsonLine = stdout.trim().split('\n').find((l) => l.startsWith('{'));
+    expect(jsonLine).toBeDefined();
+    const parsed = JSON.parse(jsonLine!);
+    expect(parsed.status).toBe('aap-denied');
+    expect(parsed.grant).toBe('grant://opena2a-protect');
+    expect(parsed.remediation).toMatch(/grant:\/\/opena2a-protect/);
+  });
+});

--- a/packages/cli/__tests__/aap/protect-grant-integration.test.ts
+++ b/packages/cli/__tests__/aap/protect-grant-integration.test.ts
@@ -246,4 +246,127 @@ describe('opena2a protect --grant', () => {
     expect(parsed.grant).toBe('grant://opena2a-protect');
     expect(parsed.remediation).toMatch(/grant:\/\/opena2a-protect/);
   });
+
+  it('denial does NOT proceed to scan: a credential-bearing fixture file is byte-identical after exit 3', async () => {
+    broker.next = { status: 403, body: { error: 'denied' } };
+    const atxPath = writeAtxFixture(tmpDir);
+
+    // Seed the scan directory with a fake credential. If the gate is load-bearing
+    // the scan never runs, the file is never rewritten, and the byte-identical
+    // check passes. If the gate is decorative, protect's migration would replace
+    // the hardcoded string with an env-var reference and this test fails.
+    const credFile = path.join(scanDir, 'config.py');
+    const credBefore = 'API_KEY = "sk-FAKE-WOULD-BE-REWRITTEN-IF-SCAN-RAN"\n';
+    fs.writeFileSync(credFile, credBefore);
+
+    const exitCode = await protect({
+      targetDir: scanDir,
+      grant: 'grant://opena2a-protect',
+      atxPath,
+      brokerSocket: broker.socketPath,
+      brokerTokenPath: broker.tokenPath,
+      ci: true,
+      skipVerify: true,
+      skipSign: true,
+      skipGit: true,
+    });
+    expect(exitCode).toBe(3);
+    expect(fs.readFileSync(credFile, 'utf-8')).toBe(credBefore);
+  });
+
+  it('500 response: returns exit 6 and does NOT echo the broker body to stderr (AAP §6.6)', async () => {
+    // A misbehaving or impostor broker tries to leak cross-tenant detail in a 500.
+    broker.next = {
+      status: 500,
+      body: { error: 'db: cross-tenant lookup for tenantA failed', secret_host: 'api.internal.example' },
+    };
+    const atxPath = writeAtxFixture(tmpDir);
+
+    const exitCode = await protect({
+      targetDir: scanDir,
+      grant: 'grant://opena2a-protect',
+      atxPath,
+      brokerSocket: broker.socketPath,
+      brokerTokenPath: broker.tokenPath,
+      ci: true,
+      skipVerify: true,
+      skipSign: true,
+      skipGit: true,
+    });
+
+    expect(exitCode).toBe(6);
+    // Status code is fine to surface; the body content is NOT.
+    expect(stderr).toMatch(/status 500/);
+    expect(stderr).not.toContain('cross-tenant');
+    expect(stderr).not.toContain('tenantA');
+    expect(stderr).not.toContain('api.internal.example');
+  });
+
+  it('rejects a structurally-invalid ATX before contacting the broker', async () => {
+    // null, primitive, missing fields, or wrong shape all reject locally.
+    const atxPath = path.join(tmpDir, 'bad-atx.json');
+    fs.writeFileSync(atxPath, JSON.stringify({ agentId: 'no-atc-version' }));
+
+    const exitCode = await protect({
+      targetDir: scanDir,
+      grant: 'grant://opena2a-protect',
+      atxPath,
+      brokerSocket: broker.socketPath,
+      brokerTokenPath: broker.tokenPath,
+      ci: true,
+      skipVerify: true,
+      skipSign: true,
+      skipGit: true,
+    });
+    expect(exitCode).toBe(2);
+    expect(broker.calls).toBe(0); // local rejection
+    expect(stderr).toMatch(/not a valid ATX/);
+  });
+
+  it('rejects an oversized ATX file (>256 KiB) before reading it into memory', async () => {
+    const atxPath = path.join(tmpDir, 'huge-atx.json');
+    fs.writeFileSync(atxPath, 'x'.repeat(300 * 1024));
+
+    const exitCode = await protect({
+      targetDir: scanDir,
+      grant: 'grant://opena2a-protect',
+      atxPath,
+      brokerSocket: broker.socketPath,
+      brokerTokenPath: broker.tokenPath,
+      ci: true,
+      skipVerify: true,
+      skipSign: true,
+      skipGit: true,
+    });
+    expect(exitCode).toBe(2);
+    expect(broker.calls).toBe(0);
+    expect(stderr).toMatch(/expected <= /);
+  });
+
+  it('sanitizes ANSI control characters in the grant reference for stderr output', async () => {
+    broker.next = { status: 403, body: { error: 'denied' } };
+    const atxPath = writeAtxFixture(tmpDir);
+    const evilGrant = 'grant://x\x1b[2J\x1b[H\x1b[31mFAKE FATAL\x1b[0m';
+
+    const exitCode = await protect({
+      targetDir: scanDir,
+      grant: evilGrant,
+      atxPath,
+      brokerSocket: broker.socketPath,
+      brokerTokenPath: broker.tokenPath,
+      ci: true,
+      skipVerify: true,
+      skipSign: true,
+      skipGit: true,
+    });
+
+    expect(exitCode).toBe(3);
+    // The ESC byte (0x1b) MUST NOT appear in user-visible stderr.
+    expect(stderr).not.toMatch(/\x1b\[2J/);
+    expect(stderr).not.toContain('\x1b[2J');
+    // The cyan() color codes the CLI itself adds are wrapped around a sanitized
+    // grant string, so the FAKE FATAL text is still printed but the C0 escapes
+    // that anchor the cursor-home + clear-screen attack are gone.
+    expect(stderr).toMatch(/AAP broker denied/);
+  });
 });

--- a/packages/cli/src/aap/client.ts
+++ b/packages/cli/src/aap/client.ts
@@ -1,0 +1,161 @@
+/**
+ * AAP grant client for opena2a-cli.
+ *
+ * Speaks the Agent Authorization Protocol wire format to a local Secretless broker
+ * over its Unix socket (HTTP over AF_UNIX). The agent presents an ATX, references a
+ * grant (grant://...), and asks the broker to authorize a logical operation. The
+ * broker returns ONLY the operation result; no credential or backend identifier
+ * crosses back into agent context (AAP §4).
+ *
+ * Shape mirrors `agent-identity-management/sdk/python/aim_sdk/grant_client.py` so
+ * the TS + Python surfaces stay aligned. AAP §6 defines the wire format. AAP §6.6
+ * defines uniform opaque denial: a 403 response carries `{error: "denied"}` and
+ * nothing else; this client raises `GrantDeniedError` with no detail.
+ */
+import * as http from 'node:http';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+export const DEFAULT_SOCKET_PATH = path.join(os.homedir(), '.secretless-ai', 'broker.sock');
+export const DEFAULT_TOKEN_PATH = path.join(os.homedir(), '.secretless-ai', 'broker.token');
+
+export class BrokerGrantError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'BrokerGrantError';
+  }
+}
+
+export class GrantDeniedError extends BrokerGrantError {
+  constructor(public readonly grant: string) {
+    super(`grant denied: ${grant}`);
+    this.name = 'GrantDeniedError';
+  }
+}
+
+export interface BrokerClientOptions {
+  socketPath?: string;
+  httpUrl?: string;
+  token?: string;
+  tokenPath?: string;
+  timeoutMs?: number;
+}
+
+export interface GrantOperation {
+  method: string;
+  path: string;
+  query?: Record<string, string>;
+  body?: unknown;
+}
+
+export interface GrantRequest {
+  agentId: string;
+  atx: Record<string, unknown>;
+  grant: string;
+  operation: GrantOperation;
+}
+
+export class BrokerClient {
+  readonly socketPath: string;
+  readonly httpUrl?: string;
+  readonly timeoutMs: number;
+  private readonly explicitToken?: string;
+  private readonly tokenPath: string;
+
+  constructor(options: BrokerClientOptions = {}) {
+    this.socketPath = options.socketPath ?? DEFAULT_SOCKET_PATH;
+    this.httpUrl = options.httpUrl;
+    this.timeoutMs = options.timeoutMs ?? 5000;
+    this.explicitToken = options.token;
+    this.tokenPath = options.tokenPath ?? DEFAULT_TOKEN_PATH;
+  }
+
+  private readToken(): string {
+    if (this.explicitToken) return this.explicitToken;
+    try {
+      return fs.readFileSync(this.tokenPath, 'utf-8').trim();
+    } catch (err) {
+      throw new BrokerGrantError(
+        `broker token not found at ${this.tokenPath}; is the broker running?`,
+        err,
+      );
+    }
+  }
+
+  async grant(req: GrantRequest): Promise<unknown> {
+    const body = JSON.stringify(req);
+    const token = this.readToken();
+    const headers: http.OutgoingHttpHeaders = {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(body),
+      Authorization: `Bearer ${token}`,
+    };
+
+    const { status, text } = await this.requestRaw('/grant', headers, body);
+
+    if (status === 200) {
+      let parsed: { result?: unknown };
+      try {
+        parsed = JSON.parse(text);
+      } catch (err) {
+        throw new BrokerGrantError('broker returned non-JSON success body', err);
+      }
+      return parsed.result;
+    }
+    if (status === 403) {
+      throw new GrantDeniedError(req.grant);
+    }
+    if (status === 401) {
+      throw new BrokerGrantError('broker rejected token (401); rotate broker.token');
+    }
+    throw new BrokerGrantError(`broker returned unexpected status ${status}: ${text}`);
+  }
+
+  private requestRaw(
+    urlPath: string,
+    headers: http.OutgoingHttpHeaders,
+    body: string,
+  ): Promise<{ status: number; text: string }> {
+    return new Promise((resolve, reject) => {
+      const requestOptions: http.RequestOptions = this.httpUrl
+        ? httpUrlToOptions(this.httpUrl, urlPath, headers)
+        : { socketPath: this.socketPath, path: urlPath, method: 'POST', headers };
+
+      const req = http.request(requestOptions, (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            text: Buffer.concat(chunks).toString('utf-8'),
+          });
+        });
+        res.on('error', (err) => reject(new BrokerGrantError(`broker response error: ${err.message}`, err)));
+      });
+
+      req.setTimeout(this.timeoutMs, () => {
+        req.destroy(new Error(`broker request timed out after ${this.timeoutMs}ms`));
+      });
+      req.on('error', (err) => reject(new BrokerGrantError(`could not reach broker: ${err.message}`, err)));
+      req.write(body);
+      req.end();
+    });
+  }
+}
+
+function httpUrlToOptions(
+  url: string,
+  urlPath: string,
+  headers: http.OutgoingHttpHeaders,
+): http.RequestOptions {
+  const parsed = new URL(url);
+  return {
+    protocol: parsed.protocol,
+    hostname: parsed.hostname,
+    port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+    path: urlPath,
+    method: 'POST',
+    headers,
+  };
+}

--- a/packages/cli/src/aap/client.ts
+++ b/packages/cli/src/aap/client.ts
@@ -20,6 +20,8 @@ import * as os from 'node:os';
 export const DEFAULT_SOCKET_PATH = path.join(os.homedir(), '.secretless-ai', 'broker.sock');
 export const DEFAULT_TOKEN_PATH = path.join(os.homedir(), '.secretless-ai', 'broker.token');
 
+const MAX_RESPONSE_BYTES = 1024 * 1024; // 1 MiB cap on broker response
+
 export class BrokerGrantError extends Error {
   constructor(message: string, public readonly cause?: unknown) {
     super(message);
@@ -31,6 +33,19 @@ export class GrantDeniedError extends BrokerGrantError {
   constructor(public readonly grant: string) {
     super(`grant denied: ${grant}`);
     this.name = 'GrantDeniedError';
+  }
+}
+
+/**
+ * A broker responded with an unexpected status (not 200/401/403). Carries the
+ * status code but NEVER the response body: AAP §6.6 says the consumer must not
+ * surface broker-side detail, and a misbehaving or impostor broker can return
+ * sensitive content (cross-tenant table names, queries, hosts) in a 5xx body.
+ */
+export class BrokerUnexpectedStatusError extends BrokerGrantError {
+  constructor(public readonly status: number) {
+    super(`broker returned unexpected status ${status}`);
+    this.name = 'BrokerUnexpectedStatusError';
   }
 }
 
@@ -109,7 +124,11 @@ export class BrokerClient {
     if (status === 401) {
       throw new BrokerGrantError('broker rejected token (401); rotate broker.token');
     }
-    throw new BrokerGrantError(`broker returned unexpected status ${status}: ${text}`);
+    // AAP §6.6: do NOT interpolate the broker response body into the error
+    // surface. A non-403 response can carry sensitive broker-side context
+    // (cross-tenant detail, host names, query strings) that the consumer must
+    // not echo. The status code alone is enough for the user to triage.
+    throw new BrokerUnexpectedStatusError(status);
   }
 
   private requestRaw(
@@ -124,8 +143,21 @@ export class BrokerClient {
 
       const req = http.request(requestOptions, (res) => {
         const chunks: Buffer[] = [];
-        res.on('data', (c: Buffer) => chunks.push(c));
+        let bytes = 0;
+        let oversized = false;
+        res.on('data', (c: Buffer) => {
+          bytes += c.length;
+          if (bytes > MAX_RESPONSE_BYTES) {
+            if (!oversized) {
+              oversized = true;
+              req.destroy(new Error('broker response exceeded 1MiB cap'));
+            }
+            return;
+          }
+          chunks.push(c);
+        });
         res.on('end', () => {
+          if (oversized) return; // req.destroy already rejected
           resolve({
             status: res.statusCode ?? 0,
             text: Buffer.concat(chunks).toString('utf-8'),

--- a/packages/cli/src/aap/index.ts
+++ b/packages/cli/src/aap/index.ts
@@ -1,0 +1,12 @@
+export {
+  BrokerClient,
+  BrokerGrantError,
+  GrantDeniedError,
+  DEFAULT_SOCKET_PATH,
+  DEFAULT_TOKEN_PATH,
+} from './client.js';
+export type {
+  BrokerClientOptions,
+  GrantOperation,
+  GrantRequest,
+} from './client.js';

--- a/packages/cli/src/aap/index.ts
+++ b/packages/cli/src/aap/index.ts
@@ -1,6 +1,7 @@
 export {
   BrokerClient,
   BrokerGrantError,
+  BrokerUnexpectedStatusError,
   GrantDeniedError,
   DEFAULT_SOCKET_PATH,
   DEFAULT_TOKEN_PATH,

--- a/packages/cli/src/commands/protect.ts
+++ b/packages/cli/src/commands/protect.ts
@@ -116,6 +116,20 @@ export interface ProtectOptions {
   skipSign?: boolean;
   /** Skip git hygiene fixes (.gitignore, .git/info/exclude) */
   skipGit?: boolean;
+  /**
+   * AAP grant reference (e.g. grant://opena2a-protect). When set, protect calls the
+   * local Secretless broker before any scan; the broker is the policy decision point
+   * and a 403 hard-fails this command. AAP §6.6 (uniform opaque denial).
+   */
+  grant?: string;
+  /** Path to a JSON file containing the agent's ATX. Required when `grant` is set. */
+  atxPath?: string;
+  /** Override the broker socket path (defaults to ~/.secretless-ai/broker.sock). */
+  brokerSocket?: string;
+  /** Override the broker token path (defaults to ~/.secretless-ai/broker.token). */
+  brokerTokenPath?: string;
+  /** Override the agent ID sent to the broker. Defaults to "opena2a_protect_cli". */
+  grantAgentId?: string;
 }
 
 // --- Credential patterns (shared module) ---
@@ -137,6 +151,7 @@ import { scanMcpCredentials, scanAiConfigFiles } from '../util/ai-config.js';
 import { scanCryptoKeyFiles } from '../util/crypto-key-files.js';
 import { calculateSecurityScore } from '../util/scoring.js';
 import { runScoringChecks } from '../util/hygiene.js';
+import { BrokerClient, GrantDeniedError, BrokerGrantError } from '../aap/index.js';
 
 // --- Core logic ---
 
@@ -150,6 +165,11 @@ export async function protect(options: ProtectOptions): Promise<number> {
   if (!fs.existsSync(targetDir)) {
     process.stderr.write(red(`Target directory not found: ${targetDir}\n`));
     return 1;
+  }
+
+  if (options.grant) {
+    const gateResult = await aapGate(options, targetDir);
+    if (gateResult !== 0) return gateResult;
   }
 
   if (options.dryRun) {
@@ -1407,4 +1427,77 @@ function findProjectRoot(startPath: string): string | null {
   }
 
   return null;
+}
+
+/**
+ * AAP gate. Calls the local Secretless broker before any scan. The broker is the
+ * policy decision point; protect proceeds only if the broker authorizes the
+ * `protect.scan` operation. AAP §6.6: a 403 is a uniform opaque denial and this
+ * command hard-fails with an actionable next step.
+ *
+ * Returns 0 on success (proceed with scan) or a non-zero exit code on failure.
+ */
+async function aapGate(options: ProtectOptions, targetDir: string): Promise<number> {
+  const grant = options.grant!;
+  const isJson = options.format === 'json';
+
+  if (!options.atxPath) {
+    process.stderr.write(red('--grant requires --atx <path-to-atx.json>\n'));
+    process.stderr.write(dim('  Issue an ATX from your AIM identity and pass its JSON file path.\n'));
+    return 2;
+  }
+
+  let atx: Record<string, unknown>;
+  try {
+    const raw = fs.readFileSync(options.atxPath, 'utf-8');
+    atx = JSON.parse(raw);
+  } catch (err) {
+    process.stderr.write(red(`Could not read ATX file at ${options.atxPath}: ${(err as Error).message}\n`));
+    return 2;
+  }
+
+  const client = new BrokerClient({
+    socketPath: options.brokerSocket,
+    tokenPath: options.brokerTokenPath,
+  });
+
+  try {
+    await client.grant({
+      agentId: options.grantAgentId ?? 'opena2a_protect_cli',
+      atx,
+      grant,
+      operation: { method: 'POST', path: '/protect/scan', query: { target: targetDir } },
+    });
+    if (!isJson && options.verbose) {
+      process.stdout.write(dim(`AAP broker authorized ${grant} for ${targetDir}\n`));
+    }
+    return 0;
+  } catch (err) {
+    if (err instanceof GrantDeniedError) {
+      if (isJson) {
+        process.stdout.write(JSON.stringify({
+          status: 'aap-denied',
+          grant,
+          targetDir,
+          remediation: `Verify your broker policy binds ${grant} to your agent's trust class.`,
+        }) + '\n');
+      } else {
+        process.stderr.write(red(`AAP broker denied ${grant}\n`));
+        process.stderr.write('\n');
+        process.stderr.write(`The Secretless broker is the policy decision point for this operation.\n`);
+        process.stderr.write(`The broker returned an opaque denial; reasons live only in the broker's signed audit log (AAP §6.6).\n`);
+        process.stderr.write('\n');
+        process.stderr.write(`${bold('Next step:')} review the broker's grant policy for ${cyan(grant)}.\n`);
+        process.stderr.write(`  Default policy dir:  ~/.secretless-ai/policies/\n`);
+        process.stderr.write(`  Audit log:           ~/.secretless-ai/broker.audit.log\n`);
+      }
+      return 3;
+    }
+    if (err instanceof BrokerGrantError) {
+      process.stderr.write(red(`AAP broker unreachable: ${err.message}\n`));
+      process.stderr.write(dim('  Start the broker:  secretless broker start\n'));
+      return 4;
+    }
+    throw err;
+  }
 }

--- a/packages/cli/src/commands/protect.ts
+++ b/packages/cli/src/commands/protect.ts
@@ -151,7 +151,31 @@ import { scanMcpCredentials, scanAiConfigFiles } from '../util/ai-config.js';
 import { scanCryptoKeyFiles } from '../util/crypto-key-files.js';
 import { calculateSecurityScore } from '../util/scoring.js';
 import { runScoringChecks } from '../util/hygiene.js';
-import { BrokerClient, GrantDeniedError, BrokerGrantError } from '../aap/index.js';
+import { BrokerClient, GrantDeniedError, BrokerGrantError, BrokerUnexpectedStatusError, DEFAULT_SOCKET_PATH } from '../aap/index.js';
+
+/**
+ * Strip ANSI / C0 control characters from a string before writing to stderr.
+ * The grant reference and broker-supplied error text are user-controlled and
+ * could otherwise inject terminal escape sequences (clear-screen, cursor-home,
+ * fake error text) into the user's session.
+ */
+function sanitizeForTty(s: string): string {
+  return s.replace(/[\x00-\x08\x0b-\x1f\x7f]/g, '?');
+}
+
+/**
+ * Defensive structural check on the user-supplied ATX before forwarding to the
+ * broker. The broker also validates, but the broker's 400 carries response
+ * text we don't want to surface (per AAP §6.6); a same-process check returns
+ * a clear actionable message instead.
+ */
+function isStructurallyValidAtx(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.atcVersion === 'string' && typeof v.agentId === 'string';
+}
+
+const MAX_ATX_FILE_BYTES = 256 * 1024; // 256 KiB
 
 // --- Core logic ---
 
@@ -1438,7 +1462,7 @@ function findProjectRoot(startPath: string): string | null {
  * Returns 0 on success (proceed with scan) or a non-zero exit code on failure.
  */
 async function aapGate(options: ProtectOptions, targetDir: string): Promise<number> {
-  const grant = options.grant!;
+  const grant = sanitizeForTty(options.grant!);
   const isJson = options.format === 'json';
 
   if (!options.atxPath) {
@@ -1447,13 +1471,56 @@ async function aapGate(options: ProtectOptions, targetDir: string): Promise<numb
     return 2;
   }
 
-  let atx: Record<string, unknown>;
+  // Size cap before read: a misconfigured path could otherwise slurp /var/log/syslog into memory.
+  try {
+    const stat = fs.statSync(options.atxPath);
+    if (stat.size > MAX_ATX_FILE_BYTES) {
+      process.stderr.write(red(`ATX file at ${options.atxPath} is ${stat.size} bytes; expected <= ${MAX_ATX_FILE_BYTES}\n`));
+      return 2;
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      process.stderr.write(red(`ATX file not found: ${options.atxPath}\n`));
+      process.stderr.write(dim('  Pass --atx <path> pointing to a JSON ATX issued by your AIM identity.\n'));
+    } else if (code === 'EACCES') {
+      process.stderr.write(red(`Permission denied reading ATX file: ${options.atxPath}\n`));
+    } else {
+      process.stderr.write(red(`Could not read ATX file at ${options.atxPath}\n`));
+    }
+    return 2;
+  }
+
+  let atx: unknown;
   try {
     const raw = fs.readFileSync(options.atxPath, 'utf-8');
     atx = JSON.parse(raw);
   } catch (err) {
     process.stderr.write(red(`Could not read ATX file at ${options.atxPath}: ${(err as Error).message}\n`));
     return 2;
+  }
+  if (!isStructurallyValidAtx(atx)) {
+    process.stderr.write(red(`ATX file at ${options.atxPath} is not a valid ATX object (missing atcVersion or agentId)\n`));
+    return 2;
+  }
+
+  // Defense-in-depth: if the broker socket exists, refuse to talk to one not owned
+  // by the current user. Same-uid attacker is already trusted on this box; a stale
+  // 0777 dir from a prior install (or a multi-user shared box) is the realistic
+  // concern. Skip when the user explicitly overrode the socket path: they opted in.
+  const socketPath = options.brokerSocket ?? DEFAULT_SOCKET_PATH;
+  if (!options.brokerSocket) {
+    try {
+      const stat = fs.statSync(socketPath);
+      const myUid = typeof process.getuid === 'function' ? process.getuid() : -1;
+      if (myUid !== -1 && stat.uid !== myUid) {
+        process.stderr.write(red(`Refusing to connect to broker socket ${socketPath}: owned by uid ${stat.uid}, expected ${myUid}\n`));
+        process.stderr.write(dim('  This protects against impostor brokers on multi-user systems.\n'));
+        return 4;
+      }
+    } catch {
+      // Socket missing is handled later as a connection failure with a clearer message.
+    }
   }
 
   const client = new BrokerClient({
@@ -1465,7 +1532,7 @@ async function aapGate(options: ProtectOptions, targetDir: string): Promise<numb
     await client.grant({
       agentId: options.grantAgentId ?? 'opena2a_protect_cli',
       atx,
-      grant,
+      grant: options.grant!,
       operation: { method: 'POST', path: '/protect/scan', query: { target: targetDir } },
     });
     if (!isJson && options.verbose) {
@@ -1477,9 +1544,9 @@ async function aapGate(options: ProtectOptions, targetDir: string): Promise<numb
       if (isJson) {
         process.stdout.write(JSON.stringify({
           status: 'aap-denied',
-          grant,
+          grant: options.grant,
           targetDir,
-          remediation: `Verify your broker policy binds ${grant} to your agent's trust class.`,
+          remediation: `Verify your broker policy binds ${options.grant} to your agent's trust class.`,
         }) + '\n');
       } else {
         process.stderr.write(red(`AAP broker denied ${grant}\n`));
@@ -1493,11 +1560,19 @@ async function aapGate(options: ProtectOptions, targetDir: string): Promise<numb
       }
       return 3;
     }
+    if (err instanceof BrokerUnexpectedStatusError) {
+      // Generic: never echo the broker's body. The status code triages this for the user;
+      // the broker operator can read the matching audit-log entry for the real reason.
+      process.stderr.write(red(`AAP broker returned status ${err.status}; refusing to proceed.\n`));
+      process.stderr.write(dim('  Reasons live only in the broker audit log (~/.secretless-ai/broker.audit.log).\n'));
+      return 6;
+    }
     if (err instanceof BrokerGrantError) {
-      process.stderr.write(red(`AAP broker unreachable: ${err.message}\n`));
+      process.stderr.write(red(`AAP broker unreachable: ${sanitizeForTty(err.message)}\n`));
       process.stderr.write(dim('  Start the broker:  secretless broker start\n'));
       return 4;
     }
-    throw err;
+    process.stderr.write(red(`AAP gate failed unexpectedly: ${sanitizeForTty((err as Error).message)}\n`));
+    return 5;
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -251,6 +251,11 @@ Learn more: https://opena2a.org/docs`);
     .option('--skip-sign', 'Skip config signing phase')
     .option('--skip-git', 'Skip git hygiene fixes (.gitignore, .git/info/exclude)')
     .option('--dir <path>', 'Target directory')
+    .option('--grant <grant-ref>', 'Gate the scan through an AAP grant (e.g. grant://opena2a-protect)')
+    .option('--atx <path>', 'Path to a JSON ATX file (required with --grant)')
+    .option('--broker-socket <path>', 'Override the Secretless broker socket path')
+    .option('--broker-token <path>', 'Override the Secretless broker token file path')
+    .option('--grant-agent-id <id>', 'Agent ID sent to the broker (default: opena2a_protect_cli)')
     .action(async (directory: string | undefined, opts) => {
       const { protect: runProtect } = await import('./commands/protect.js');
       const globalOpts = program.opts();
@@ -265,6 +270,11 @@ Learn more: https://opena2a.org/docs`);
         skipSign: opts.skipSign,
         skipGit: opts.skipGit,
         report: opts.report,
+        grant: opts.grant,
+        atxPath: opts.atx,
+        brokerSocket: opts.brokerSocket,
+        brokerTokenPath: opts.brokerToken,
+        grantAgentId: opts.grantAgentId,
       });
       printFooter({ ci: globalOpts.ci, json: globalOpts.format === 'json' });
     });

--- a/packages/cli/src/router.ts
+++ b/packages/cli/src/router.ts
@@ -84,6 +84,11 @@ export async function dispatchCommand(
   // Handle 'protect' directly (not adapter-based — it orchestrates HMA + Secretless)
   if (command === 'protect') {
     const targetDir = args[0] ?? process.cwd();
+    const grantIdx = args.indexOf('--grant');
+    const atxIdx = args.indexOf('--atx');
+    const brokerSocketIdx = args.indexOf('--broker-socket');
+    const brokerTokenIdx = args.indexOf('--broker-token');
+    const agentIdIdx = args.indexOf('--grant-agent-id');
     return protect({
       targetDir,
       dryRun: args.includes('--dry-run'),
@@ -91,6 +96,11 @@ export async function dispatchCommand(
       ci: globalOptions.ci ?? false,
       format: (globalOptions.format as 'text' | 'json') ?? 'text',
       skipVerify: args.includes('--skip-verify'),
+      grant: grantIdx >= 0 ? args[grantIdx + 1] : undefined,
+      atxPath: atxIdx >= 0 ? args[atxIdx + 1] : undefined,
+      brokerSocket: brokerSocketIdx >= 0 ? args[brokerSocketIdx + 1] : undefined,
+      brokerTokenPath: brokerTokenIdx >= 0 ? args[brokerTokenIdx + 1] : undefined,
+      grantAgentId: agentIdIdx >= 0 ? args[agentIdIdx + 1] : undefined,
     });
   }
 


### PR DESCRIPTION
## Summary

First TypeScript consumer of the [Agent Authorization Protocol](https://github.com/opena2a-standards/agent-authorization-protocol). Adds an opt-in `--grant <grant-ref> --atx <path>` flag to `opena2a protect` that gates the scan through the local Secretless broker (POST `/grant` over the broker's Unix socket).

Default behavior is unchanged: protect without `--grant` runs exactly as before.

## Why this PR

AAP shipped end-of-day 2026-06-01: spec at `opena2a-standards/agent-authorization-protocol`, reference broker on Secretless (secretless-ai#76), AIM Python grant decorator (agent-identity-management#266), architecture-site rows (opena2a-architecture#30). The protocol now exists but had zero TS consumers wired end-to-end. This PR is the first one.

The session handoff lived at `.claude-sessions/next-session-prompt-aap-first-integrator.md`. Picked Option A (opena2a-cli protect) per CHIEF-CPO recommendation.

## Design

- **Wire format** mirrors `secretless/src/broker/server.ts` `POST /grant` (request: `{agentId, atx, grant, operation:{method,path,query?}}`; response: `{result}` 200 / `{error:"denied"}` 403).
- **TS broker client** at `packages/cli/src/aap/client.ts` is the precedent-setting shape; the Python equivalent is `agent-identity-management/sdk/python/aim_sdk/grant_client.py`. The two surfaces stay aligned.
- **Opt-in only**: `protect` runs as before when `--grant` is not passed.
- **Hard fail on denial**: 403 -> exit 3 with an actionable next step. Per AAP §6.6 the denial is opaque; the response body is never echoed.

## Exit codes

| Code | Meaning |
|---|---|
| 0 | Broker authorized; protect proceeds |
| 2 | `--grant` without `--atx`, ATX file missing, or ATX structurally invalid |
| 3 | Broker denied (403) - uniform opaque denial per AAP §6.6 |
| 4 | Broker socket unreachable or owned by a different uid |
| 5 | Unexpected client error |
| 6 | Broker returned non-200/non-403 status - body never echoed |

## Hardening (from the adversarial pre-push review)

The first commit landed the integration. The second commit addresses an adversarial review that surfaced one HIGH and four MEDIUMs:

- **HIGH (AAP §6.6 spirit)**: a misbehaving broker's 5xx response body could be interpolated into user-visible stderr. Fixed by `BrokerUnexpectedStatusError` (carries status only, never body) + new exit code 6.
- **MED**: default-socket-path connections now verify `stat.uid == process.getuid()` before connecting (defense against same-uid impostor brokers on multi-user hosts).
- **MED**: ATX structural validation (`atcVersion + agentId` required); 256 KiB file-size cap before read.
- **MED**: 1 MiB cap on broker response bytes (impostor broker can no longer OOM the CLI).
- **MED**: ANSI / C0 control chars stripped from the user-supplied `--grant` value and from interpolated `err.message` before stderr writes (terminal-injection defense).
- **MED**: 403 integration test now seeds `scanDir` with a credential-bearing fixture and asserts byte-identity after exit 3 - proves the gate is load-bearing, not decorative.

## Threat matrix

Defends **T-3002** (cross-tenant grant leakage), **T-3003** (over-broad credential scope), **T-3006** (credential leaking into agent context), **T-8002** (audit attribution gap) at the CLI surface. The broker is the integrity-protected decision and audit point; the CLI carries no policy state.

## Test plan

- [x] `npm test -w opena2a-cli` -> 1119/1119 passing (was 1112; +7 client unit + 5 -> 10 integration)
- [x] `npm test` workspace-wide -> 20/20 turbo tasks successful
- [x] `npm run lint` clean
- [x] HMA scan on the changed files -> 98/100 (only LOW: missing .gitignore in temp scan area)
- [x] `--help` shows all 5 new flags
- [x] `node dist/index.js protect --grant grant://opena2a-protect /tmp` -> exit 2 with actionable message (no `--atx`)
- [x] `node dist/index.js protect --grant grant://opena2a-protect --atx /tmp/nope.json /tmp` -> exit 2 with prettified "ATX file not found"
- [x] `/pre-push-review` full 8-phase gate PASSED (adversarial subagent re-ran on diff; all findings addressed in code + regression tests)

## Files

```
packages/cli/src/aap/client.ts                          new  ~155 LOC
packages/cli/src/aap/index.ts                           new
packages/cli/__tests__/aap/client.test.ts               new  9 tests
packages/cli/__tests__/aap/protect-grant-integration.test.ts  new  10 tests
packages/cli/src/commands/protect.ts                    +173/-1
packages/cli/src/index.ts                               +10/-0  Commander flags
packages/cli/src/router.ts                              +10/-0  router pass-through
README.md                                               +20 protect AAP-gate subsection
CHANGELOG.md                                            +3
```

## Follow-up

Option B (HMA `trust`) was deferred per the handoff. It's a 1-day follow-up using the broker client code proven by this PR. Open question for that PR: TS-to-Go interop on the same Unix socket.

Architecture site update is also a small follow-up (mention `opena2a-cli` as the first AAP consumer in the Conformance row).
