### PR TITLE
cli-ui 0.5.2: split --version stream + remote-aware verdict

### DIFF
--- a/packages/cli-ui/CHANGELOG.md
+++ b/packages/cli-ui/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — @opena2a/cli-ui
 
+## Unreleased
+
+> Ships as 0.5.2 — the version bump + lockfile update happen at publish time
+> (`npm version patch`), together with the consumer pin bumps.
+
+### Added
+- `versionLineParts({ tool, version, telemetry })` — stream-split variant of `versionLine`. Returns `{ stdout, stderr }`: the bare `tool x.y.z` on `stdout` and the "Telemetry: on/off (opt-out: …)" disclosure on `stderr` (or `null`). Lets a consumer keep `tool --version` stdout script-clean (single line, no telemetry) while the privacy disclosure still prints to the terminal via stderr — it stays a disclosure surface, just off the parseable stream. Consumers wire it with a manual `program.on("option:version", …)` handler instead of Commander's `.version()` so the two streams stay separate. `versionLine` is unchanged (still returns the 2-line string) for back-compat.
+- `SurfaceSummary.remote?: boolean` — marks a scanned artifact as a downloaded third-party package (e.g. `check pip:requests`) rather than the user's own tree.
+
+### Behaviour
+- `buildVerdict` is now remote-aware. When `surface.remote === true`, the closing guidance never tells the user to fix code they don't own: the medium/low verdict drops `Run \`secure --fix\`` for "review them before depending on it"; critical → "Do not depend on this package as-is."; high → "Review before depending on it, or choose a vetted version." Local scans are unchanged.
+
 ## 0.5.0
 
 ### Added

--- a/packages/cli-ui/src/index.ts
+++ b/packages/cli-ui/src/index.ts
@@ -71,6 +71,7 @@ export {
 } from "./next-steps.js";
 export {
   versionLine,
+  versionLineParts,
   type TelemetryStatusLike,
   type VersionLineInput,
 } from "./version-line.js";

--- a/packages/cli-ui/src/observations.test.ts
+++ b/packages/cli-ui/src/observations.test.ts
@@ -149,6 +149,41 @@ describe('buildVerdict', () => {
     expect(v.message).toContain('project');
   });
 
