### PR TITLE
fix(protect): route credential labels through shared @opena2a/credential-patterns catalog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4180,6 +4180,7 @@
         "@inquirer/prompts": "^7.0.0",
         "@opena2a/cli-ui": "0.5.2",
         "@opena2a/contribute": "0.1.0",
+        "@opena2a/credential-patterns": "0.1.2",
         "@opena2a/registry-client": "0.2.0",
         "@opena2a/shared": "0.1.0",
         "@opena2a/telemetry": "0.3.0",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.10.8
+
+### Fixes
+- **`protect` / `review` / `init` no longer mislabel every `sk-` credential as "OpenAI API Key".** The local catch-all pattern (`CRED-002`) matched any non-Anthropic `sk-` token and surfaced it as `OpenAI API Key` with an `OPENAI_API_KEY` env var — wrong for OpenRouter (`sk-or-v1-…`) and any future `sk-`-prefixed provider, and the generic-assignment bucket (`CRED-004`) labelled Stripe keys (`sk_live_…` / `sk_test_…`) as a generic "API Key". The displayed label and suggested env var for those two generic buckets are now routed through the canonical `@opena2a/credential-patterns` catalog, which orders specific prefixes before catch-alls, so the precise provider is recovered (Anthropic / OpenAI Project / OpenAI Legacy / OpenRouter / Stripe …). Detection is unchanged — only the label of values the scanner already flagged is refined; the deliberate "(Gemini drift risk)" / "(Bedrock drift risk)" framing on the Google/AWS patterns is preserved. The ESM-only catalog is loaded once per scan via a dynamic `import()` (this CLI is CommonJS), with a graceful fallback to the local label if it cannot be loaded. New regression test `__tests__/util/credential-label-classification.test.ts` covers `sk-ant-…`, OpenRouter, OpenAI, and Stripe `sk_live_…` / `sk_test_…` fixtures.
+
 ## 0.10.7
 
 Resolves three follow-ups surfaced by the `0.10.6` release test (#188, #189, #190). No bundled-tool version change; the `release-smoke:corpus` goldens are unchanged.

--- a/packages/cli/__tests__/benign-fp-regression.test.ts
+++ b/packages/cli/__tests__/benign-fp-regression.test.ts
@@ -53,19 +53,19 @@ describe('benign FPR regression — credential detection', () => {
     }
   });
 
