### PR TITLE
feat(credential-patterns): name-gated AWS secret-key detection (shared pkg + protect)

### DIFF
--- a/packages/cli/__tests__/util/credential-patterns-fixture-exclusion.test.ts
+++ b/packages/cli/__tests__/util/credential-patterns-fixture-exclusion.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { quickCredentialScan, SKIP_FILENAME_PATTERNS, TEMPLATE_ENV_FILES } from '../../src/util/credential-patterns.js';
+import { quickCredentialScan, SKIP_FILENAME_PATTERNS, TEMPLATE_ENV_FILES, isPlaceholderSecretValue } from '../../src/util/credential-patterns.js';
 
 // Real-shaped placeholder credentials. These are the values that triggered
 // the 7 false positives surfaced during the 2026-04-29 `opena2a review` audit
@@ -218,6 +218,47 @@ describe('quickCredentialScan: template env files are skipped (placeholders, not
     const matches = quickCredentialScan(tmpDir);
     expect(matches.length).toBeGreaterThan(0);
     expect(matches.every(m => !m.filePath.includes('.env.example'))).toBe(true);
+  });
+});
+
+describe('name-gated AWS secret access key (CRED-005)', () => {
+  const REAL = 'abcdEFGH1234ijklMNOP5678qrstUVWX90ABcdef'; // 40-char, high-entropy
+
+  it('flags a real AWS secret keyed by name', () => {
+    write('creds.py', `aws_secret_access_key = "${REAL}"\n`);
+    const m = quickCredentialScan(tmpDir);
+    expect(m.length).toBeGreaterThan(0);
+    expect(m[0].findingId).toBe('CRED-005');
+  });
+
+  it('flags JS-SDK `secretAccessKey` and Terraform `secret_access_key` (no nearby "aws")', () => {
+    write('client.js', `const c = new AWS.S3({ secretAccessKey: "${REAL}" });\n`);
+    write('main.tf', `provider "aws" {\n  secret_access_key = "${REAL}"\n}\n`);
+    expect(quickCredentialScan(tmpDir).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('does NOT flag the AWS docs example secret (contains EXAMPLE)', () => {
+    write('docs.env', 'AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n');
+    expect(quickCredentialScan(tmpDir).filter(m => m.findingId === 'CRED-005')).toHaveLength(0);
+  });
+
+  it('does NOT flag low-entropy sentinels (40 x\'s / 40 zeros)', () => {
+    write('a.py', `aws_secret_access_key = "${'x'.repeat(40)}"\n`);
+    write('b.py', `aws_secret_access_key = "${'0'.repeat(40)}"\n`);
+    expect(quickCredentialScan(tmpDir).filter(m => m.findingId === 'CRED-005')).toHaveLength(0);
+  });
+
+  it('does NOT flag a bare 40-char blob with no credential name', () => {
+    write('blob.js', `const data = "${REAL}";\n`);
+    expect(quickCredentialScan(tmpDir).filter(m => m.findingId === 'CRED-005')).toHaveLength(0);
+  });
+
+  it('isPlaceholderSecretValue: catches EXAMPLE/sentinel, passes real keys', () => {
+    expect(isPlaceholderSecretValue('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY')).toBe(true);
+    expect(isPlaceholderSecretValue('x'.repeat(40))).toBe(true);
+    expect(isPlaceholderSecretValue('0'.repeat(40))).toBe(true);
+    expect(isPlaceholderSecretValue('YOUR_SECRET_KEY_HERE')).toBe(true);
+    expect(isPlaceholderSecretValue(REAL)).toBe(false);
   });
 });
 

--- a/packages/cli/src/commands/protect.ts
+++ b/packages/cli/src/commands/protect.ts
@@ -139,6 +139,7 @@ import {
   SKIP_DIRS,
   SKIP_EXTENSIONS,
   walkFiles,
+  isPlaceholderSecretValue,
   type CredentialPattern,
   type CredentialMatch,
 } from '../util/credential-patterns.js';
@@ -742,6 +743,10 @@ function scanForCredentials(targetDir: string): CredentialMatch[] {
         while ((match = re.exec(line)) !== null) {
           // For capture group patterns, use group 1; otherwise full match
           const value = match[1] ?? match[0];
+          // Name-gated patterns (e.g. AWS secret key) match a prefix-less value
+          // by name only, so drop placeholder / low-entropy values (the AWS docs
+          // `wJalr…EXAMPLEKEY`, `xxxx…`) — not real exposures.
+          if (pattern.nameGated && isPlaceholderSecretValue(value)) continue;
           const dedupKey = `${value}:${filePath}`;
 
           if (seen.has(dedupKey)) continue;

--- a/packages/cli/src/util/credential-patterns.ts
+++ b/packages/cli/src/util/credential-patterns.ts
@@ -15,6 +15,13 @@ export interface CredentialPattern {
   severity: string;
   explanation: string;
   businessImpact: string;
+  /**
+   * Name-gated patterns match a prefix-less value (e.g. a 40-char AWS secret
+   * access key) only by the credential NAME, so the captured value must pass a
+   * placeholder / low-entropy check — otherwise the AWS docs example
+   * (`wJalr…EXAMPLEKEY`) and sentinels (`xxxx…`) would be flagged as real.
+   */
+  nameGated?: boolean;
 }
 
 export interface CredentialMatch {
@@ -80,9 +87,17 @@ export const CREDENTIAL_PATTERNS: CredentialPattern[] = [
   {
     id: 'CRED-005',
     title: 'AWS Secret Access Key',
-    pattern: /(?:AWS_SECRET_ACCESS_KEY|aws[_-]?secret[_-]?access[_-]?key|secretAccessKey|SecretAccessKey)\s*[:=]\s*['"]?([A-Za-z0-9+\/]{40})['"]?/g,
+    // Name-gated (the value has no prefix). Two anchors ending in `key`:
+    // `aws … secret|private … key` and the AWS-specific full phrase
+    // `secret[_ ]access[_ ]key` (covers JS-SDK `secretAccessKey` and Terraform
+    // `secret_access_key` with no nearby `aws`). The `key` token rejects
+    // `aws secretsmanager arn:` / etag FPs; value captured in group 1. The
+    // placeholder/low-entropy suppression (nameGated) drops the AWS docs
+    // example + sentinel values. Mirrors HMA's canonical scanner.
+    pattern: /(?:aws.{0,16}(?:secret|private).{0,16}key|secret[_\s.-]?access[_\s.-]?key)["'\s]*[:=]+>?\s*['"]?([A-Za-z0-9+/]{40})(?![A-Za-z0-9+/])/gi,
     envVarPrefix: 'AWS_SECRET_ACCESS_KEY',
     severity: 'critical',
+    nameGated: true,
     explanation: 'AWS Secret Access Key hardcoded in source. Combined with an Access Key ID, this grants full programmatic AWS access to all authorized services.',
     businessImpact: 'Full AWS API access. Migrate to environment variables and rotate the key pair immediately.',
   },
@@ -155,6 +170,23 @@ export const SKIP_FILENAME_PATTERNS: RegExp[] = [
 export const TEMPLATE_ENV_FILES = new Set([
   '.env.example', '.env.sample', '.env.template', '.env.dist',
 ]);
+
+/**
+ * True when a name-gated credential value is a placeholder/sentinel rather than
+ * a real secret. Used for prefix-less patterns (e.g. AWS secret access key)
+ * where the value alone can't be trusted: catches the AWS docs example
+ * (`wJalr…EXAMPLEKEY`), `YOUR_…`/`REPLACE_ME` templates, and low-entropy fillers
+ * (`xxxx…`, `0000…`). A real 40-char base64 key has ~30+ distinct chars, far
+ * above the entropy floor, so this never suppresses a genuine key.
+ */
+export function isPlaceholderSecretValue(value: string): boolean {
+  if (/FAKE|EXAMPLE|PLACEHOLDER|DUMMY|YOUR[_-]?(?:KEY|SECRET|TOKEN)|REPLACE[_-]?ME|INSERT[_-]?HERE|SAMPLE|CHANGE[_-]?ME|TEST[_-]?(?:KEY|SECRET)/i.test(value)) {
+    return true;
+  }
+  // Low-entropy fillers (40 `x`s, 40 `0`s, repeated short runs).
+  if (new Set(value).size <= 6) return true;
+  return false;
+}
 
 const CASE_INSENSITIVE_FS = process.platform === 'darwin' || process.platform === 'win32';
 
@@ -280,6 +312,10 @@ export function quickCredentialScan(targetDir: string): CredentialMatch[] {
         let match: RegExpExecArray | null;
         while ((match = re.exec(line)) !== null) {
           const value = match[1] ?? match[0];
+          // Name-gated patterns match a prefix-less value purely by name, so a
+          // placeholder / low-entropy value (AWS docs `wJalr…EXAMPLEKEY`,
+          // `xxxx…`, `0000…`) must be dropped — it's not a real exposure.
+          if (pattern.nameGated && isPlaceholderSecretValue(value)) continue;
           const dedupKey = `${value}:${filePath}`;
 
           if (seen.has(dedupKey)) continue;

--- a/packages/credential-patterns/src/patterns.test.ts
+++ b/packages/credential-patterns/src/patterns.test.ts
@@ -60,6 +60,22 @@ const PATTERN_TEST_CASES: Record<string, { valid: string[]; invalid: string[] }>
     valid: ['ASIAIOSFODNN7EXAMPLE'],
     invalid: ['ASIA123', 'BSIAIOSFODNN7EXAMPLE'],
   },
+  'aws-secret': {
+    // Name-gated: a 40-char value matches only when an `aws…secret…key` /
+    // `secret_access_key` name precedes it (lookbehind). match[0] is the value.
+    valid: [
+      'AWS_SECRET_ACCESS_KEY=' + 'a'.repeat(40),
+      'aws_secret_access_key = "' + 'b'.repeat(40) + '"',
+      'secretAccessKey: "' + 'c'.repeat(40) + '"',          // JS SDK, no "aws"
+      'secret_access_key = "' + 'd'.repeat(40) + '"',        // Terraform
+    ],
+    invalid: [
+      'e'.repeat(40),                                        // bare 40-char, no name
+      'aws_secret_access_key = "tooShort"',                  // value not 40 chars
+      'aws secretsmanager arn: ' + 'f'.repeat(40),           // no "key" token
+      'session_secret = "' + 'g'.repeat(40) + '"',           // no "aws", not the full phrase
+    ],
+  },
   'gcp-service-account': {
     valid: ['"type": "service_account"', '"type":"service_account"'],
     invalid: ['"type": "user_account"', '"type":"oauth"'],

--- a/packages/credential-patterns/src/patterns.ts
+++ b/packages/credential-patterns/src/patterns.ts
@@ -33,6 +33,19 @@ export const CREDENTIAL_PATTERNS: CredentialPattern[] = [
   // ── Cloud Providers (category: cloud) ─────────────────────────────────
   { id: 'aws-access', name: 'AWS Access Key', regex: /AKIA[0-9A-Z]{16}/, envPrefix: 'AWS_ACCESS_KEY_ID', category: 'cloud' },
   { id: 'aws-sts', name: 'AWS STS Temporary Key', regex: /ASIA[0-9A-Z]{16}/, envPrefix: 'AWS_ACCESS_KEY_ID', category: 'cloud' },
+  // AWS secret access key: 40-char [A-Za-z0-9/+] with NO prefix, so it must be
+  // name-gated or it floods on every base64 blob/hash. The credential NAME is
+  // matched first and the VALUE is captured in group 1 (a forward scan — a
+  // variable-width lookbehind was measured >50ms on adversarial input). Two name
+  // anchors, both ending in `key`: `aws … secret|private … key`, and the
+  // AWS-specific full phrase `secret[_ ]access[_ ]key` (catches JS-SDK
+  // `secretAccessKey` and Terraform `secret_access_key` with no nearby `aws`).
+  // The `key` token rejects `aws secretsmanager arn:` / etag false positives.
+  // Consumers that need just the value read match[1]; `.replace`-based maskers
+  // over-mask the name token (fail-safe). The `wJalr…EXAMPLEKEY` docs value
+  // (which contains EXAMPLE) and `xxx`/`example`/… placeholders are caught by
+  // PLACEHOLDER_INDICATORS, so isKnownExample suppresses them.
+  { id: 'aws-secret', name: 'AWS Secret Access Key', regex: /(?:aws.{0,16}(?:secret|private).{0,16}key|secret[_\s.-]?access[_\s.-]?key)["'\s]*[:=]+>?\s*["']?([A-Za-z0-9/+]{40})(?![A-Za-z0-9/+])/i, envPrefix: 'AWS_SECRET_ACCESS_KEY', category: 'cloud' },
   { id: 'gcp-service-account', name: 'GCP Service Account JSON', regex: /"type"\s*:\s*"service_account"/, envPrefix: 'GOOGLE_APPLICATION_CREDENTIALS', category: 'cloud' },
   { id: 'digitalocean', name: 'DigitalOcean PAT', regex: /dop_v1_[a-f0-9]{64}/, envPrefix: 'DIGITALOCEAN_TOKEN', category: 'cloud' },
   { id: 'heroku', name: 'Heroku API Key', regex: /HRKU-[a-zA-Z0-9_-]{30,}/, envPrefix: 'HEROKU_API_KEY', category: 'cloud' },


### PR DESCRIPTION
Ports the name-gated AWS secret-access-key detection from HMA (hackmyagent #229) to the other two credential-pattern impls. The scanner false-negative the user hit (ai-trust→HMA) is already fixed; this brings the shared catalog and opena2a-cli `protect`/`init` to parity.

## (A) Shared `@opena2a/credential-patterns`
- New **`aws-secret`** pattern. A 40-char `[A-Za-z0-9/+]` value has no prefix, so it's **name-gated**: `aws … secret|private … key` OR the AWS-specific full phrase `secret[_ ]access[_ ]key` (catches JS-SDK `secretAccessKey` and Terraform `secret_access_key` with no nearby "aws"). Value captured in group 1.
- **Forward capture-group** form, not a lookbehind: a variable-width lookbehind measured **78 ms** on the package's `<50 ms` ReDoS perf test. `match[0]` includes the name; consumers needing the value read `match[1]`; `.replace`-based maskers over-mask the name token (fail-safe).
- No `match.ts` change: the `wJalr…EXAMPLEKEY` docs value is in `KNOWN_EXAMPLE_KEYS` and `xxx`/`example`/… are in `PLACEHOLDER_INDICATORS`, so `isKnownExample` already suppresses them.
- `patterns.test.ts` samples added; full suite 236 green (incl. the ReDoS perf test).

## (B) opena2a-cli `protect` / `init`
The existing `CRED-005` was already name-gated but (1) FP'd on the AWS docs example + `xxxx…`/`0000…` sentinels and (2) missed snake-case `secret_access_key` (no "aws").
- Broadened the anchor to the HMA form (adds Terraform parity).
- Added a `nameGated` flag + `isPlaceholderSecretValue()` (EXAMPLE/`YOUR_`/sentinel + ≤6 distinct chars — a real 40-char key has ~30+ distinct, empirically ≥19 over 2M samples), applied in **both** value-extracting loops (`quickCredentialScan` for init, protect's own `scanForCredentials`).
- `ai-config.ts` loops intentionally unpatched — they test bare MCP `env` *values* (no name context), so the name-gated pattern is inert there.

## Verification
- `opena2a protect`: AWS docs example + 40-x/40-zero sentinels + bare blob → **not** flagged; real key + Terraform `secret_access_key` → flagged. (was: docs example + sentinels FP'd as CRITICAL.)
- Coverage parity with HMA across `AWS_SECRET_ACCESS_KEY=`, `awsSecretKey:`, JSON `"awsSecretAccessKey":`, Terraform. ReDoS-safe (<1 ms on adversarial inputs).
- cli suite 1167 green; shared 236 green. Adversarial review: PASS, no blockers.

## Follow-ups (publish-budget gated, sequenced)
1. Republish `@opena2a/credential-patterns` (so consumers get `aws-secret`).
2. Then bump + sync **secretless**'s lockstepped local `src/patterns.ts` (byte-for-byte drift guard runs against the *installed* version — green today since 0.1.1 is still pinned).
3. In that same secretless-sync, **port the ≤6-distinct-char entropy floor into the shared `isKnownExample` (value-aware, `match[1] ?? match[0]`)** for full parity — currently the shared pattern relies on `PLACEHOLDER_INDICATORS` and would FP on low-entropy non-keyword sentinels (e.g. `0000…`, `DEADBEEF…`) that the CLI suppresses. Latent only — zero consumers have the pattern until step 1. (Per adversarial-review recommendation.)
- No republish in this PR.