### PR TITLE
release(credential-patterns): 0.1.2 — value-aware isKnownExample + entropy floor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2474,6 +2474,21 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/hackmyagent/node_modules/@opena2a/cli-ui": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.5.1.tgz",
+      "integrity": "sha512-QfiZUEQS8HIHQKthZrXSGyO4OP3t2/AhR1/YDvglkbDstg6lG2GL5/O2UjH+8PlIBRhBzSvMpJt0OuCoVVuHoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0"
+      }
+    },
+    "node_modules/hackmyagent/node_modules/@opena2a/credential-patterns": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@opena2a/credential-patterns/-/credential-patterns-0.1.1.tgz",
+      "integrity": "sha512-7yfSCcxqhgGHIEysLtBP8pEaMeY+44Y9dnhQDZTDPt/d5qFL7EDrugQHd8ysEiNYtE+U6GBmu7IGb6kO3ueyOw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/hackmyagent/node_modules/@opena2a/registry-client": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@opena2a/registry-client/-/registry-client-0.1.0.tgz",
@@ -4240,7 +4255,7 @@
     },
     "packages/credential-patterns": {
       "name": "@opena2a/credential-patterns",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/packages/credential-patterns/CHANGELOG.md
+++ b/packages/credential-patterns/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `@opena2a/credential-patterns` will be documented in this file.
 
+## 0.1.2 — 2026-06-08
+
+Name-gated AWS secret-access-key detection (ports hackmyagent's scanner rule to the shared catalog).
+
+### New pattern
+
+- **`aws-secret` (AWS Secret Access Key).** AWS secret keys are 40-char `[A-Za-z0-9/+]` values with no distinctive prefix, so a value-only regex would flood on every base64 blob/hash. This pattern is **name-gated**: it matches the 40-char value only when `aws … secret|private … key` or the AWS-specific full phrase `secret[_ ]access[_ ]key` precedes it (the latter catches JS-SDK `secretAccessKey` and Terraform `secret_access_key` with no nearby `aws`). The value is captured in group 1; `match[0]` includes the name token, so `.replace`-based maskers over-mask the name (fail-safe). A forward capture group is used rather than a lookbehind because a variable-width lookbehind exceeded the package's 50 ms ReDoS perf budget.
+
+### `isKnownExample`
+
+- **Value-aware.** Now reads the captured value (`match[1] ?? match[0]`) so the example/placeholder checks apply to the secret value of a name-gated match, not the `name = value` whole. Value-only patterns (no group 1) are unchanged.
+- **Low-entropy floor.** A name-gated value of ≥20 chars with ≤6 distinct characters (e.g. `0000…`, `DEADBEEF…`) is treated as a placeholder. A real ≥20-char secret never has so few distinct characters, so genuine keys are unaffected. The `wJalr…EXAMPLEKEY` docs secret remains covered by `KNOWN_EXAMPLE_KEYS`, and `xxx`/`example`/… by `PLACEHOLDER_INDICATORS`.
+
 ## 0.1.1 — 2026-04-30
 
 False-positive suppression release driven by `secretless-ai status` dogfooding inside the `hackmyagent` repo (4/4 reported findings were tutorial fixtures, JSDoc comments, or block-comment context that the 0.1.0 allowlist branches did not cover).

--- a/packages/credential-patterns/package.json
+++ b/packages/credential-patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/credential-patterns",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Canonical credential regex catalog and match-with-allowlist helpers for OpenA2A security tools (secretless-ai, hackmyagent).",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/credential-patterns/src/match.test.ts
+++ b/packages/credential-patterns/src/match.test.ts
@@ -362,3 +362,45 @@ describe('findRealMatch (0.1.1 — multi-real per-pattern-category coverage)', (
     });
   }
 });