-  it('b01: empty package.json — no findings', () => {
+  it('b01: empty package.json — no findings', async () => {
     const dir = fixture('b01', { 'package.json': '{}\n' });
-    expect(getHighCriticalFindings(quickCredentialScan(dir))).toEqual([]);
+    expect(getHighCriticalFindings(await quickCredentialScan(dir))).toEqual([]);
   });
 
-  it('b02: README mentions API_KEY without an actual key — no findings', () => {
+  it('b02: README mentions API_KEY without an actual key — no findings', async () => {
     const dir = fixture('b02', {
       'README.md': '# App\n\nSet `API_KEY` in your environment before running.\n',
     });
-    expect(getHighCriticalFindings(quickCredentialScan(dir))).toEqual([]);
+    expect(getHighCriticalFindings(await quickCredentialScan(dir))).toEqual([]);
   });
 
-  it('b03: .env.example with placeholder values — no findings', () => {
+  it('b03: .env.example with placeholder values — no findings', async () => {
     const dir = fixture('b03', {
       '.env.example': [
         'ANTHROPIC_API_KEY=your-key-here',
@@ -73,10 +73,10 @@ describe('benign FPR regression — credential detection', () => {
         'GITHUB_TOKEN=ghp_change_this',
       ].join('\n') + '\n',
     });
-    expect(getHighCriticalFindings(quickCredentialScan(dir))).toEqual([]);
+    expect(getHighCriticalFindings(await quickCredentialScan(dir))).toEqual([]);
   });
 
-  it('b04: code reads keys via process.env — no findings', () => {
+  it('b04: code reads keys via process.env — no findings', async () => {
     const dir = fixture('b04', {
       'app.js': [
         "const apiKey = process.env.ANTHROPIC_API_KEY;",
@@ -84,10 +84,10 @@ describe('benign FPR regression — credential detection', () => {
         "if (!apiKey) throw new Error('missing ANTHROPIC_API_KEY');",
       ].join('\n') + '\n',
     });
-    expect(getHighCriticalFindings(quickCredentialScan(dir))).toEqual([]);
+    expect(getHighCriticalFindings(await quickCredentialScan(dir))).toEqual([]);
   });
 
-  it('b05: comment showing key shape but no real key — no findings', () => {
+  it('b05: comment showing key shape but no real key — no findings', async () => {
     const dir = fixture('b05', {
       'docs.md': [
         '# How to set credentials',
@@ -96,29 +96,29 @@ describe('benign FPR regression — credential detection', () => {
         'GitHub PATs look like `ghp_...`.',
       ].join('\n') + '\n',
     });
-    expect(getHighCriticalFindings(quickCredentialScan(dir))).toEqual([]);
+    expect(getHighCriticalFindings(await quickCredentialScan(dir))).toEqual([]);
   });
 
-  it('b06: test fixture with key-shaped content under test/ — no findings (SKIP_DIRS)', () => {
+  it('b06: test fixture with key-shaped content under test/ — no findings (SKIP_DIRS)', async () => {
     const dir = fixture('b06', {
       'test/fixture.js': [
         "const fakeKey = 'sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';",
       ].join('\n') + '\n',
     });
-    expect(getHighCriticalFindings(quickCredentialScan(dir))).toEqual([]);
+    expect(getHighCriticalFindings(await quickCredentialScan(dir))).toEqual([]);
   });
 
-  it('b07: vendored content under node_modules — no findings (SKIP_DIRS)', () => {
+  it('b07: vendored content under node_modules — no findings (SKIP_DIRS)', async () => {
     const dir = fixture('b07', {
       'node_modules/sample-pkg/index.js': [
         "const example = 'AKIAIOSFODNN7EXAMPLE';",
         "module.exports = { example };",
       ].join('\n') + '\n',
     });
-    expect(getHighCriticalFindings(quickCredentialScan(dir))).toEqual([]);
+    expect(getHighCriticalFindings(await quickCredentialScan(dir))).toEqual([]);
   });
 
-  it('b08: code-block in markdown docs — no findings on shape-only example', () => {
+  it('b08: code-block in markdown docs — no findings on shape-only example', async () => {
     const dir = fixture('b08', {
       'docs/setup.md': [
         '# Setup',
@@ -129,10 +129,10 @@ describe('benign FPR regression — credential detection', () => {
         '```',
       ].join('\n') + '\n',
     });
-    expect(getHighCriticalFindings(quickCredentialScan(dir))).toEqual([]);
+    expect(getHighCriticalFindings(await quickCredentialScan(dir))).toEqual([]);
   });
 
-  it('b09: template placeholder syntax — no findings', () => {
+  it('b09: template placeholder syntax — no findings', async () => {
     const dir = fixture('b09', {
       'config.template.json': [
         '{',
@@ -141,10 +141,10 @@ describe('benign FPR regression — credential detection', () => {
         '}',
       ].join('\n') + '\n',
     });
-    expect(getHighCriticalFindings(quickCredentialScan(dir))).toEqual([]);
+    expect(getHighCriticalFindings(await quickCredentialScan(dir))).toEqual([]);
   });
 
-  it('b10: regex literal showing key shape — no findings', () => {
+  it('b10: regex literal showing key shape — no findings', async () => {
     const dir = fixture('b10', {
       'patterns.js': [
         "// match Anthropic keys",
@@ -153,14 +153,14 @@ describe('benign FPR regression — credential detection', () => {
         "const GOOGLE_KEY_RE = /AIza[0-9A-Za-z_-]{35,}/g;",
       ].join('\n') + '\n',
     });
-    expect(getHighCriticalFindings(quickCredentialScan(dir))).toEqual([]);
+    expect(getHighCriticalFindings(await quickCredentialScan(dir))).toEqual([]);
   });
 
-  it('positive control: real-shaped Anthropic key SHOULD fire (sanity check on the gate)', () => {
+  it('positive control: real-shaped Anthropic key SHOULD fire (sanity check on the gate)', async () => {
     const dir = fixture('positive', {
       'app.js': "const apiKey = 'sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';\n",
     });
-    const findings = getHighCriticalFindings(quickCredentialScan(dir));
+    const findings = getHighCriticalFindings(await quickCredentialScan(dir));
     expect(findings.length).toBeGreaterThan(0);
     expect(findings.some((f) => f.findingId === 'CRED-001')).toBe(true);
   });

--- a/packages/cli/__tests__/util/credential-label-classification.test.ts
+++ b/packages/cli/__tests__/util/credential-label-classification.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  classifyCredentialValue,
+  refineCredentialLabel,
+  loadCanonicalPatterns,
+  quickCredentialScan,
+  type CanonicalCredentialPattern,
+} from '../../src/util/credential-patterns.js';
+
+// Regression for the `opena2a protect` cosmetic bug: the local CRED-002 pattern
+// matches `sk-(?!ant-)…` and labelled EVERY non-Anthropic `sk-` token
+// "OpenAI API Key". The label is now routed through the canonical
+// `@opena2a/credential-patterns` catalog so anthropic / openai-* / openrouter /
+// stripe `sk_` are distinguished. See session-protect-credential-label-shared-catalog.
+
+// Synthetic, non-real key shapes (length-padded to satisfy the catalog regexes).
+const ANTHROPIC_KEY = 'sk-ant-api03-' + 'a'.repeat(80);
+const OPENAI_PROJ_KEY = 'sk-proj-' + 'a'.repeat(40);
+const OPENAI_LEGACY_KEY = 'sk-' + 'a'.repeat(48);
+const OPENROUTER_KEY = 'sk-or-v1-' + 'a'.repeat(48);
+const STRIPE_LIVE_KEY = 'sk_live_' + 'a'.repeat(24);
+const STRIPE_TEST_KEY = 'sk_test_' + 'a'.repeat(24);
+
+let catalog: CanonicalCredentialPattern[];
+
+beforeAll(async () => {
+  catalog = await loadCanonicalPatterns();
+});
+
+describe('classifyCredentialValue', () => {
+  it('loads a non-empty canonical catalog', () => {
+    expect(catalog.length).toBeGreaterThan(0);
+  });
+
+  it('labels an Anthropic key as Anthropic, not OpenAI', async () => {
+    expect(classifyCredentialValue(ANTHROPIC_KEY, catalog)).toEqual({
+      title: 'Anthropic API Key',
+      envVarPrefix: 'ANTHROPIC_API_KEY',
+    });
+  });
+
+  it('labels an OpenAI project key as OpenAI', async () => {
+    expect(classifyCredentialValue(OPENAI_PROJ_KEY, catalog)).toEqual({
+      title: 'OpenAI Project Key',
+      envVarPrefix: 'OPENAI_API_KEY',
+    });
+  });
+
+  it('labels a legacy OpenAI key as OpenAI', async () => {
+    expect(classifyCredentialValue(OPENAI_LEGACY_KEY, catalog)).toEqual({
+      title: 'OpenAI Legacy Key',
+      envVarPrefix: 'OPENAI_API_KEY',
+    });
+  });
+
+  it('labels an OpenRouter key as OpenRouter (not OpenAI)', async () => {
+    expect(classifyCredentialValue(OPENROUTER_KEY, catalog)).toEqual({
+      title: 'OpenRouter API Key',
+      envVarPrefix: 'OPENROUTER_API_KEY',
+    });
+  });
+
+  it('labels a Stripe live key as Stripe (not OpenAI)', async () => {
+    expect(classifyCredentialValue(STRIPE_LIVE_KEY, catalog)).toEqual({
+      title: 'Stripe Live Key',
+      envVarPrefix: 'STRIPE_SECRET_KEY',
+    });
+  });
+
+  it('labels a Stripe test key as Stripe (not OpenAI)', async () => {
+    expect(classifyCredentialValue(STRIPE_TEST_KEY, catalog)).toEqual({
+      title: 'Stripe Test Key',
+      envVarPrefix: 'STRIPE_SECRET_KEY',
+    });
+  });
+
+  it('returns null for an unrecognised value', () => {
+    expect(classifyCredentialValue('not-a-credential-12345', catalog)).toBeNull();
+  });
+});
+
+describe('refineCredentialLabel', () => {
+  const fallback = { title: 'OpenAI API Key', envVarPrefix: 'OPENAI_API_KEY' };
+
+  it('refines the CRED-002 catch-all to the precise provider', () => {
+    expect(refineCredentialLabel('CRED-002', OPENROUTER_KEY, fallback, catalog)).toEqual({
+      title: 'OpenRouter API Key',
+      envVarPrefix: 'OPENROUTER_API_KEY',
+    });
+  });
+
+  it('refines a CRED-004 generic assignment value (Stripe) to the precise provider', () => {
+    const generic = { title: 'Generic API Key in Assignment', envVarPrefix: 'API_KEY' };
+    expect(refineCredentialLabel('CRED-004', STRIPE_LIVE_KEY, generic, catalog)).toEqual({
+      title: 'Stripe Live Key',
+      envVarPrefix: 'STRIPE_SECRET_KEY',
+    });
+  });
+
+  it('keeps the local label for non-refinable specific patterns', () => {
+    // DRIFT-002 carries deliberate "(Bedrock drift risk)" framing the catalog lacks.
+    const aws = { title: 'AWS Access Key (Bedrock drift risk)', envVarPrefix: 'AWS_ACCESS_KEY_ID' };
+    expect(refineCredentialLabel('DRIFT-002', 'AKIA' + 'A'.repeat(16), aws, catalog)).toEqual(aws);
+  });
+
+  it('keeps the fallback when the value matches nothing in the catalog', () => {
+    expect(refineCredentialLabel('CRED-002', 'sk-test-short', fallback, catalog)).toEqual(fallback);
+  });
+});
+
+describe('quickCredentialScan label routing (integration)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-label-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function write(rel: string, body: string): void {
+    const abs = path.join(tmpDir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+  }
+
+  it('labels a hardcoded Anthropic key as Anthropic, not OpenAI', async () => {
+    write('config.js', `const apiKey = "${ANTHROPIC_KEY}";`);
+    const matches = await quickCredentialScan(tmpDir);
+    const m = matches.find(x => x.value === ANTHROPIC_KEY);
+    expect(m).toBeDefined();
+    expect(m!.title).toBe('Anthropic API Key');
+    expect(m!.envVar).toBe('ANTHROPIC_API_KEY');
+  });
+
+  it('labels a hardcoded Stripe key in an assignment as Stripe, not OpenAI', async () => {
+    write('billing.js', `const apiKey = "${STRIPE_LIVE_KEY}";`);
+    const matches = await quickCredentialScan(tmpDir);
+    const m = matches.find(x => x.value === STRIPE_LIVE_KEY);
+    expect(m).toBeDefined();
+    expect(m!.title).toBe('Stripe Live Key');
+    expect(m!.envVar).toBe('STRIPE_SECRET_KEY');
+  });
+
+  it('labels a hardcoded OpenRouter key as OpenRouter, not OpenAI', async () => {
+    write('llm.js', `const apiKey = "${OPENROUTER_KEY}";`);
+    const matches = await quickCredentialScan(tmpDir);
+    const m = matches.find(x => x.value === OPENROUTER_KEY);
+    expect(m).toBeDefined();
+    expect(m!.title).toBe('OpenRouter API Key');
+    expect(m!.envVar).toBe('OPENROUTER_API_KEY');
+  });
+
+  it('still labels a real OpenAI key as OpenAI', async () => {
+    write('openai.js', `const apiKey = "${OPENAI_PROJ_KEY}";`);
+    const matches = await quickCredentialScan(tmpDir);
+    const m = matches.find(x => x.value === OPENAI_PROJ_KEY);
+    expect(m).toBeDefined();
+    expect(m!.title).toMatch(/OpenAI/);
+    expect(m!.envVar).toBe('OPENAI_API_KEY');
+  });
+});

--- a/packages/cli/__tests__/util/credential-patterns-fixture-exclusion.test.ts
+++ b/packages/cli/__tests__/util/credential-patterns-fixture-exclusion.test.ts
@@ -32,24 +32,24 @@ function write(rel: string, body: string): string {
 describe('credential-patterns: SKIP_FILENAME_PATTERNS regex correctness', () => {
   const matches = (name: string) => SKIP_FILENAME_PATTERNS.some(re => re.test(name));
 
-  it('matches *.test.ts / *.test.tsx / *.test.js / *.test.jsx / *.test.mjs / *.test.cjs / *.test.py', () => {
+  it('matches *.test.ts / *.test.tsx / *.test.js / *.test.jsx / *.test.mjs / *.test.cjs / *.test.py', async () => {
     for (const ext of ['ts', 'tsx', 'js', 'jsx', 'mjs', 'cjs', 'py']) {
       expect(matches(`dlp.test.${ext}`)).toBe(true);
     }
   });
 
-  it('matches *.spec.* equivalents', () => {
+  it('matches *.spec.* equivalents', async () => {
     for (const ext of ['ts', 'tsx', 'js', 'jsx', 'mjs', 'cjs', 'py']) {
       expect(matches(`dlp.spec.${ext}`)).toBe(true);
     }
   });
 
-  it('matches Go and Python *_test conventions', () => {
+  it('matches Go and Python *_test conventions', async () => {
     expect(matches('dlp_test.go')).toBe(true);
     expect(matches('dlp_test.py')).toBe(true);
   });
 
-  it('matches demo-* scripts (sh / ts / js / py)', () => {
+  it('matches demo-* scripts (sh / ts / js / py)', async () => {
     expect(matches('demo-setup.sh')).toBe(true);
     expect(matches('demo_setup.sh')).toBe(true);
     expect(matches('demo-setup.ts')).toBe(true);
@@ -57,7 +57,7 @@ describe('credential-patterns: SKIP_FILENAME_PATTERNS regex correctness', () => 
     expect(matches('demo-setup.py')).toBe(true);
   });
 
-  it('does NOT match production source files', () => {
+  it('does NOT match production source files', async () => {
     expect(matches('dlp.ts')).toBe(false);
     expect(matches('protect.ts')).toBe(false);
     expect(matches('handler.go')).toBe(false);
@@ -65,7 +65,7 @@ describe('credential-patterns: SKIP_FILENAME_PATTERNS regex correctness', () => 
     expect(matches('setup.sh')).toBe(false);
   });
 
-  it('does NOT match files that merely contain "test" or "demo" in the middle', () => {
+  it('does NOT match files that merely contain "test" or "demo" in the middle', async () => {
     expect(matches('greatest.ts')).toBe(false);
     expect(matches('contestant.ts')).toBe(false);
     expect(matches('redemo.sh')).toBe(false);
@@ -73,73 +73,73 @@ describe('credential-patterns: SKIP_FILENAME_PATTERNS regex correctness', () => 
 });
 
 describe('quickCredentialScan: fixture/demo files are silently skipped', () => {
-  it('skips *.test.ts files alongside source (the dlp.test.ts case)', () => {
+  it('skips *.test.ts files alongside source (the dlp.test.ts case)', async () => {
     write('packages/aim-core/src/dlp/dlp.ts', 'export const x = 1;');
     write('packages/aim-core/src/dlp/dlp.test.ts',
       `const realShape = "${FIXTURE_OPENAI_KEY}";\n` +
       `const aws = "${FIXTURE_AWS_KEY}";\n` +
       `const gh = "${FIXTURE_GITHUB_TOKEN}";\n`,
     );
-    const matches = quickCredentialScan(tmpDir);
+    const matches = await quickCredentialScan(tmpDir);
     expect(matches).toHaveLength(0);
   });
 
-  it('skips *.spec.ts files alongside source', () => {
+  it('skips *.spec.ts files alongside source', async () => {
     write('src/auth/token.ts', 'export const t = 1;');
     write('src/auth/token.spec.ts', `const k = "${FIXTURE_OPENAI_KEY}";`);
-    const matches = quickCredentialScan(tmpDir);
+    const matches = await quickCredentialScan(tmpDir);
     expect(matches).toHaveLength(0);
   });
 
-  it('skips files in vhs/ directory (terminal-recording demo asset convention)', () => {
+  it('skips files in vhs/ directory (terminal-recording demo asset convention)', async () => {
     write('docs/vhs/setup-lab.sh',
       `# VHS demo recording — placeholder creds for terminal capture\n` +
       `export OPENAI_API_KEY="${FIXTURE_OPENAI_KEY}"\n` +
       `export AWS_ACCESS_KEY_ID="${FIXTURE_AWS_KEY}"\n`,
     );
-    const matches = quickCredentialScan(tmpDir);
+    const matches = await quickCredentialScan(tmpDir);
     expect(matches).toHaveLength(0);
   });
 
-  it('skips demo-*.sh scripts (the scripts/demo-setup.sh case)', () => {
+  it('skips demo-*.sh scripts (the scripts/demo-setup.sh case)', async () => {
     write('scripts/demo-setup.sh', `OPENAI_API_KEY="${FIXTURE_OPENAI_KEY}"`);
-    const matches = quickCredentialScan(tmpDir);
+    const matches = await quickCredentialScan(tmpDir);
     expect(matches).toHaveLength(0);
   });
 
-  it('skips Go _test.go files (e.g. handler_test.go)', () => {
+  it('skips Go _test.go files (e.g. handler_test.go)', async () => {
     write('cmd/api/handler_test.go', `var key = "${FIXTURE_AWS_KEY}"`);
-    const matches = quickCredentialScan(tmpDir);
+    const matches = await quickCredentialScan(tmpDir);
     expect(matches).toHaveLength(0);
   });
 
-  it('STILL detects credentials in production source files (regression guard)', () => {
+  it('STILL detects credentials in production source files (regression guard)', async () => {
     write('src/config.ts',
       `// real production code path — must NOT be skipped\n` +
       `const apiKey = "${FIXTURE_OPENAI_KEY}";\n`,
     );
-    const matches = quickCredentialScan(tmpDir);
+    const matches = await quickCredentialScan(tmpDir);
     expect(matches.length).toBeGreaterThan(0);
     expect(matches[0].findingId).toBe('CRED-002');
   });
 
-  it('STILL detects credentials in non-test shell scripts (regression guard)', () => {
+  it('STILL detects credentials in non-test shell scripts (regression guard)', async () => {
     // setup.sh (no demo- prefix) is production tooling — must keep firing
     write('scripts/setup.sh', `export OPENAI_API_KEY="${FIXTURE_OPENAI_KEY}"`);
-    const matches = quickCredentialScan(tmpDir);
+    const matches = await quickCredentialScan(tmpDir);
     expect(matches.length).toBeGreaterThan(0);
   });
 
-  it('does NOT skip a production file just because a sibling is a test file', () => {
+  it('does NOT skip a production file just because a sibling is a test file', async () => {
     write('src/auth/token.ts', `const real = "${FIXTURE_OPENAI_KEY}";`);
     write('src/auth/token.test.ts', `const fixture = "${FIXTURE_OPENAI_KEY}";`);
-    const matches = quickCredentialScan(tmpDir);
+    const matches = await quickCredentialScan(tmpDir);
     expect(matches).toHaveLength(1);
     expect(matches[0].filePath).toMatch(/token\.ts$/);
     expect(matches[0].filePath).not.toMatch(/\.test\.ts$/);
   });
 
-  it('reproduces the exact 2026-04-29 audit FP set: 7 fixtures across 3 file paths → 0 findings', () => {
+  it('reproduces the exact 2026-04-29 audit FP set: 7 fixtures across 3 file paths → 0 findings', async () => {
     // Mirrors the user's `opena2a review` self-scan output:
     //   - 3 OpenAI keys (dlp.test.ts, setup-lab.sh, demo-setup.sh)
     //   - 2 AWS keys   (dlp.test.ts, setup-lab.sh)
@@ -158,7 +158,7 @@ describe('quickCredentialScan: fixture/demo files are silently skipped', () => {
     write('scripts/demo-setup.sh',
       `export OPENAI_API_KEY="${FIXTURE_OPENAI_KEY}"\n`,
     );
-    const matches = quickCredentialScan(tmpDir);
+    const matches = await quickCredentialScan(tmpDir);
     expect(matches).toHaveLength(0);
   });
 });
@@ -172,39 +172,39 @@ describe('quickCredentialScan: template env files are skipped (placeholders, not
   const PLACEHOLDER = `OPENAI_API_KEY=${FIXTURE_OPENAI_KEY}`; // real-shaped placeholder
 
   for (const tmpl of [...TEMPLATE_ENV_FILES]) {
-    it(`skips ${tmpl} (no findings even with a real-shaped placeholder)`, () => {
+    it(`skips ${tmpl} (no findings even with a real-shaped placeholder)`, async () => {
       write(tmpl, PLACEHOLDER + '\n');
-      expect(quickCredentialScan(tmpDir)).toHaveLength(0);
+      expect(await quickCredentialScan(tmpDir)).toHaveLength(0);
     });
   }
 
-  it('STILL scans a real .env file (regression guard — that is where protect migrates from)', () => {
+  it('STILL scans a real .env file (regression guard — that is where protect migrates from)', async () => {
     write('.env', PLACEHOLDER + '\n');
-    const matches = quickCredentialScan(tmpDir);
+    const matches = await quickCredentialScan(tmpDir);
     expect(matches.length).toBeGreaterThan(0);
     expect(matches[0].findingId).toBe('CRED-002');
   });
 
-  it('STILL scans .env.local and .env.production (live env files, not templates)', () => {
+  it('STILL scans .env.local and .env.production (live env files, not templates)', async () => {
     write('.env.local', PLACEHOLDER + '\n');
     write('.env.production', PLACEHOLDER + '\n');
-    expect(quickCredentialScan(tmpDir).length).toBeGreaterThanOrEqual(2);
+    expect((await quickCredentialScan(tmpDir)).length).toBeGreaterThanOrEqual(2);
   });
 
-  it('TEMPLATE_ENV_FILES covers the four conventional template names', () => {
+  it('TEMPLATE_ENV_FILES covers the four conventional template names', async () => {
     expect([...TEMPLATE_ENV_FILES].sort()).toEqual(
       ['.env.dist', '.env.example', '.env.sample', '.env.template'],
     );
   });
 
-  it('STILL scans a real .env nested in a normal subdirectory (subtree scanning intact)', () => {
+  it('STILL scans a real .env nested in a normal subdirectory (subtree scanning intact)', async () => {
     // Guard against an over-broad skip: only template FILES are excluded, never
     // whole subtrees. A real secret in config/.env must still be found.
     write('config/.env', PLACEHOLDER + '\n');
-    expect(quickCredentialScan(tmpDir).length).toBeGreaterThan(0);
+    expect((await quickCredentialScan(tmpDir)).length).toBeGreaterThan(0);
   });
 
-  it('a DIRECTORY named .env.example is treated as a normal hidden dir (documents, does not special-case)', () => {
+  it('a DIRECTORY named .env.example is treated as a normal hidden dir (documents, does not special-case)', async () => {
     // Documents the intended behavior: because the exclusion is enforced via
     // SCAN_DOTFILES omission (not a name-keyed skip branch), a dir named like a
     // template is handled by the same rule as any other hidden directory
@@ -215,7 +215,7 @@ describe('quickCredentialScan: template env files are skipped (placeholders, not
     // and the real-.env tests. Per adversarial-review verifier feedback.
     write('.env.example/.env', PLACEHOLDER + '\n');     // inside a hidden dir → not scanned
     write('visible/.env', PLACEHOLDER + '\n');           // normal dir → scanned
-    const matches = quickCredentialScan(tmpDir);
+    const matches = await quickCredentialScan(tmpDir);
     expect(matches.length).toBeGreaterThan(0);
     expect(matches.every(m => !m.filePath.includes('.env.example'))).toBe(true);
   });
@@ -224,36 +224,36 @@ describe('quickCredentialScan: template env files are skipped (placeholders, not
 describe('name-gated AWS secret access key (CRED-005)', () => {
   const REAL = 'abcdEFGH1234ijklMNOP5678qrstUVWX90ABcdef'; // 40-char, high-entropy
 
-  it('flags a real AWS secret keyed by name', () => {
+  it('flags a real AWS secret keyed by name', async () => {
     write('creds.py', `aws_secret_access_key = "${REAL}"\n`);
-    const m = quickCredentialScan(tmpDir);
+    const m = await quickCredentialScan(tmpDir);
     expect(m.length).toBeGreaterThan(0);
     expect(m[0].findingId).toBe('CRED-005');
   });
 
-  it('flags JS-SDK `secretAccessKey` and Terraform `secret_access_key` (no nearby "aws")', () => {
+  it('flags JS-SDK `secretAccessKey` and Terraform `secret_access_key` (no nearby "aws")', async () => {
     write('client.js', `const c = new AWS.S3({ secretAccessKey: "${REAL}" });\n`);
     write('main.tf', `provider "aws" {\n  secret_access_key = "${REAL}"\n}\n`);
-    expect(quickCredentialScan(tmpDir).length).toBeGreaterThanOrEqual(2);
+    expect((await quickCredentialScan(tmpDir)).length).toBeGreaterThanOrEqual(2);
   });
 
-  it('does NOT flag the AWS docs example secret (contains EXAMPLE)', () => {
+  it('does NOT flag the AWS docs example secret (contains EXAMPLE)', async () => {
     write('docs.env', 'AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n');
-    expect(quickCredentialScan(tmpDir).filter(m => m.findingId === 'CRED-005')).toHaveLength(0);
+    expect((await quickCredentialScan(tmpDir)).filter(m => m.findingId === 'CRED-005')).toHaveLength(0);
   });
 
-  it('does NOT flag low-entropy sentinels (40 x\'s / 40 zeros)', () => {
+  it('does NOT flag low-entropy sentinels (40 x\'s / 40 zeros)', async () => {
     write('a.py', `aws_secret_access_key = "${'x'.repeat(40)}"\n`);
     write('b.py', `aws_secret_access_key = "${'0'.repeat(40)}"\n`);
-    expect(quickCredentialScan(tmpDir).filter(m => m.findingId === 'CRED-005')).toHaveLength(0);
+    expect((await quickCredentialScan(tmpDir)).filter(m => m.findingId === 'CRED-005')).toHaveLength(0);
   });
 
-  it('does NOT flag a bare 40-char blob with no credential name', () => {
+  it('does NOT flag a bare 40-char blob with no credential name', async () => {
     write('blob.js', `const data = "${REAL}";\n`);
-    expect(quickCredentialScan(tmpDir).filter(m => m.findingId === 'CRED-005')).toHaveLength(0);
+    expect((await quickCredentialScan(tmpDir)).filter(m => m.findingId === 'CRED-005')).toHaveLength(0);
   });
 
-  it('isPlaceholderSecretValue: catches EXAMPLE/sentinel, passes real keys', () => {
+  it('isPlaceholderSecretValue: catches EXAMPLE/sentinel, passes real keys', async () => {
     expect(isPlaceholderSecretValue('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY')).toBe(true);
     expect(isPlaceholderSecretValue('x'.repeat(40))).toBe(true);
     expect(isPlaceholderSecretValue('0'.repeat(40))).toBe(true);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
     "@inquirer/prompts": "^7.0.0",
     "@opena2a/cli-ui": "0.5.2",
     "@opena2a/contribute": "0.1.0",
+    "@opena2a/credential-patterns": "0.1.2",
     "@opena2a/registry-client": "0.2.0",
     "@opena2a/shared": "0.1.0",
     "@opena2a/telemetry": "0.3.0",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -132,7 +132,7 @@ export async function init(options: InitOptions): Promise<number> {
 
   // 2. Quick credential scan (source files + MCP configs)
   if (isTTY) spinner.update('Scanning for credentials...');
-  const credentialMatches = quickCredentialScan(targetDir);
+  const credentialMatches = await quickCredentialScan(targetDir);
 
   // Scan MCP config files for credentials (these are skipped by walkFiles)
   const mcpCreds = scanMcpCredentials(targetDir);

--- a/packages/cli/src/commands/protect.ts
+++ b/packages/cli/src/commands/protect.ts
@@ -140,7 +140,8 @@ import {
   SKIP_EXTENSIONS,
   walkFiles,
   isPlaceholderSecretValue,
-  type CredentialPattern,
+  refineCredentialLabel,
+  loadCanonicalPatterns,
   type CredentialMatch,
 } from '../util/credential-patterns.js';
 import {
@@ -205,7 +206,7 @@ export async function protect(options: ProtectOptions): Promise<number> {
   const spinner = new Spinner('Scanning for credentials...');
   spinner.start();
 
-  let matches = scanForCredentials(targetDir);
+  let matches = await scanForCredentials(targetDir);
 
   // Also scan MCP config files (skipped by walkFiles due to dot-file/JSON filtering)
   const mcpCreds = scanMcpCredentials(targetDir);
@@ -563,7 +564,7 @@ export async function protect(options: ProtectOptions): Promise<number> {
       spinner.start();
     }
 
-    const remainingMatches = scanForCredentials(targetDir)
+    const remainingMatches = (await scanForCredentials(targetDir))
       .filter(m => {
         // Exclude .env files from verification -- credentials are supposed to be there
         const basename = path.basename(m.filePath);
@@ -716,9 +717,11 @@ export async function protect(options: ProtectOptions): Promise<number> {
 
 // --- Scanning ---
 
-function scanForCredentials(targetDir: string): CredentialMatch[] {
+async function scanForCredentials(targetDir: string): Promise<CredentialMatch[]> {
   const matches: CredentialMatch[] = [];
   const seen = new Set<string>(); // dedup by value+file
+  // Loaded once before the walk so per-value label refinement stays synchronous.
+  const catalog = await loadCanonicalPatterns();
 
   walkFiles(targetDir, (filePath) => {
     let content: string;
@@ -755,7 +758,15 @@ function scanForCredentials(targetDir: string): CredentialMatch[] {
           // Skip if it looks like an env var reference already
           if (isEnvVarReference(line, match.index)) continue;
 
-          const envVar = deriveEnvVarName(pattern, filePath, matches);
+          // Refine the catch-all label (CRED-002/CRED-004) against the canonical
+          // `@opena2a/credential-patterns` catalog so OpenRouter (`sk-or-v1-…`) and
+          // Stripe (`sk_live_…`) aren't surfaced as "OpenAI API Key". Specific
+          // patterns (Anthropic, GitHub, AWS/Google drift) keep their local label.
+          const refined = refineCredentialLabel(pattern.id, value, {
+            title: pattern.title,
+            envVarPrefix: pattern.envVarPrefix,
+          }, catalog);
+          const envVar = deriveEnvVarName(refined.envVarPrefix, matches);
 
           matches.push({
             value,
@@ -764,7 +775,7 @@ function scanForCredentials(targetDir: string): CredentialMatch[] {
             findingId: pattern.id,
             envVar,
             severity: pattern.severity,
-            title: pattern.title,
+            title: refined.title,
             explanation: pattern.explanation,
             businessImpact: pattern.businessImpact,
           });
@@ -786,11 +797,9 @@ function isEnvVarReference(line: string, matchIndex: number): boolean {
 }
 
 function deriveEnvVarName(
-  pattern: CredentialPattern,
-  _filePath: string,
+  base: string,
   existingMatches: CredentialMatch[]
 ): string {
-  const base = pattern.envVarPrefix;
   const existing = existingMatches.filter(m => m.envVar.startsWith(base));
 
   if (existing.length === 0) return base;

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -301,7 +301,7 @@ export async function review(options: ReviewOptions): Promise<number> {
   // Phase 2: Credential Scan (reuses Phase 1 credential data)
   const phase2Start = Date.now();
   progress(2, 'Checking credentials...');
-  const credentialData = runCredentialPhase(targetDir);
+  const credentialData = await runCredentialPhase(targetDir);
   const phase2Ms = Date.now() - phase2Start;
   const credScore = computeCredentialScore(credentialData);
   const phase2Status = credentialData.totalFindings === 0 ? 'pass'
@@ -592,7 +592,7 @@ export async function review(options: ReviewOptions): Promise<number> {
 
 async function runInitPhase(targetDir: string): Promise<InitPhaseData> {
   const project = detectProject(targetDir);
-  const credentialMatches = quickCredentialScan(targetDir);
+  const credentialMatches = await quickCredentialScan(targetDir);
   const credsBySeverity: Record<string, number> = {};
   for (const m of credentialMatches) {
     credsBySeverity[m.severity] = (credsBySeverity[m.severity] || 0) + 1;
@@ -645,8 +645,8 @@ async function runInitPhase(targetDir: string): Promise<InitPhaseData> {
   };
 }
 
-function runCredentialPhase(targetDir: string): CredentialPhaseData {
-  const matches = quickCredentialScan(targetDir);
+async function runCredentialPhase(targetDir: string): Promise<CredentialPhaseData> {
+  const matches = await quickCredentialScan(targetDir);
   const bySeverity: Record<string, number> = {};
   for (const m of matches) {
     bySeverity[m.severity] = (bySeverity[m.severity] || 0) + 1;

--- a/packages/cli/src/shield/init.ts
+++ b/packages/cli/src/shield/init.ts
@@ -91,7 +91,7 @@ export async function shieldInit(options: {
   let credentialFindings = 0;
   try {
     const { quickCredentialScan } = await import('../util/credential-patterns.js');
-    const matches = quickCredentialScan(targetDir);
+    const matches = await quickCredentialScan(targetDir);
     credentialFindings = matches.length;
     if (isText) {
       if (matches.length === 0) {

--- a/packages/cli/src/util/credential-patterns.ts
+++ b/packages/cli/src/util/credential-patterns.ts
@@ -188,6 +188,96 @@ export function isPlaceholderSecretValue(value: string): boolean {
   return false;
 }
 
+/**
+ * Local finding IDs whose label is a generic/catch-all bucket and so should be
+ * refined against the canonical `@opena2a/credential-patterns` catalog:
+ *
+ *   - CRED-002 ("OpenAI API Key") matches `sk-(?!ant-)…` — a broad rule that
+ *     labels EVERY non-Anthropic `sk-` token "OpenAI API Key", which is wrong for
+ *     OpenRouter (`sk-or-v1-`) and any future `sk-`-prefixed provider.
+ *   - CRED-004 ("Generic API Key in Assignment") captures whatever sits inside
+ *     `api_key = "…"`, so the value may be a Stripe (`sk_live_…`), Slack, etc.
+ *
+ * The other local patterns are intentionally specific (Anthropic, GitHub) or
+ * carry deliberate framing the catalog lacks — DRIFT-001/002 say "(Gemini drift
+ * risk)" / "(Bedrock drift risk)" — so they are NOT refined.
+ */
+const REFINABLE_FINDING_IDS = new Set(['CRED-002', 'CRED-004']);
+
+/**
+ * Minimal shape of a `@opena2a/credential-patterns` catalog entry. Declared
+ * locally so this CommonJS module needs no static (type) import from that
+ * ESM-only package — the catalog is pulled in at runtime via a dynamic
+ * `import()` (see {@link loadCanonicalPatterns}).
+ */
+export interface CanonicalCredentialPattern {
+  id: string;
+  name: string;
+  regex: RegExp;
+  envPrefix: string;
+  category?: string;
+}
+
+/**
+ * Lazily import the canonical catalog from the ESM-only
+ * `@opena2a/credential-patterns` package. This CLI is CommonJS, so a static
+ * `import` would emit a `require()` that fails on an ESM target — the dynamic
+ * `import()` is the supported bridge. The resolved array is memoised, so the
+ * package is loaded at most once per process. On any import failure (e.g. the
+ * dependency is absent in a degraded install) it resolves to `[]`, and every
+ * caller falls back to its local label rather than crashing.
+ */
+let _canonicalPatterns: Promise<CanonicalCredentialPattern[]> | null = null;
+export function loadCanonicalPatterns(): Promise<CanonicalCredentialPattern[]> {
+  if (!_canonicalPatterns) {
+    _canonicalPatterns = import('@opena2a/credential-patterns')
+      .then(m => m.CREDENTIAL_PATTERNS as CanonicalCredentialPattern[])
+      .catch(() => []);
+  }
+  return _canonicalPatterns;
+}
+
+/**
+ * Map a raw credential value onto the canonical catalog to recover the precise
+ * provider label and env-var prefix. The catalog orders specific prefixes before
+ * catch-alls (`sk-ant-` / `sk-proj-` / `sk-or-v1-` before `sk-[48,]`; Stripe
+ * `sk_live_`/`sk_test_` are their own entries), so the FIRST entry whose regex
+ * matches the value is the correct provider.
+ *
+ * Returns null when nothing in the catalog matches — callers keep their local
+ * label. Detection is unchanged: this only relabels values the local scanner
+ * already flagged, never widens or narrows what gets flagged.
+ */
+export function classifyCredentialValue(
+  value: string,
+  catalog: CanonicalCredentialPattern[],
+): { title: string; envVarPrefix: string } | null {
+  for (const p of catalog) {
+    // The catalog regexes are non-global, but clone defensively so a stray `g`
+    // flag can't leak `lastIndex` state across calls.
+    const re = new RegExp(p.regex.source, p.regex.flags.replace('g', ''));
+    if (re.test(value)) {
+      return { title: p.name, envVarPrefix: p.envPrefix };
+    }
+  }
+  return null;
+}
+
+/**
+ * Apply {@link classifyCredentialValue} to a local match, but only for the
+ * generic/catch-all buckets in {@link REFINABLE_FINDING_IDS}. Returns the
+ * (possibly refined) `{ title, envVarPrefix }` to use for the match.
+ */
+export function refineCredentialLabel(
+  findingId: string,
+  value: string,
+  fallback: { title: string; envVarPrefix: string },
+  catalog: CanonicalCredentialPattern[],
+): { title: string; envVarPrefix: string } {
+  if (!REFINABLE_FINDING_IDS.has(findingId)) return fallback;
+  return classifyCredentialValue(value, catalog) ?? fallback;
+}
+
 const CASE_INSENSITIVE_FS = process.platform === 'darwin' || process.platform === 'win32';
 
 /**
@@ -291,9 +381,11 @@ export function walkFiles(dir: string, callback: (filePath: string) => void): vo
 
 // --- Quick scan (used by init) ---
 
-export function quickCredentialScan(targetDir: string): CredentialMatch[] {
+export async function quickCredentialScan(targetDir: string): Promise<CredentialMatch[]> {
   const matches: CredentialMatch[] = [];
   const seen = new Set<string>();
+  // Loaded once before the walk so per-value label refinement stays synchronous.
+  const catalog = await loadCanonicalPatterns();
 
   walkFiles(targetDir, (filePath) => {
     let content: string;
@@ -328,7 +420,14 @@ export function quickCredentialScan(targetDir: string): CredentialMatch[] {
             /os\.environ\[['"]?\w*$/.test(before) ||
             /getenv\(['"]?\w*$/.test(before)) continue;
 
-          const base = pattern.envVarPrefix;
+          // Refine the catch-all label (CRED-002/CRED-004) against the canonical
+          // catalog so a `sk-or-v1-…` / Stripe `sk_live_…` value isn't surfaced
+          // as "OpenAI API Key". Specific patterns keep their local label.
+          const refined = refineCredentialLabel(pattern.id, value, {
+            title: pattern.title,
+            envVarPrefix: pattern.envVarPrefix,
+          }, catalog);
+          const base = refined.envVarPrefix;
           const existing = matches.filter(m => m.envVar.startsWith(base));
           const envVar = existing.length === 0 ? base : `${base}_${existing.length + 1}`;
 
@@ -339,7 +438,7 @@ export function quickCredentialScan(targetDir: string): CredentialMatch[] {
             findingId: pattern.id,
             envVar,
             severity: pattern.severity,
-            title: pattern.title,
+            title: refined.title,
             explanation: pattern.explanation,
             businessImpact: pattern.businessImpact,
           });


### PR DESCRIPTION
## Problem

\`opena2a protect\` (and the shared \`review\`/\`init\` quick scan) labelled every non-Anthropic \`sk-\` token as **OpenAI API Key**. The local CRED-002 pattern (\`sk-(?!ant-)…\`) is a catch-all, so OpenRouter (\`sk-or-v1-…\`) and any future \`sk-\` provider were mislabelled, and the generic-assignment bucket (CRED-004) showed Stripe keys (\`sk_live_…\`/\`sk_test_…\`) as a generic "API Key".

## Fix

Route the displayed **label** (title + suggested env var) for the two generic buckets (CRED-002, CRED-004) through the canonical \`@opena2a/credential-patterns\` catalog, which orders specific prefixes before catch-alls. First matching catalog entry wins, recovering the precise provider.

- \`packages/cli/src/util/credential-patterns.ts\` — \`loadCanonicalPatterns()\` (lazy, memoised), \`classifyCredentialValue()\`, \`refineCredentialLabel()\`; applied in \`quickCredentialScan\`.
- \`packages/cli/src/commands/protect.ts\` — applied in \`scanForCredentials\`.
- \`packages/cli/package.json\` + lockfile — added \`@opena2a/credential-patterns\` (exact pin 0.1.2).
- CHANGELOG 0.10.8 entry.

### Constraints handled
- **Detection unchanged** — only the label of already-flagged values is refined (cosmetics fix, not coverage change).
- The deliberate "(Gemini drift risk)" / "(Bedrock drift risk)" framing on Google/AWS patterns is preserved (intentionally not refined).
- Catalog package is ESM-only, CLI is CommonJS — used a one-time dynamic \`import()\` per scan with graceful fallback to the local label if the package can't load.

## Verification
- New regression test \`__tests__/util/credential-label-classification.test.ts\` (sk-ant-…, OpenRouter, OpenAI proj/legacy, Stripe sk_live_/sk_test_) — passes.
- Full CLI suite: 1183 tests pass.
- Runtime smoke on built CJS dist: \`sk-or-v1-…\` → OpenRouter, \`sk-proj-…\` → OpenAI Project Key, \`sk-ant-…\` → Anthropic, \`apiKey="sk_live_…"\` → Stripe Live Key.

## Known gap (out of scope)
A bare Stripe key with no variable name (\`"sk_live_…"\` standalone) still isn't *detected* by the local patterns — only when in a generic assignment. That's a detection-coverage gap, not part of this label fix.