### PR TITLE
test(contribute): isolate HOME so concurrent suites don't clobber shared ~/.opena2a

### DIFF
--- a/packages/contribute/package.json
+++ b/packages/contribute/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "vitest run --passWithNoTests",
+    "test": "HOME=\"$(mktemp -d)\" vitest run --passWithNoTests",
     "lint": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"


### PR DESCRIPTION
## Problem
The release workflow's monorepo `npm run test` intermittently fails on `packages/contribute/__tests__/contribute.test.ts:115` (`auto-flushes after 10 events` → `expected "vi.fn()" to be called at least once`). It hit the `opena2a-cli 0.10.8` release run and was cleared only by a re-run.

## Root cause
`contribute` resolves its queue/config paths under `homedir()/.opena2a` **at module load** (`src/queue.ts`, `src/config.ts`, `src/contributor.ts`). Turbo runs package test suites **concurrently**, and other packages' tests also write `~/.opena2a/config.json`. When a sibling suite flips `contribute.enabled` mid-test, `isContributeEnabled()` returns false, `scanResult()` early-returns without queueing, the 10-event flush threshold is never reached, and `fetch` is never called → the assertion fails. (The contribute package's own `fileParallelism: false` only serializes *within* the package, not across packages.)

## Fix
Point the contribute test **process**'s `HOME` at a fresh `mktemp -d` so `os.homedir()` (POSIX honors `$HOME`) resolves to an isolated tree — immune to other packages' concurrent writes to the real `~/.opena2a`.

```
-    "test": "vitest run --passWithNoTests",
+    "test": "HOME=\"$(mktemp -d)\" vitest run --passWithNoTests",
```

## Scope / safety
- **Test-script only.** Not in the published tarball (`files: ["dist","README.md"]`) → **no republish**.
- Verified: `os.homedir()` honors the `$HOME` override on this platform; full contribute suite green (29/29) under the isolated home.
- No source/runtime behavior change — production still uses the real `homedir()/.opena2a`.