### PR TITLE
fix(protect/init/review): don't flag .env.example template files as hardcoded credentials

### DIFF
--- a/packages/cli/__tests__/commands/init.test.ts
+++ b/packages/cli/__tests__/commands/init.test.ts
@@ -570,12 +570,15 @@ describe('init', () => {
       const { output: benignOut } = await captureStdout(() => init({ targetDir: benignDir, format: 'json' }));
       const benign = JSON.parse(benignOut);
 
-      // Buggy: 1 hardcoded credential in .env.example
+      // Buggy: 1 hardcoded credential in a source file. (Must be a real
+      // credential surface, NOT .env.example — template env files hold
+      // placeholders and are intentionally not scanned; see
+      // credential-patterns TEMPLATE_ENV_FILES.)
       const buggyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opena2a-buggy-'));
       fs.writeFileSync(path.join(buggyDir, 'package.json'), JSON.stringify({ name: 'bg' }));
       fs.writeFileSync(path.join(buggyDir, '.gitignore'), '.env\n');
       const fakeKey = 'sk-ant-api03-' + 'Q'.repeat(85);
-      fs.writeFileSync(path.join(buggyDir, '.env.example'), `KEY=${fakeKey}\n`);
+      fs.writeFileSync(path.join(buggyDir, 'config.ts'), `const KEY = "${fakeKey}";\n`);
 
       const { output: buggyOut } = await captureStdout(() => init({ targetDir: buggyDir, format: 'json' }));
       const buggy = JSON.parse(buggyOut);

--- a/packages/cli/__tests__/util/credential-patterns-fixture-exclusion.test.ts
+++ b/packages/cli/__tests__/util/credential-patterns-fixture-exclusion.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { quickCredentialScan, SKIP_FILENAME_PATTERNS } from '../../src/util/credential-patterns.js';
+import { quickCredentialScan, SKIP_FILENAME_PATTERNS, TEMPLATE_ENV_FILES } from '../../src/util/credential-patterns.js';
 
 // Real-shaped placeholder credentials. These are the values that triggered
 // the 7 false positives surfaced during the 2026-04-29 `opena2a review` audit
@@ -160,6 +160,64 @@ describe('quickCredentialScan: fixture/demo files are silently skipped', () => {
     );
     const matches = quickCredentialScan(tmpDir);
     expect(matches).toHaveLength(0);
+  });
+});
+
+// Regression: template env files (.env.example / .sample / .template / .dist)
+// hold placeholder values by convention and are meant to be committed. Scanning
+// them produced CRITICAL false positives (surfaced 2026-06-08 by the
+// opena2a-cli 0.10.8 fresh-user release test, where `protect`/`init` flagged
+// `.env.example:1` as a CRITICAL OpenAI key). Real env files still scan.
+describe('quickCredentialScan: template env files are skipped (placeholders, not secrets)', () => {
+  const PLACEHOLDER = `OPENAI_API_KEY=${FIXTURE_OPENAI_KEY}`; // real-shaped placeholder
+
+  for (const tmpl of [...TEMPLATE_ENV_FILES]) {
+    it(`skips ${tmpl} (no findings even with a real-shaped placeholder)`, () => {
+      write(tmpl, PLACEHOLDER + '\n');
+      expect(quickCredentialScan(tmpDir)).toHaveLength(0);
+    });
+  }
+
+  it('STILL scans a real .env file (regression guard — that is where protect migrates from)', () => {
+    write('.env', PLACEHOLDER + '\n');
+    const matches = quickCredentialScan(tmpDir);
+    expect(matches.length).toBeGreaterThan(0);
+    expect(matches[0].findingId).toBe('CRED-002');
+  });
+
+  it('STILL scans .env.local and .env.production (live env files, not templates)', () => {
+    write('.env.local', PLACEHOLDER + '\n');
+    write('.env.production', PLACEHOLDER + '\n');
+    expect(quickCredentialScan(tmpDir).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('TEMPLATE_ENV_FILES covers the four conventional template names', () => {
+    expect([...TEMPLATE_ENV_FILES].sort()).toEqual(
+      ['.env.dist', '.env.example', '.env.sample', '.env.template'],
+    );
+  });
+
+  it('STILL scans a real .env nested in a normal subdirectory (subtree scanning intact)', () => {
+    // Guard against an over-broad skip: only template FILES are excluded, never
+    // whole subtrees. A real secret in config/.env must still be found.
+    write('config/.env', PLACEHOLDER + '\n');
+    expect(quickCredentialScan(tmpDir).length).toBeGreaterThan(0);
+  });
+
+  it('a DIRECTORY named .env.example is treated as a normal hidden dir (documents, does not special-case)', () => {
+    // Documents the intended behavior: because the exclusion is enforced via
+    // SCAN_DOTFILES omission (not a name-keyed skip branch), a dir named like a
+    // template is handled by the same rule as any other hidden directory
+    // (.git, .vscode) — not recursed. NOTE: this is a documentation test, not a
+    // regression guard for the over-broad name-skip an earlier draft had — that
+    // draft was behaviorally identical for a template-named entry, so no fixture
+    // can distinguish them. The real guards are the subtree-scanning test above
+    // and the real-.env tests. Per adversarial-review verifier feedback.
+    write('.env.example/.env', PLACEHOLDER + '\n');     // inside a hidden dir → not scanned
+    write('visible/.env', PLACEHOLDER + '\n');           // normal dir → scanned
+    const matches = quickCredentialScan(tmpDir);
+    expect(matches.length).toBeGreaterThan(0);
+    expect(matches.every(m => !m.filePath.includes('.env.example'))).toBe(true);
   });
 });
 

--- a/packages/cli/src/util/credential-patterns.ts
+++ b/packages/cli/src/util/credential-patterns.ts
@@ -136,6 +136,26 @@ export const SKIP_FILENAME_PATTERNS: RegExp[] = [
   /^demo[-_].*\.(?:sh|ts|js|py)$/i,
 ];
 
+/**
+ * Canonical list of template env files. They hold PLACEHOLDER values by
+ * convention (e.g. `OPENAI_API_KEY=sk-your-key-here`), are meant to be
+ * committed and edited, and per the project Secretless policy are explicitly
+ * NOT credential surfaces — scanning them produces noisy CRITICAL false
+ * positives (a `sk-…` placeholder is not a real exposure).
+ *
+ * Enforcement: these names are simply omitted from `SCAN_DOTFILES` in
+ * `walkFiles`, so the existing "dot-name not in the allowlist is skipped" rule
+ * excludes them — no separate skip branch (which would also have skipped a
+ * directory of the same name). Real env files (`.env`, `.env.local`,
+ * `.env.production`, …) stay in the allowlist and still scan. Detecting a real
+ * secret accidentally pasted into a template is the wrong layer (use
+ * git-secrets / a pre-commit hook), not the migration scanner. Exported so
+ * callers/tests share one source of truth for "what is a template env file".
+ */
+export const TEMPLATE_ENV_FILES = new Set([
+  '.env.example', '.env.sample', '.env.template', '.env.dist',
+]);
+
 const CASE_INSENSITIVE_FS = process.platform === 'darwin' || process.platform === 'win32';
 
 /**
@@ -205,8 +225,15 @@ export function walkFiles(dir: string, callback: (filePath: string) => void): vo
     if (a === r || a.startsWith(r + path.sep)) return;
   }
 
-  // Dot-files to scan (credential sources)
-  const SCAN_DOTFILES = new Set(['.env', '.env.example', '.env.local', '.env.development', '.env.production', '.env.staging', '.env.test']);
+  // Dot-files to scan (credential sources). This is an explicit allowlist:
+  // any dot-name NOT listed here is skipped by the rule below (files AND
+  // directories alike — hidden dirs like .git/.vscode/.config are never
+  // recursed). Template env files (TEMPLATE_ENV_FILES: .env.example/.sample/
+  // .template/.dist) are deliberately OMITTED — they hold placeholders, not
+  // live secrets, so a `sk-…` value in them is not a real exposure. Do NOT
+  // add a template name here: it would re-introduce the .env.example CRITICAL
+  // false positive (opena2a-cli 0.10.8 fresh-user finding).
+  const SCAN_DOTFILES = new Set(['.env', '.env.local', '.env.development', '.env.production', '.env.staging', '.env.test']);
 
   for (const entry of entries) {
     if (entry.name.startsWith('.') && !SCAN_DOTFILES.has(entry.name)) continue;


### PR DESCRIPTION
## Problem
Found by the opena2a-cli 0.10.8 fresh-user release test: `opena2a protect` and `opena2a init` flag `.env.example` as a **CRITICAL** hardcoded credential (e.g. `OPENAI_API_KEY=sk-your-key-here`). Template env files hold placeholder values by convention and are meant to be committed — per the project Secretless policy they are explicitly **not** credential surfaces. A `sk-…` placeholder is not a real exposure, so this is a noisy false positive that also drags the security score down.

## Fix
Omit template env files (`.env.example`, `.env.sample`, `.env.template`, `.env.dist`) from `SCAN_DOTFILES` in `walkFiles` (`src/util/credential-patterns.ts`). The existing "dot-name not in the allowlist is skipped" rule then excludes them — no separate name-keyed skip branch.

`TEMPLATE_ENV_FILES` is exported as the documented canonical list (shared with tests) with a "do not re-add to SCAN_DOTFILES" warning so the FP can't silently return.

Real env files (`.env`, `.env.local`, `.env.production`, …) and all source files **still scan** — genuine exposures are unaffected.

## Scope
Affects all three credential-scan consumers via the shared `walkFiles`: **`protect`, `init`, and `review`** (the latter inherits the same fix — noted because the relaxation is intentional).

## Adversarial review
A first draft added an in-loop `TEMPLATE_ENV_FILES.has(name)` skip *before* the directory branch; an adversarial review caught that it also skipped a *directory* named `.env.example` (vs scanned on main). The revised fix removes that branch, so a `.env.example/` directory is now treated like any other hidden directory (`.git`, `.vscode`) — consistent, not a new bypass. A second verifier confirmed the HIGH is resolved, the FP is fixed, and no real surface lost detection.

## Tests
- Each template name skipped even with a real-shaped placeholder; real `.env` / `.env.local` / `.env.production` still detected.
- Real `.env` in a normal subdirectory still found (guards against over-broad subtree skipping).
- `init` #116 monotonic-score test: moved the "buggy" fixture's credential from `.env.example` into `config.ts` (it was relying on the FP).
- Full cli suite green (1161).

## Notes
No republish here — rides opena2a-cli's next release (publish budget already used today). The version-split release (0.10.8) is already out.