### PR TITLE
fix(scan-soul): register --explain passthrough + bump bundled hackmyagent 0.23.4 -> 0.23.6 (0.10.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2442,9 +2442,9 @@
       }
     },
     "node_modules/hackmyagent": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/hackmyagent/-/hackmyagent-0.23.4.tgz",
-      "integrity": "sha512-TjzNXtnwQIp5tSGM7y1bcRjshQ5Yz8MukrN8PqRA0Z65magvWzo9Z2yB8nRyklgQODyWNktArjh+JtT3c0R4lA==",
+      "version": "0.23.6",
+      "resolved": "https://registry.npmjs.org/hackmyagent/-/hackmyagent-0.23.6.tgz",
+      "integrity": "sha512-tDPQOHfpN+RfLkM4aPg+rZ/ZRzOIUF9zYhcyEV8EMKGrhB7E8qGPk5+4FYbPbFt5IYgKMa2tvOyjgmhJ5ACNgg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
@@ -2452,7 +2452,7 @@
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/aim-core": "^0.1.2",
         "@opena2a/check-core": "0.2.0",
-        "@opena2a/cli-ui": "0.5.0",
+        "@opena2a/cli-ui": "0.5.1",
         "@opena2a/contribute": "^0.1.0",
         "@opena2a/credential-patterns": "0.1.1",
         "@opena2a/registry-client": "0.1.0",
@@ -2481,15 +2481,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/hackmyagent/node_modules/@opena2a/cli-ui": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.5.0.tgz",
-      "integrity": "sha512-c90/pOe/JiFe6WZnn9a8HVqOoaZ4cguI7Dkslh88FZM3Pqx8wP/9eaeoHFTKs/PrV9RYLj4GBC2OJ8srj7R7+g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "chalk": "^5.3.0"
       }
     },
     "node_modules/hackmyagent/node_modules/commander": {
@@ -3935,7 +3926,7 @@
     },
     "packages/cli": {
       "name": "opena2a-cli",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
@@ -3946,7 +3937,7 @@
         "@opena2a/telemetry": "0.3.0",
         "ai-trust": "^0.2.23",
         "commander": "^13.1.0",
-        "hackmyagent": "0.23.4",
+        "hackmyagent": "0.23.6",
         "secretless-ai": "^0.14.1"
       },
       "bin": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## Unreleased (queued for 0.10.5)
