### PR TITLE
release(cli-ui): 0.5.2 — versionLineParts + remote-aware verdict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4163,7 +4163,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
-        "@opena2a/cli-ui": "0.5.1",
+        "@opena2a/cli-ui": "0.5.2",
         "@opena2a/contribute": "0.1.0",
         "@opena2a/registry-client": "0.2.0",
         "@opena2a/shared": "0.1.0",
@@ -4193,7 +4193,7 @@
     },
     "packages/cli-ui": {
       "name": "@opena2a/cli-ui",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0"

--- a/packages/cli-ui/CHANGELOG.md
+++ b/packages/cli-ui/CHANGELOG.md
@@ -1,9 +1,6 @@
 # Changelog — @opena2a/cli-ui
 
-## Unreleased
-
-> Ships as 0.5.2 — the version bump + lockfile update happen at publish time
-> (`npm version patch`), together with the consumer pin bumps.
+## 0.5.2
 
 ### Added
 - `versionLineParts({ tool, version, telemetry })` — stream-split variant of `versionLine`. Returns `{ stdout, stderr }`: the bare `tool x.y.z` on `stdout` and the "Telemetry: on/off (opt-out: …)" disclosure on `stderr` (or `null`). Lets a consumer keep `tool --version` stdout script-clean (single line, no telemetry) while the privacy disclosure still prints to the terminal via stderr — it stays a disclosure surface, just off the parseable stream. Consumers wire it with a manual `program.on("option:version", …)` handler instead of Commander's `.version()` so the two streams stay separate. `versionLine` is unchanged (still returns the 2-line string) for back-compat.

--- a/packages/cli-ui/package.json
+++ b/packages/cli-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/cli-ui",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Shared terminal UI primitives for OpenA2A CLIs (score meter, trust level legend, verdict colors, observations + verdict block, analyst-render, check block, check rich-block (skill+mcp), not-found block, next-steps, version-line, telemetry-command)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^7.0.0",
-    "@opena2a/cli-ui": "0.5.1",
+    "@opena2a/cli-ui": "0.5.2",
     "@opena2a/contribute": "0.1.0",
     "@opena2a/registry-client": "0.2.0",
     "@opena2a/shared": "0.1.0",


### PR DESCRIPTION
Publishes the cli-ui changes merged in #194 (P3.3 stream-split `--version`, P3.4 remote-aware `buildVerdict`).

- Bumps `@opena2a/cli-ui` 0.5.1 → 0.5.2.
- Bumps the in-repo `opena2a-cli` (`packages/cli`) exact pin to 0.5.2 (required — the workspace would otherwise desync) and regenerates the lockfile.
- CHANGELOG `Unreleased` → `0.5.2`.

Merging this, then pushing tag `cli-ui-v0.5.2`, triggers the OIDC publish.

## Validation
- Root build 10/10, root test **1148 + 240 pass**.
- Library release-test: packed the tarball, installed it in a clean dir, verified version 0.5.2 + all exports resolve + `versionLineParts` (clean stdout / stderr disclosure) and remote `buildVerdict` (no `secure --fix`) behave from the published artifact.
- Version / opena2a-cli pin / lockfile all consistent at 0.5.2.

Consumer rollout (separate, after publish): hackmyagent + ai-trust pin bumps to 0.5.2, then adopt `versionLineParts` + `surface.remote`.