### PR TITLE
fix(cli): 0.10.9 scoped batch — #184 anthropic short-key + 2 release-test fixes

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,8 +1,22 @@
 # Changelog
 
-## 0.10.8
+## 0.10.9
+
+Consolidated release. `0.10.8` was published to npm from a version-bump commit that
+predated the credential-label work and six other merged PRs, so the label/prose fixes
+below ship for the first time here. Also batches three small fixes surfaced by the
+release test and the open-issue triage. Three already-fixed issues are closed against
+this release (#176 `scan-soul --explain`, #183 `attack --local` citation, #182 `check`
+reporting SAFE on hardcoded credentials). Five architectural issues (#175 composite
+verdict, #124 score representations, #111 shield event-log hardening, #130 protect/scan
+detector divergence, #191 bundled-tool help rebrand) are tracked as separate design work.
 
 ### Fixes
+- **`protect` / `review` / `init` detect a short `sk-ant-api03-` Anthropic key** ([#184](https://github.com/opena2a-org/opena2a/issues/184)). The `CRED-001` pattern required an 80+ char body, so a realistic short/fake key (`sk-ant-api03-FAKE_…`, 28 chars) was silently skipped while the OpenAI key on the very next line was flagged — an asymmetric coverage gap exactly where users expect the strongest coverage. The `sk-ant-api\d{2}-` prefix is highly specific to Anthropic, so the body floor is lowered to 20 chars (matching the OpenAI `CRED-002` floor). A bare prefix with no body is still not flagged (no false positives), and full-length production keys are unaffected. Regression tests in `__tests__/util/credential-label-classification.test.ts`.
+- **The contribute prompt no longer corrupts machine-readable output.** `check`/`review`/`detect`/`identity` wrote an interactive "Your scans help the community…" prompt to stderr after enough scans, so `opena2a check --json 2>&1 | jq` merged the banner into the parsed stream and broke it. `recordScanAndMaybePrompt` now suppresses the prompt in machine-readable mode (`--json` / `--format json|sarif` / `--ci`) and whenever stdout is not a TTY; the scan count is still recorded so the prompt fires on a later interactive run. Surfaced by the 0.10.8 fresh-user release test.
+- **`init` empty-project Verify command no longer errors.** The `ENV-DOTENV` finding (".env not in .gitignore") suggested `cat .gitignore | grep -c '.env'`, which fails with "No such file or directory" on a project that has no `.gitignore`. The Verify command is now `grep -c '\.env' .gitignore 2>/dev/null || echo 0`, which prints `0` (correctly reading as ".env not ignored") and exits cleanly when `.gitignore` is absent. New `__tests__/commands/init-verify-command.test.ts`. Surfaced by the 0.10.8 fresh-user release test.
+
+### Fixes (first shipped here — were merged after the stale 0.10.8 publish)
 - **`protect` / `review` / `init` no longer mislabel every `sk-` credential as "OpenAI API Key".** The local catch-all pattern (`CRED-002`) matched any non-Anthropic `sk-` token and surfaced it as `OpenAI API Key` with an `OPENAI_API_KEY` env var — wrong for OpenRouter (`sk-or-v1-…`) and any future `sk-`-prefixed provider, and the generic-assignment bucket (`CRED-004`) labelled Stripe keys (`sk_live_…` / `sk_test_…`) as a generic "API Key". The displayed label and suggested env var for those two generic buckets are now routed through the canonical `@opena2a/credential-patterns` catalog, which orders specific prefixes before catch-alls, so the precise provider is recovered (Anthropic / OpenAI Project / OpenAI Legacy / OpenRouter / Stripe …). Detection is unchanged — only the label of values the scanner already flagged is refined; the deliberate "(Gemini drift risk)" / "(Bedrock drift risk)" framing on the Google/AWS patterns is preserved. The ESM-only catalog is loaded once per scan via a dynamic `import()` (this CLI is CommonJS), with a graceful fallback to the local label if it cannot be loaded. New regression test `__tests__/util/credential-label-classification.test.ts` covers `sk-ant-…`, OpenRouter, OpenAI, and Stripe `sk_live_…` / `sk_test_…` fixtures.
 - **The `Why:` / `Impact:` rationale no longer contradicts a refined credential label.** When the refined `Type` named a different provider than the local pattern (e.g. `OpenRouter API Key`), the explanation still read "OpenAI API key … grants full OpenAI API access", and Stripe keys kept the generic "Generic API key found in a variable assignment" copy. `refineCredentialLabel` now also swaps to provider-neutral prose keyed off the refined title whenever the title changes, so the displayed `Why:`/`Impact:` always agree with the label (the catalog carries no prose, so neutral-but-correct is preferred over inventing provider-specific copy). Non-refined findings (Anthropic, GitHub, AWS/Google drift) keep their richer local copy verbatim. Caught by the 0.10.8 fresh-user release test.
 

--- a/packages/cli/__tests__/commands/init-verify-command.test.ts
+++ b/packages/cli/__tests__/commands/init-verify-command.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { getVerificationCommand } from '../../src/commands/init.js';
+
+// Regression for the 0.10.8 release-test P3 finding: `init` on an empty project
+// emitted an ENV-DOTENV Verify command (`cat .gitignore | grep -c '.env'`) that
+// errors when no .gitignore exists ("No such file or directory"). The Verify
+// command must be runnable on a project with no .gitignore.
+
+function finding(findingId: string) {
+  return {
+    findingId,
+    title: '.env not in .gitignore',
+    severity: 'medium',
+    count: 1,
+    explanation: '',
+    businessImpact: '',
+    locations: [],
+  };
+}
+
+describe('getVerificationCommand — ENV-DOTENV (#release-test P3)', () => {
+  it('returns a command that suppresses errors and defaults to 0', () => {
+    const cmd = getVerificationCommand(finding('ENV-DOTENV'), '/tmp');
+    expect(cmd).toBeTruthy();
+    expect(cmd).toContain('2>/dev/null');
+    expect(cmd).toContain('|| echo 0');
+    // The old fragile form piped a bare `cat .gitignore` — must be gone.
+    expect(cmd).not.toMatch(/^cat \.gitignore \| grep/);
+  });
+
+  it('the emitted command runs cleanly (exit 0) in a dir with no .gitignore', () => {
+    const cmd = getVerificationCommand(finding('ENV-DOTENV'), '/tmp')!;
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'env-dotenv-verify-'));
+    try {
+      // Should print "0" and exit 0, not throw on a missing .gitignore.
+      const out = execSync(cmd, { cwd: dir, shell: '/bin/sh', encoding: 'utf-8' });
+      expect(out.trim()).toBe('0');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('counts matches when .gitignore exists', () => {
+    const cmd = getVerificationCommand(finding('ENV-DOTENV'), '/tmp')!;
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'env-dotenv-verify-'));
+    try {
+      fs.writeFileSync(path.join(dir, '.gitignore'), '.env\nnode_modules\n');
+      const out = execSync(cmd, { cwd: dir, shell: '/bin/sh', encoding: 'utf-8' });
+      expect(Number(out.trim())).toBeGreaterThanOrEqual(1);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/__tests__/util/credential-label-classification.test.ts
+++ b/packages/cli/__tests__/util/credential-label-classification.test.ts
@@ -219,4 +219,26 @@ describe('quickCredentialScan label routing (integration)', () => {
     // CRED-001 is not refinable; its specific copy is preserved verbatim.
     expect(m!.explanation).toContain('Claude models');
   });
+
+  // Issue #184: a short sk-ant-api03- key (under the old 80-char floor) was
+  // silently skipped while the OpenAI key on the same line was flagged. The
+  // prefix is specific enough that a 20+ char body must be detected too.
+  it('detects a short sk-ant-api03- key alongside an OpenAI key (#184)', async () => {
+    const shortAnthropic = 'sk-ant-api03-FAKE_VERIFY_XYZ_NOT_REAL_KEY'; // 28-char body
+    write('.env', `ANTHROPIC_API_KEY=${shortAnthropic}\nOPENAI_API_KEY=sk-FAKE_NOT_REAL_KEY_VERIFY_XYZ\n`);
+    const matches = await quickCredentialScan(tmpDir);
+    const anth = matches.find(x => x.value === shortAnthropic);
+    expect(anth).toBeDefined();
+    expect(anth!.findingId).toBe('CRED-001');
+    expect(anth!.title).toBe('Anthropic API Key');
+    expect(anth!.envVar).toBe('ANTHROPIC_API_KEY');
+    // The OpenAI sibling is still detected (no regression).
+    expect(matches.some(x => x.findingId === 'CRED-002')).toBe(true);
+  });
+
+  it('does not flag a bare sk-ant-api03- prefix with no key body (#184 no-FP)', async () => {
+    write('doc.js', `const note = 'set the sk-ant-api03- prefix';`);
+    const matches = await quickCredentialScan(tmpDir);
+    expect(matches.some(x => x.findingId === 'CRED-001')).toBe(false);
+  });
 });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -887,7 +887,9 @@ function generateNextSteps(
 
 // --- Verification & Recommendation helpers ---
 
-function getVerificationCommand(
+// Exported for regression testing of the per-finding Verify command strings
+// (e.g. the ENV-DOTENV command must not error on a project with no .gitignore).
+export function getVerificationCommand(
   finding: GroupedFinding,
   reportDir: string,
 ): string | null {
@@ -925,7 +927,11 @@ function getVerificationCommand(
     return 'curl -s http://127.0.0.1:11434/api/tags | head -c 200';
   }
   if (finding.findingId === 'ENV-DOTENV') {
-    return "cat .gitignore | grep -c '.env'";
+    // Robust to a missing .gitignore: grep on an absent file exits non-zero and
+    // writes to stderr ("No such file"), so a bare `cat .gitignore | grep` errors
+    // on an empty/new project (issue: 0.10.8 release-test P3). Suppress the error
+    // and print 0 — which correctly reads as ".env is not ignored".
+    return "grep -c '\\.env' .gitignore 2>/dev/null || echo 0";
   }
   if (finding.findingId === 'MCP-TOOLS') {
     // Show the first MCP config file found

--- a/packages/cli/src/router.ts
+++ b/packages/cli/src/router.ts
@@ -411,7 +411,11 @@ export async function dispatchCommand(
   // Track scan count and prompt to contribute after enough scans.
   // This runs on EVERY scan so the prompt can fire when threshold is reached.
   try {
-    await recordScanAndMaybePrompt();
+    await recordScanAndMaybePrompt({
+      machineReadable: globalOptions.format === 'json'
+        || globalOptions.format === 'sarif'
+        || globalOptions.ci === true,
+    });
   } catch {
     // Non-critical -- never block on contribution failures
   }

--- a/packages/cli/src/util/credential-patterns.ts
+++ b/packages/cli/src/util/credential-patterns.ts
@@ -51,7 +51,13 @@ export const CREDENTIAL_PATTERNS: CredentialPattern[] = [
   {
     id: 'CRED-001',
     title: 'Anthropic API Key',
-    pattern: /sk-ant-api\d{2}-[A-Za-z0-9_-]{80,}/g,
+    // The `sk-ant-api\d{2}-` prefix is highly specific to Anthropic, so a 20+ char
+    // body is enough signal — matching the OpenAI floor (CRED-002 below) instead of
+    // requiring the full ~95-char production length. A shorter floor catches the
+    // realistic fake/short keys that 80+ silently skipped while OpenAI's sibling key
+    // was flagged on the same line (issue #184: asymmetric coverage). No legitimate
+    // non-credential string carries this prefix, so the lower floor adds no FPs.
+    pattern: /sk-ant-api\d{2}-[A-Za-z0-9_-]{20,}/g,
     envVarPrefix: 'ANTHROPIC_API_KEY',
     severity: 'critical',
     explanation: 'Anthropic API key hardcoded in source. Anyone who reads this file can use your Anthropic account and access Claude models.',

--- a/packages/cli/src/util/report-submission.ts
+++ b/packages/cli/src/util/report-submission.ts
@@ -261,12 +261,20 @@ export async function getRegistryUrl(): Promise<string> {
  * Only prompts after 3+ scans, and not if the user already opted in or recently
  * dismissed the prompt. This lets us demonstrate value first.
  */
-export async function recordScanAndMaybePrompt(): Promise<void> {
+export async function recordScanAndMaybePrompt(
+  opts: { machineReadable?: boolean } = {},
+): Promise<void> {
   try {
     const mod = await loadShared();
     mod.incrementScanCount();
 
-    if (mod.shouldPromptContribute()) {
+    // The contribute prompt is interactive guidance written to stderr. Never emit
+    // it in machine-readable mode (--json / --format json|sarif / --ci) or when
+    // stdout is not a TTY — otherwise a `check --json 2>&1 | jq` merges the banner
+    // into the parsed stream and breaks it (issue: 0.10.8 release-test P2). The
+    // scan count is still recorded so the prompt fires on a later interactive run.
+    const machineReadable = opts.machineReadable === true || !process.stdout.isTTY;
+    if (!machineReadable && mod.shouldPromptContribute()) {
       printContributePrompt();
       // Mark as shown so it doesn't repeat every scan
       mod.dismissContributePrompt();


### PR DESCRIPTION
Scoped batch for the **0.10.9 consolidated release**. Context: npm's `0.10.8` was published from a version-bump commit that predated the credential-label work (#201/#202) and six other merged PRs, so those fixes ship for the first time in 0.10.9. This PR adds three small fixes from the release-test + open-issue triage.

## Fixes

### #184 — short `sk-ant-api03-` Anthropic key not detected
`CRED-001` required an 80+ char body, so a realistic short/fake key (`sk-ant-api03-FAKE_…`, 28 chars) was silently skipped while the OpenAI key on the next line was flagged. The `sk-ant-api\d{2}-` prefix is Anthropic-specific, so the floor is lowered to 20 (matching the OpenAI `CRED-002` floor). Bare prefix → still no finding (no FP); full-length keys unaffected.

### release-test P2 — contribute prompt corrupts `--json`
The "Your scans help the community…" prompt was written to stderr after enough scans, so `check --json 2>&1 | jq` merged it into the parsed stream. `recordScanAndMaybePrompt` now suppresses it in machine-readable mode (`--json`/`--format json|sarif`/`--ci`) and when stdout is not a TTY. Scan count still recorded.

### release-test P3 — `init` empty-project Verify command errors
`ENV-DOTENV` suggested `cat .gitignore | grep -c '.env'`, which errors when there's no `.gitignore`. Now `grep -c '\.env' .gitignore 2>/dev/null || echo 0` — prints `0` and exits clean.

## Tests
- New regression tests for #184 (short key detected, bare prefix no-FP, OpenAI sibling still found) and the `ENV-DOTENV` Verify command (runs clean with/without `.gitignore`).
- P2 (machine-readable prompt) is runtime- + release-test-verified rather than unit-tested (forcing the prompt threshold needs a heavy `@opena2a/shared` mock; the guard is trivially correct and the fresh-user release test exercises the `--json 2>&1 | jq` path end-to-end).
- Full suite: **1192 pass**.

## Issue disposition (this release)
- **Closing (already fixed in main, verified):** #176, #183, #182.
- **Deferred to design tracks (not this release):** #175 (composite formula — needs A/B/C decision), #124 (score representations — API contract), #111 (shield event-log hardening — security design), #130 (protect/scan detector divergence — FP risk), #191 (bundled-tool help rebrand — partly upstream; absorbs the `secrets --help` leak).

The version bump (`npm version patch` → 0.10.9) is done at publish time on `main`, not in this PR (avoids the monorepo lockfile desync).