+## 0.10.5
+
+### Dependencies
+- **Bundled `hackmyagent` bumped `0.23.4` -> `0.23.6`** ([opena2a-org/hackmyagent#214](https://github.com/opena2a-org/hackmyagent/pull/214)). End-to-end effect for opena2a-cli users:
+  - **`opena2a scan-soul`** no longer flags HIGH on the scaffold `hackmyagent create-skill` produces, and the `harden-soul -> scan-soul` rescan loop now lands at 100/100 HARDENED on the empty-tree gold path.
+  - Adversarial-review hardening on SOUL-OVERRIDE-001 (decoy-negation gate), AST-PROMPT-004 (sibling-decoy), LIFECYCLE-001 (realpath dedupe), and YAML-frontmatter strip on the prompt-analyzer noise filter all reach `opena2a check` via the bundled HMA.
+  - Skipped `0.23.5` (HMA's 0.23.5 release pivoted to 0.23.6 after the release-test surfaced two scanner FP paths; the 0.23.6 commit landed both fixes plus 4 adversarial-review issues).
+  - Known follow-up: [hackmyagent#216](https://github.com/opena2a-org/hackmyagent/issues/216) -- `scan-soul --profile <override>` returns 100/100 HARDENED on the malicious-corpus `kitchen-sink` fixture. Not a regression; default `scan-soul` correctly clamps + discloses scope.
+
+### Fixes
+- **`opena2a scan-soul --explain` is now a registered option that passes through to bundled hackmyagent.** Previously the wrapper's Commander parser rejected `--explain` with `unknown option`, leaving the concept-explainer block referenced in HMA findings a dead-end for opena2a-cli users. The fix adds the option to the scan-soul command and delegates to `hackmyagent scan-soul --explain` via a thin spawn helper. Pairs with HMA PR #209 (cited command namespaced with `hackmyagent` prefix) and HMA's `concept-explainer-command-references.test.ts` regression gate.
+
+## Earlier work shipping in 0.10.5
 
 ### Features
 - **NanoMind classifier adapter for the natural-language layer.** New module `packages/cli/src/natural/nanomind-classifier.ts` plus types at `nanomind-types.ts` ports the aicomply 2.0 reference adapter to opena2a-cli. Speaks the frozen `@nanomind/daemon` v0.3.0 wire contract: HTTP POST to `127.0.0.1:47200/v1/infer`, strict schema validation, block rule `attackClass !== '' && confidence > 0.8` per AIM FGA Step 5. Returns a simple `{ blocked, attackClass, confidence, modelVersion, latencyMs } | null` shape; null on any failure (network, non-2xx, malformed, timeout) so callers silently fall back. Daemon `evidence` and `remediation` are deliberately dropped in the mapper because they can carry attacker-influenced bytes. Liveness probe `isNanoMindDaemonAvailable()` against `/health`. No router wiring in this drop; that lands in a follow-up. `MOCK_NANOMIND_URL` env honored for tests.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opena2a-cli",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Unified CLI for the OpenA2A security platform",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -26,7 +26,7 @@
     "@opena2a/telemetry": "0.3.0",
     "ai-trust": "^0.2.23",
     "commander": "^13.1.0",
-    "hackmyagent": "0.23.4",
+    "hackmyagent": "0.23.6",
     "secretless-ai": "^0.14.1"
   },
   "optionalDependencies": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -685,9 +685,15 @@ analysis runs and results can be shared with the community.
     .option('--tier <level>', 'Force tier (BASIC|STANDARD|AGENTIC)')
     .option('--deep', 'Enable LLM-assisted deep analysis')
     .option('--strict', 'Fail if any critical SOUL control is missing (SOUL-IH-003, SOUL-HB-001)')
+    .option('--explain', 'Print the 9-domain governance model (concept explainer) and exit')
     .action(async (directory: string | undefined, opts) => {
-      const { scanSoul } = await import('./commands/soul.js');
       const globalOpts = program.opts();
+      if (opts.explain) {
+        process.exitCode = await spawnHackmyagent(['scan-soul', '--explain']);
+        printFooter({ ci: globalOpts.ci, json: globalOpts.format === 'json' });
+        return;
+      }
+      const { scanSoul } = await import('./commands/soul.js');
       process.exitCode = await scanSoul({
         targetDir: opts.dir ?? directory ?? process.cwd(),
         ci: globalOpts.ci,
@@ -1340,6 +1346,41 @@ function spawnHmaCheck(
       npxChild.on('close', (code) => resolve(code ?? 1));
     });
 
+    child.on('close', (code) => resolve(code ?? 1));
+  });
+}
+
+/**
+ * Pass-through delegate for hackmyagent CLI commands that opena2a-cli
+ * does not implement directly. Used for `scan-soul --explain` which is a
+ * CLI-level concept explainer (not exposed on the SoulScanner programmatic API).
+ */
+function spawnHackmyagent(args: string[]): Promise<number> {
+  return new Promise<number>((resolve) => {
+    const hmaEnv = {
+      ...process.env,
+      HMA_CLI_PREFIX: 'opena2a',
+      HMA_CHECK_COMMAND: 'opena2a check',
+      HMA_FULL_SCAN_HINT: 'opena2a review',
+    };
+    const child = spawn('hackmyagent', args, {
+      cwd: process.cwd(),
+      stdio: 'inherit',
+      env: hmaEnv,
+    });
+    child.on('error', () => {
+      const npxChild = spawn('npx', ['hackmyagent', ...args], {
+        cwd: process.cwd(),
+        stdio: 'inherit',
+        env: hmaEnv,
+      });
+      npxChild.on('error', () => {
+        process.stderr.write('hackmyagent is not installed.\n');
+        process.stderr.write('Install: npm install -g hackmyagent\n');
+        resolve(1);
+      });
+      npxChild.on('close', (code) => resolve(code ?? 1));
+    });
     child.on('close', (code) => resolve(code ?? 1));
   });
 }


### PR DESCRIPTION
## Summary

Two changes shipping in `opena2a-cli@0.10.5`:

1. **`opena2a scan-soul --explain` is now a registered option.** Previously the wrapper's Commander parser rejected `--explain` with `unknown option`, even though HMA registered it on the underlying scan-soul command (HMA's `concept-explainer-command-references.test.ts` regression gate catches the HMA side; this PR catches the wrapper side). The fix delegates to `hackmyagent scan-soul --explain` via a thin spawn helper since HMA's concept-explainer block is a CLI-level static printout, not exposed on the `SoulScanner` programmatic API.

2. **Bundled `hackmyagent` 0.23.4 -> 0.23.6.** Skipped 0.23.5 (HMA pivoted to 0.23.6 after release-test surfaced two scanner FP paths -- create-skill scaffold flagged by check skill; harden-soul -> scan-soul loop left below hardened threshold). End-to-end effect for opena2a-cli users:
   - `opena2a scan-soul` no longer flags HIGH on the scaffold `hackmyagent create-skill` produces.
   - `opena2a harden-soul` -> `opena2a scan-soul` loop reaches 100/100 HARDENED on the empty-tree gold path.
   - Adversarial-review hardening on SOUL-OVERRIDE-001 (decoy-negation gate), AST-PROMPT-004 (sibling-decoy), LIFECYCLE-001 (realpath dedupe), YAML strip on noise filter reaches `opena2a check`.

Known follow-up: [hackmyagent#216](https://github.com/opena2a-org/hackmyagent/issues/216) -- `scan-soul --profile <override>` returns 100/100 HARDENED on the malicious-corpus `kitchen-sink` fixture. Not a regression in this bump; default `scan-soul` correctly clamps + discloses scope.

## Test plan

- [x] Built `opena2a-cli` via turbo; 1100 vitest tests pass.
- [x] Smoke: `node packages/cli/dist/index.js scan-soul --explain` prints the 9-domain governance model (output identical to `hackmyagent scan-soul --explain`).
- [ ] `/release-test` post-merge, before tag-push.
- [ ] Verify SLSA v1 provenance post-publish.
