### PR TITLE
chore(cli): stream-split --version via cli-ui 0.5.2 versionLineParts

### DIFF
--- a/packages/cli/__tests__/version-stream-split.test.ts
+++ b/packages/cli/__tests__/version-stream-split.test.ts
@@ -1,0 +1,70 @@
+/**
+ * cli-ui 0.5.2 — `--version` stream split.
+ *
+ * The version output is rendered via `versionLineParts` and a manual
+ * `option:version` handler (not Commander's `.version()`, which writes
+ * everything to stdout). The bare `opena2a x.y.z` must land on stdout as a
+ * single parseable line; the telemetry disclosure must land on stderr.
+ *
+ * Exercises the built `dist/index.js` end-to-end.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const CLI_PATH = resolve(__dirname, '../dist/index.js');
+const STRIP_ANSI = /\x1b\[[0-9;]*m/g;
+
+function runVersion(flag: string, telemetry = 'on'): { stdout: string; stderr: string; status: number } {
+  const res = spawnSync(process.execPath, [CLI_PATH, flag], {
+    encoding: 'utf8',
+    timeout: 20000,
+    env: { ...process.env, NODE_OPTIONS: '', NO_COLOR: '1', OPENA2A_TELEMETRY: telemetry },
+  });
+  return {
+    stdout: (res.stdout ?? '').replace(STRIP_ANSI, ''),
+    stderr: (res.stderr ?? '').replace(STRIP_ANSI, ''),
+    status: res.status ?? 1,
+  };
+}
+
+describe('--version stream split (cli-ui 0.5.2)', () => {
+  it('dist/index.js exists', () => {
+    expect(existsSync(CLI_PATH)).toBe(true);
+  });
+
+  it('stdout is a single clean `opena2a x.y.z` line, telemetry goes to stderr', () => {
+    if (!existsSync(CLI_PATH)) return;
+    const { stdout, stderr, status } = runVersion('--version');
+    expect(status).toBe(0);
+
+    const stdoutLines = stdout.trim().split('\n').filter((l) => l.length > 0);
+    expect(stdoutLines).toHaveLength(1);
+    expect(stdoutLines[0]).toMatch(/^opena2a \d+\.\d+\.\d+/);
+    // The telemetry disclosure must NOT pollute the parseable stream.
+    expect(stdout).not.toMatch(/Telemetry:/);
+
+    // Disclosure still surfaces — on stderr.
+    expect(stderr).toMatch(/Telemetry: on/);
+  });
+
+  it('-v behaves identically to --version (stdout, stderr disclosure, exit 0)', () => {
+    if (!existsSync(CLI_PATH)) return;
+    const long = runVersion('--version');
+    const short = runVersion('-v');
+    expect(short.status).toBe(0);
+    expect(short.stdout.trim()).toBe(long.stdout.trim());
+    expect(short.stderr).toMatch(/Telemetry: on/);
+  });
+
+  it('OPENA2A_TELEMETRY=off: stdout stays the single version line, no telemetry leak', () => {
+    if (!existsSync(CLI_PATH)) return;
+    const { stdout, status } = runVersion('--version', 'off');
+    expect(status).toBe(0);
+    const lines = stdout.trim().split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatch(/^opena2a \d+\.\d+\.\d+/);
+    expect(stdout).not.toMatch(/Telemetry:/);
+  });
+});

--- a/packages/cli/docs/testing/new-user-walkthrough.md
+++ b/packages/cli/docs/testing/new-user-walkthrough.md
@@ -25,7 +25,7 @@ node dist/index.js -v
 node dist/index.js --version
 ```
 
-`--version` should be a two-line disclosure (version + telemetry status, brand-model split per 0.9.0 telemetry canary). `--help` lists every registered command and the global flags.
+`--version` is stream-split as of cli-ui 0.5.2: the bare version (`opena2a 0.x.x`) prints to **stdout** as a single parseable line, and the telemetry disclosure prints to **stderr**. `node dist/index.js --version 2>/dev/null` must show exactly one line. `--help` lists every registered command and the global flags.
 
 ## Composite review
 

--- a/packages/cli/docs/testing/release-smoke.md
+++ b/packages/cli/docs/testing/release-smoke.md
@@ -16,16 +16,24 @@ node dist/index.js --help  # banner + commands list, no panics
 ## 1. Help and version
 
 ```bash
-node dist/index.js --version
+node dist/index.js --version              # version on stdout + telemetry on stderr
+node dist/index.js --version 2>/dev/null  # stdout ONLY: single clean line `opena2a 0.x.x`
+node dist/index.js --version 2>&1 1>/dev/null  # stderr ONLY: telemetry disclosure
 ```
 
-Expected output (exactly two lines for the `--version` invocation):
+As of cli-ui 0.5.2 the `--version` output is stream-split: the bare version
+goes to **stdout** as a single parseable line, the telemetry disclosure to
+**stderr**:
 ```
+# stdout
 opena2a 0.10.0
+# stderr
 Telemetry: on (opt-out: OPENA2A_TELEMETRY=off  •  details: opena2a.org/telemetry)
 ```
 
-If the second line is missing, `versionLine()` isn't wired or the SDK init failed silently.
+If the stderr line is missing, `versionLineParts()` isn't wired or the SDK init
+failed silently. If the telemetry line leaks into stdout, the manual
+`option:version` handler regressed back to Commander's `.version()`.
 
 ## 2. Telemetry — disclosure surfaces and opt-out (3 min)
 
@@ -39,7 +47,7 @@ rm -f ~/.config/opena2a/telemetry.json
 
 | # | Command | Expected |
 |---|---------|----------|
-| 2.1 | `opena2a --version` | `opena2a 0.10.0` then `Telemetry: on (opt-out: OPENA2A_TELEMETRY=off  •  details: opena2a.org/telemetry)` |
+| 2.1 | `opena2a --version` | `opena2a 0.10.0` on **stdout** (single line) + `Telemetry: on (opt-out: OPENA2A_TELEMETRY=off  •  details: opena2a.org/telemetry)` on **stderr**. `--version 2>/dev/null` shows only the version; `--version 2>&1 1>/dev/null` shows only the telemetry line. |
 | 2.2 | `opena2a telemetry status` | `opena2a telemetry`, then `state: on`, install_id, config path, policy URL, toggle hint |
 | 2.3 | `opena2a telemetry off` | `Telemetry disabled for opena2a.` Then `--version` shows `Telemetry: off`. `~/.config/opena2a/telemetry.json` has `"enabled": false`. |
 | 2.4 | `opena2a telemetry on` | Re-enables persistently. |

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -59,7 +59,7 @@ async function main(): Promise<void> {
   // or `opena2a telemetry off`. See README \u00a7Telemetry. Disclosure surfaces:
   // README, --version line, telemetry subcommand, opena2a.org/telemetry.
   const tele = await import('@opena2a/telemetry');
-  const { versionLine, runTelemetryCommand, verdictColor, divider, sanitizeForTerminal } =
+  const { versionLineParts, runTelemetryCommand, verdictColor, divider, sanitizeForTerminal } =
     await import('@opena2a/cli-ui');
   await tele.init({ tool: TOOL, version: VERSION });
 
@@ -86,7 +86,7 @@ async function main(): Promise<void> {
   program
     .name('opena2a')
     .description('Open-source security platform for AI agents')
-    .version(versionLine({ tool: 'opena2a', version: VERSION, telemetry: tele.status() }), '-v, --version')
+    .option('-v, --version', 'Output the version number')
     .option('--ci', 'CI mode (no interactive prompts, machine-readable output)')
     .option('--quiet', 'Suppress non-essential output')
     .option('--verbose', 'Verbose output')
@@ -167,6 +167,17 @@ Telemetry:
   Local scans may contribute to the OpenA2A Registry. Disable: --no-contribute
 
 Learn more: https://opena2a.org/docs`);
+
+  // Stream-split --version (cli-ui 0.5.2): bare `opena2a x.y.z` to stdout
+  // (single parseable line), telemetry disclosure to stderr. Use a manual
+  // `option:version` handler rather than Commander's `.version()`, which
+  // writes everything to stdout and exits.
+  const vparts = versionLineParts({ tool: 'opena2a', version: VERSION, telemetry: tele.status() });
+  program.on('option:version', () => {
+    process.stdout.write(vparts.stdout + '\n');
+    if (vparts.stderr) process.stderr.write(vparts.stderr + '\n');
+    process.exit(0);
+  });
 
   // Register all adapter-backed commands
   for (const [name, config] of Object.entries(ADAPTER_REGISTRY)) {


### PR DESCRIPTION
Wires the published \`@opena2a/cli-ui@0.5.2\` \`versionLineParts\` into opena2a-cli. Final repo in the cli-ui 0.5.2 consumer-adoption sweep (todo/2026-06-08-cli-ui-0.5.2-consumer-adoption.md).

## Changes
- **Stream-split \`--version\`:** replaced Commander's \`.version()\` (writes everything to stdout) with \`versionLineParts\` + a manual \`option:version\` handler. \`opena2a --version\` now prints the bare \`opena2a x.y.z\` as a single line on **stdout**; the telemetry disclosure prints to **stderr**.
- **Docs:** release-smoke §1/§2.1 + new-user-walkthrough updated for the stdout/stderr split.
- **Test:** \`__tests__/version-stream-split.test.ts\` (stdout single line, telemetry on stderr, -v parity + exit/stderr, telemetry-off no leak).

## Scope notes
- The \`@opena2a/cli-ui\` pin is **already 0.5.2** on main (#195) — no pin bump needed here.
- **No \`surface.remote\` work for opena2a-cli (#3 N/A).** The only \`buildVerdict\` path is \`opena2a review\`, which scans the user's own project tree (\`process.cwd()\`) → a local verdict, correctly \`remote: false\`. \`opena2a check <pkg>\` delegates to \`hackmyagent check\`, which carries its own remote-aware verdict (hackmyagent PR #228).

## Verification
- \`opena2a --version 2>/dev/null\` → single line \`opena2a 0.10.7\`; \`--version 2>&1 1>/dev/null\` → telemetry line only; \`--help\` still exits 0 and lists \`-v, --version\`.
- Full cli suite green (1152 pass), \`tsc --noEmit\` clean.

## Notes
- HMA self-scan flagged a CRITICAL \`.env Not Ignored\` on a **local, untracked, root-\`.gitignore\`-ignored** dev artifact in \`packages/cli/\` (present since March, not in this diff, never pushed) — a false positive (HMA checked only the package-level \`.gitignore\`, missing the committed root one).
- No republish — rides opena2a-cli's next release per the publish budget.