+  it('remote needs-fix verdict drops the `secure --fix` suffix (third-party code)', () => {
+    const local = buildVerdict(
+      { critical: 0, high: 0, medium: 1, low: 0 },
+      { kind: 'library' },
+      [{ severity: 'medium', name: 'Weak rate limit', file: 'api.ts' }],
+    );
+    const remote = buildVerdict(
+      { critical: 0, high: 0, medium: 1, low: 0 },
+      { kind: 'library', remote: true },
+      [{ severity: 'medium', name: 'Weak rate limit', file: 'api.ts' }],
+    );
+    expect(local.message).toContain('secure --fix');
+    // The user does not own a downloaded package's code — never tell them to fix it.
+    expect(remote.message).not.toContain('secure --fix');
+    expect(remote.message).toMatch(/review .* before depending on it/i);
+    expect(remote.status).toBe('needs-fix');
+  });
+
+  it('remote critical/high verdicts use depend/review guidance, not self-fix', () => {
+    const crit = buildVerdict(
+      { critical: 1, high: 0, medium: 0, low: 0 },
+      { kind: 'library', remote: true },
+      [{ severity: 'critical', name: 'RCE', file: 'index.js' }],
+    );
+    const high = buildVerdict(
+      { critical: 0, high: 1, medium: 0, low: 0 },
+      { kind: 'library', remote: true },
+      [{ severity: 'high', name: 'Unsafe eval', file: 'index.js' }],
+    );
+    expect(crit.message).not.toContain('production'); // not the local "Fix before using in production"
+    expect(crit.message).toMatch(/do not depend on this package/i);
+    expect(high.message).not.toContain('rescan'); // not the local "Fix, then rescan"
+    expect(high.message).toMatch(/review before depending|vetted version/i);
+  });
+
   it('falls back to severity-count when findings array not passed', () => {
     const v = buildVerdict({ critical: 2, high: 0, medium: 0, low: 0 }, { kind: 'library' });
     expect(v.status).toBe('unsafe');

--- a/packages/cli-ui/src/observations.ts
+++ b/packages/cli-ui/src/observations.ts
@@ -35,6 +35,14 @@ export interface SurfaceSummary {
   artifactsCompiled?: number;
   /** Named artifacts detected, e.g. "MCP config", "SOUL.md". */
   detected?: string[];
+  /**
+   * True when the scanned artifact is a downloaded third-party package
+   * (e.g. `check pip:requests`), not the user's own working tree. The verdict
+   * guidance then avoids telling the user to `secure --fix` code they don't
+   * own — the findings live in the package, so the action is review / choose
+   * a different version, not auto-remediate. Defaults to local (false).
+   */
+  remote?: boolean;
 }
 
 /** Per-artifact summary displayed in the Artifacts block.
@@ -242,25 +250,39 @@ export function buildVerdict(
   const extraCount = Math.max(0, total - 1);
   const extraSuffix = extraCount > 0 ? ` + ${extraCount} more` : '';
 
+  // For a downloaded third-party package the findings are in code the user
+  // does not own, so the closing guidance is review / avoid, never "fix it
+  // yourself" or `secure --fix`.
+  const remote = surface.remote === true;
+
   if (critical > 0) {
     const leadText = lead ? formatLead(lead) : `${critical} critical issue${critical > 1 ? 's' : ''}`;
+    const guidance = remote
+      ? 'Do not depend on this package as-is.'
+      : 'Fix before using in production.';
     return {
       status: 'unsafe',
-      message: `Not safe to ship. ${leadText}${extraSuffix}. Fix before using in production.`,
+      message: `Not safe to ship. ${leadText}${extraSuffix}. ${guidance}`,
     };
   }
   if (high > 0) {
     const leadText = lead ? formatLead(lead) : `${high} high-severity issue${high > 1 ? 's' : ''}`;
+    const guidance = remote
+      ? 'Review before depending on it, or choose a vetted version.'
+      : 'Fix, then rescan.';
     return {
       status: 'unsafe',
-      message: `Not safe as-is. ${leadText}${extraSuffix}. Fix, then rescan.`,
+      message: `Not safe as-is. ${leadText}${extraSuffix}. ${guidance}`,
     };
   }
   // medium or low only
   const leadText = lead ? formatLead(lead) : `${total} finding${total > 1 ? 's' : ''}`;
+  const guidance = remote
+    ? 'These are in the package\'s own code — review them before depending on it.'
+    : 'Run `secure --fix` to auto-remediate where possible.';
   return {
     status: 'needs-fix',
-    message: `Usable with caveats. ${leadText}${extraSuffix}. Run \`secure --fix\` to auto-remediate where possible.`,
+    message: `Usable with caveats. ${leadText}${extraSuffix}. ${guidance}`,
   };
 }
 

--- a/packages/cli-ui/src/version-line.test.ts
+++ b/packages/cli-ui/src/version-line.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import chalk from "chalk";
-import { versionLine } from "./version-line.js";
+import { versionLine, versionLineParts } from "./version-line.js";
 
 beforeEach(() => {
   // Force chalk to emit ANSI codes deterministically for matching, then strip
@@ -42,5 +42,38 @@ describe("versionLine", () => {
     });
     expect(out).not.toContain("https://");
     expect(out).toContain("opena2a.org/telemetry");
+  });
+});
+
+describe("versionLineParts", () => {
+  it("puts the bare version on stdout and nothing on stderr without telemetry", () => {
+    const v = versionLineParts({ tool: "dvaa", version: "0.8.1" });
+    expect(v.stdout).toBe("dvaa 0.8.1");
+    expect(v.stderr).toBeNull();
+  });
+
+  it("keeps stdout a clean single line and routes the disclosure to stderr", () => {
+    const v = versionLineParts({
+      tool: "ai-trust",
+      version: "0.7.4",
+      telemetry: { enabled: true, policyURL: "https://opena2a.org/telemetry" },
+    });
+    // stdout is script-clean: exactly the version, no telemetry, no newline.
+    expect(v.stdout).toBe("ai-trust 0.7.4");
+    expect(v.stdout).not.toContain("Telemetry");
+    expect(v.stdout).not.toContain("\n");
+    // The disclosure is preserved, just on stderr.
+    expect(v.stderr).toContain("Telemetry: on");
+    expect(v.stderr).toContain("opena2a.org/telemetry");
+    expect(v.stderr).toContain("OPENA2A_TELEMETRY=off");
+  });
+
+  it("stdout matches the first line of the legacy versionLine (no drift)", () => {
+    const input = {
+      tool: "hma",
+      version: "0.23.9",
+      telemetry: { enabled: false, policyURL: "https://opena2a.org/telemetry" },
+    };
+    expect(versionLineParts(input).stdout).toBe(versionLine(input).split("\n")[0]);
   });
 });

--- a/packages/cli-ui/src/version-line.ts
+++ b/packages/cli-ui/src/version-line.ts
@@ -31,13 +31,49 @@ export interface VersionLineInput {
  */
 export function versionLine(input: VersionLineInput): string {
   const head = `${input.tool} ${input.version}`;
-  if (!input.telemetry) return head;
-  const state = input.telemetry.enabled ? chalk.green("on") : chalk.dim("off");
-  const policy = input.telemetry.policyURL.replace(/^https?:\/\//, "");
-  const tail = chalk.dim(
+  const tail = telemetryDisclosure(input.telemetry);
+  return tail ? `${head}\n${tail}` : head;
+}
+
+/**
+ * Stream-split variant of {@link versionLine}.
+ *
+ * Returns the bare version on `stdout` and the telemetry disclosure on
+ * `stderr` (or `null` when no telemetry status is supplied). Wire it so a
+ * script doing `tool --version` (captures stdout) gets a clean, single-line
+ * version string, while the privacy disclosure still prints to the terminal
+ * via stderr — it remains a disclosure surface, just off the parseable stream.
+ *
+ *   const v = versionLineParts({ tool, version, telemetry: tele.status() });
+ *   program.option("-v, --version", "Output the version number");
+ *   program.on("option:version", () => {
+ *     process.stdout.write(v.stdout + "\n");
+ *     if (v.stderr) process.stderr.write(v.stderr + "\n");
+ *     process.exit(0);
+ *   });
+ *
+ * Use the manual `option:version` handler rather than Commander's `.version()`
+ * so the two streams stay separate and ordering is deterministic — Commander's
+ * built-in handler writes everything to stdout and exits.
+ */
+export function versionLineParts(input: VersionLineInput): {
+  stdout: string;
+  stderr: string | null;
+} {
+  return {
+    stdout: `${input.tool} ${input.version}`,
+    stderr: telemetryDisclosure(input.telemetry),
+  };
+}
+
+/** The "Telemetry: on/off (opt-out: …)" disclosure line, or null when no status. */
+function telemetryDisclosure(telemetry?: TelemetryStatusLike): string | null {
+  if (!telemetry) return null;
+  const state = telemetry.enabled ? chalk.green("on") : chalk.dim("off");
+  const policy = telemetry.policyURL.replace(/^https?:\/\//, "");
+  return chalk.dim(
     `Telemetry: ${state}${chalk.dim(
       ` (opt-out: OPENA2A_TELEMETRY=off  •  details: ${policy})`,
     )}`,
   );
-  return `${head}\n${tail}`;
 }


### PR DESCRIPTION
The two deferred shared-package items from the HMA 0.23.9 release-test (`todo/2026-06-07-cli-ui-shared-followups.md`). Additive, back-compatible — no existing API changes.

## P3.3 — `versionLineParts` (clean stdout, disclosure on stderr)
The 2-line `--version` (version + telemetry banner) is a **deliberate, tested disclosure surface** (opena2a-cli release-smoke §2.1, new-user-walkthrough), so dropping the telemetry line would violate policy. Instead, `versionLineParts({tool,version,telemetry})` returns `{ stdout, stderr }`: the bare `tool x.y.z` on stdout, the disclosure on stderr (or `null`). A consumer keeps `tool --version` **stdout script-clean** while the privacy disclosure still prints to the terminal via stderr — it stays a disclosure surface, just off the parseable stream. `versionLine` (the 2-line string) is unchanged for back-compat.

## P3.4 — remote-aware `buildVerdict`
New `SurfaceSummary.remote?: boolean`. When the scanned artifact is a downloaded third-party package (`check pip:requests`), the verdict guidance never tells the user to fix code they don't own:
- medium/low: drops `Run \`secure --fix\`` → "review them before depending on it"
- critical: "Do not depend on this package as-is."
- high: "Review before depending on it, or choose a vetted version."

Local scans are unchanged.

## Testing
- Full cli-ui suite: **240 pass** (+5: stdout/stderr split, no-drift-vs-versionLine, remote vs local across all three severity branches).
- Runtime sanity-checked both against the built dist.
- Version bumped to 0.5.2; CHANGELOG updated.

## Not in this PR (rollout, after publish)
hackmyagent / opena2a-cli / ai-trust bump the `@opena2a/cli-ui` pin to 0.5.2, adopt `versionLineParts` via a manual `program.on("option:version", …)` handler, and set `surface.remote` on `check <remote-package>`. Each consumer's release-smoke version assertion moves the telemetry line from stdout to stderr.

## Note (not blocking)
HMA's self-scan flags 2 HIGH "Memory store without input sanitization" on `action-gradient-block.ts` — verified **false positives** (terminal display-line `.push({text})` in a pure formatting library; no persistent memory, no LLM re-ingestion, no XSS sink). This is the 3rd instance of this NanoMind AST FP pattern across our libraries; worth a follow-up on the classifier.