+
+describe('isKnownExample — name-gated value-awareness + entropy floor (aws-secret 0.1.2)', () => {
+  const awsSecret = CREDENTIAL_PATTERNS.find(p => p.id === 'aws-secret')!;
+  const REAL = 'abcdEFGH1234ijklMNOP5678qrstUVWX90ABcdef'; // 40-char, high entropy
+  const matchOf = (line: string) =>
+    line.match(new RegExp(awsSecret.regex.source, awsSecret.regex.flags + 'g'))
+      ? [...line.matchAll(new RegExp(awsSecret.regex.source, awsSecret.regex.flags + 'g'))][0]
+      : null;
+
+  it('aws-secret pattern exists with a capturing group for the value', () => {
+    expect(awsSecret).toBeTruthy();
+    const m = matchOf(`aws_secret_access_key = "${REAL}"`);
+    expect(m?.[1]).toBe(REAL);
+  });
+
+  it('a real name-gated AWS secret is NOT a known example (findRealMatch returns it)', () => {
+    const line = `aws_secret_access_key = "${REAL}"`;
+    expect(isKnownExample(line, matchOf(line)!)).toBe(false);
+    expect(findRealMatch(line, awsSecret)).not.toBeNull();
+  });
+
+  it('the AWS docs example secret IS suppressed via the captured value (KNOWN_EXAMPLE_KEYS)', () => {
+    const line = 'AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+    expect(isKnownExample(line, matchOf(line)!)).toBe(true);
+    expect(findRealMatch(line, awsSecret)).toBeNull();
+  });
+
+  it('low-entropy sentinels (40 zeros / DEADBEEF run) are suppressed by the entropy floor', () => {
+    for (const v of ['0'.repeat(40), 'DEADBEEF'.repeat(5)]) {
+      const line = `aws_secret_access_key = "${v}"`;
+      expect(isKnownExample(line, matchOf(line)!), `value=${v}`).toBe(true);
+      expect(findRealMatch(line, awsSecret)).toBeNull();
+    }
+  });
+
+  it('value-only patterns (no group 1) are unaffected — a real AKIA key still matches', () => {
+    const akia = CREDENTIAL_PATTERNS.find(p => p.id === 'aws-access')!;
+    const line = 'AKIAREALKEY1234567890';
+    const m = line.match(akia.regex)!;
+    expect(isKnownExample(line, m)).toBe(false); // match[1] undefined -> match[0], unchanged
+  });
+});

--- a/packages/credential-patterns/src/match.ts
+++ b/packages/credential-patterns/src/match.ts
@@ -67,10 +67,20 @@ function isExampleInComment(line: string): boolean {
  * AKIAIOSFODNN7EXAMPLE.
  */
 export function isKnownExample(line: string, match: RegExpMatchArray): boolean {
-  const value = match[0];
+  // Prefer the captured value (group 1) when a pattern is name-gated — its
+  // match[0] is "name = value", so the example/placeholder checks must run on
+  // the value, not the whole match. Value-only patterns have no group 1 and
+  // fall back to match[0] unchanged.
+  const value = match[1] ?? match[0];
   if (KNOWN_EXAMPLE_KEYS.has(value)) return true;
   const lower = value.toLowerCase();
   if (PLACEHOLDER_INDICATORS.some(p => lower.includes(p))) return true;
+  // Low-entropy filler keyed by a credential name (e.g. `aws_secret_access_key
+  // = "0000…"` / `DEADBEEF…`): a real ≥20-char secret never has so few distinct
+  // characters (random base64 of a 40-char key has ~30+), so this can't suppress
+  // a genuine key. Guards name-gated patterns whose value alone can't be trusted
+  // by shape.
+  if (value.length >= 20 && new Set(value).size <= 6) return true;
   if (isLocalhostDemoConnectionString(value)) return true;
   if (isExampleInComment(line)) return true;
   return false;


### PR DESCRIPTION
Completes the name-gated AWS secret-key work (the `aws-secret` pattern shipped in #199; this is the parity fix + version bump for republish).

## Changes
- **`isKnownExample` value-aware:** reads `match[1] ?? match[0]` so example/placeholder checks run on a name-gated match's captured **value**, not the `name = value` whole. Value-only patterns (no group 1) unchanged.
- **Low-entropy floor:** a name-gated value ≥20 chars with ≤6 distinct chars (`0000…`, `DEADBEEF…`) is treated as a placeholder. Real ≥20-char secrets never have so few distinct chars (random 40-char base64 ≈30+; empirically ≥19 over 2M samples), so genuine keys are unaffected.
- Bump 0.1.1 → 0.1.2 + CHANGELOG.

## Why
Closes the parity gap the #199 adversarial review flagged: the shared `aws-secret` pattern previously relied only on `PLACEHOLDER_INDICATORS` and would FP on low-entropy non-keyword sentinels that hackmyagent (#229) and opena2a-cli (#199) already suppress.

## Tests
Shared suite **241 green**, incl. new cases: real key not suppressed, AWS docs example suppressed via the captured value, `0000…`/`DEADBEEF…` suppressed by the entropy floor, value-only patterns (AKIA) unaffected. ReDoS perf test still green.

## After merge
Tag `credential-patterns-v0.1.2` → OIDC publish. Then secretless lockstep sync (separate PR in the secretless repo): bump dep + mirror the `aws-secret` pattern and the `isKnownExample` value-aware/entropy change so its byte-for-byte + behavioral lockstep stays green.