### PR TITLE
docs(check-core): document the check --json score contract (#124)

### DIFF
--- a/packages/check-core/README.md
+++ b/packages/check-core/README.md
@@ -75,6 +75,48 @@ The emission order of `buildCheckOutput` is load-bearing: the
 reorder fields without bumping to a new minor — consumers rely on stable
 shape.
 
+### `check --json` score fields — which one do I gate CI on?
+
+A found result can carry up to three score-shaped numbers on different
+scales from two sources. They are **orthogonal, not contradictory**.
+`CHECK_FIELD_GUIDE` and `checkJsonSchema` are the exported, machine-readable
+documentation of this (one entry per field, with `source`, `scale`, and
+`gating`); `check-json-schema.test.ts` keeps them consistent with the emitter.
+
+| Field(s) | Source | Scale | What it answers |
+|----------|--------|-------|-----------------|
+| `score` / `maxScore` / `findings` | local-scan | 0..100 | "Did my local static checks pass on this artifact?" |
+| `trustLevel` | registry | 0..4 ordinal | "Does the registry trust this package?" (gate here) |
+| `trustScore` | registry | 0..1 | continuous *input* to `trustLevel` — not a standalone gate |
+| `verdict` | registry | string | the word label of `trustLevel` ("blocked".."verified") |
+| `scanStatus` | registry | enum | has the registry's *server-side* scan run yet |
+
+- `score: 100` means "the local scan found nothing" — **not** a registry
+  trust verdict. A package the registry has never scanned can still read
+  `score: 100`, with `scanStatus: "pending"`. That is not a contradiction:
+  the local scan ran; the registry's has not.
+- `trustLevel` (0..4: Blocked, Warning, Listed, Scanned, Verified) is
+  derived from `trustScore` **plus hard gates** — a critical finding forces
+  Blocked, Verified additionally needs SLSA L2+, 30+ days observation, and a
+  verified signature. So a package can have `trustScore: 0.9` and still
+  `trustLevel: 0`. **Gate on `trustLevel`, not a raw `trustScore` cutoff** —
+  the cutoff would miss those hard gates. `verdict` is the same signal as
+  `trustLevel`, in words.
+- Never compare a 0..100 `score` against a 0..1 `trustScore`.
+
+```ts
+import { CHECK_FIELD_GUIDE, checkJsonSchema } from "@opena2a/check-core";
+CHECK_FIELD_GUIDE.score.gating;      // "Gate on this for 'did my local static checks pass'..."
+CHECK_FIELD_GUIDE.trustLevel.source; // "registry"
+```
+
+**1.0.0 (deferred breaking change, CHIEF-CA + CHIEF-CPO):** the flat object
+namespaces the two layers — `{ localScan: { score, maxScore, findings },
+registry: { trustScore, trustLevel, verdict, scanStatus } }`. Whether to keep
+both `verdict` and `trustLevel` is a separate 1.0.0 decision. Until then the
+wire shape is frozen for the parity contract and `CHECK_FIELD_GUIDE` is the
+contract.
+
 ## License
 
 Apache-2.0

--- a/packages/check-core/src/check-json-schema.test.ts
+++ b/packages/check-core/src/check-json-schema.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { CHECK_FIELD_GUIDE, checkJsonSchema } from "./check-json-schema.js";
+import { buildCheckOutput } from "./output.js";
+import type { ScanResult, TrustData } from "./types.js";
+import type { PackageNarrative } from "./narrative.js";
+
+/**
+ * Issue #124, UX rule 7: the machine-readable JSON schema must be
+ * documented AND self-consistent with what `buildCheckOutput` actually
+ * emits. These tests fail the moment a new field is added to the emitter
+ * without a matching entry in the field guide — so the documented
+ * contract can never silently drift from the wire format.
+ */
+describe("check-json contract", () => {
+  const fullScan: ScanResult = {
+    projectType: "mcp-server",
+    score: 100,
+    maxScore: 100,
+    findings: [],
+    version: "4.18.2",
+    analystFindings: [{ id: "x" }],
+  };
+
+  // Every optional field set, so any newly-copied field in output.ts
+  // surfaces in allEmittableKeys() and trips the drift guard (P2).
+  const fullRegistry: TrustData = {
+    found: true,
+    name: "express",
+    trustScore: 0.67,
+    trustLevel: 2,
+    verdict: "listed",
+    scanStatus: "pending",
+    packageType: "npm_package",
+    lastScannedAt: "2026-03-02T10:00:00.000Z",
+    communityScans: 12,
+    cveCount: 0,
+    recommendation: "review before adopting",
+    dependencies: { totalDeps: 3, vulnerableDeps: 0, minTrustLevel: 2 },
+  };
+
+  const narrative = {
+    schemaVersion: 1,
+    generatedAt: "2026-04-27T07:30:00.000Z",
+    generatedFrom: { artifactType: "skill", artifactVersion: "0.3.1" },
+    summary: "",
+    verdictReasoning: [],
+    nextSteps: [],
+  } as unknown as PackageNarrative;
+
+  /** Every key the emitter can produce, across all paths. */
+  function allEmittableKeys(): Set<string> {
+    const merged = buildCheckOutput({
+      name: "express",
+      type: "npm-package",
+      scan: fullScan,
+      registry: fullRegistry,
+      narrative,
+    });
+    return new Set(Object.keys(merged));
+  }
+
+  it("documents every field buildCheckOutput can emit (no undocumented drift)", () => {
+    const undocumented = [...allEmittableKeys()].filter(
+      (k) => !(k in CHECK_FIELD_GUIDE),
+    );
+    expect(undocumented).toEqual([]);
+  });
+
+  it("does not document fields the emitter never produces (no stale guide entries)", () => {
+    const emittable = allEmittableKeys();
+    const stale = Object.keys(CHECK_FIELD_GUIDE).filter((k) => !emittable.has(k));
+    expect(stale).toEqual([]);
+  });
+
+  it("documents the skill-path output shape (built outside buildCheckOutput)", () => {
+    // check-package.ts builds source:"skill" results as a bare literal that
+    // bypasses buildCheckOutput, so the buildCheckOutput drift guard above
+    // can't see it. Guard its keys here too. If the skill literal grows a
+    // field, this fails until the guide documents it.
+    const skillKeys = ["name", "type", "source"]; // mirrors check-package.ts skill branch
+    const undocumented = skillKeys.filter((k) => !(k in CHECK_FIELD_GUIDE));
+    expect(undocumented).toEqual([]);
+    // The guide's `source` field must enumerate "skill" as a valid value.
+    expect(CHECK_FIELD_GUIDE.source.scale).toContain("skill");
+  });
+
+  it("guide order matches the byte-equality emission order", () => {
+    const emittedOrder = Object.keys(
+      buildCheckOutput({
+        name: "express",
+        type: "npm-package",
+        scan: fullScan,
+        registry: fullRegistry,
+        narrative,
+      }),
+    );
+    const guideOrder = Object.keys(CHECK_FIELD_GUIDE);
+    // The guide lists fields in emission order; filtering to emitted keys
+    // must reproduce the exact wire order.
+    expect(guideOrder.filter((k) => emittedOrder.includes(k))).toEqual(emittedOrder);
+  });
+
+  it("classifies the score-shaped fields on distinct axes (issue #124 core)", () => {
+    expect(CHECK_FIELD_GUIDE.score.source).toBe("local-scan");
+    expect(CHECK_FIELD_GUIDE.trustLevel.source).toBe("registry");
+    expect(CHECK_FIELD_GUIDE.trustScore.source).toBe("registry");
+    // trustLevel is the canonical 0..4 ordinal gate; trustScore (0..1) is
+    // its continuous input, not a standalone gate.
+    expect(CHECK_FIELD_GUIDE.trustLevel.scale).toBe("0..4 ordinal");
+    expect(CHECK_FIELD_GUIDE.trustScore.scale).toBe("0..1");
+    // score and trustLevel must carry explicit gating guidance so CI
+    // consumers don't misread "score: 100" as a trust verdict, or gate on
+    // a raw trustScore threshold.
+    expect(CHECK_FIELD_GUIDE.score.gating).toBeTruthy();
+    expect(CHECK_FIELD_GUIDE.trustLevel.gating).toBeTruthy();
+    expect(CHECK_FIELD_GUIDE.trustScore.gating).toMatch(/prefer trustLevel/i);
+  });
+
+  it("every field carries a non-empty description and valid source", () => {
+    for (const [field, doc] of Object.entries(CHECK_FIELD_GUIDE)) {
+      expect(doc.description, `${field} description`).toBeTruthy();
+      expect(["meta", "local-scan", "registry"]).toContain(doc.source);
+    }
+  });
+
+  it("emits a JSON Schema whose properties match the field guide", () => {
+    expect(checkJsonSchema.type).toBe("object");
+    expect(Object.keys(checkJsonSchema.properties)).toEqual(
+      Object.keys(CHECK_FIELD_GUIDE),
+    );
+    expect(checkJsonSchema.required).toContain("name");
+    expect(checkJsonSchema.required).toContain("source");
+  });
+});

--- a/packages/check-core/src/check-json-schema.ts
+++ b/packages/check-core/src/check-json-schema.ts
@@ -1,0 +1,209 @@
+/**
+ * The documented, machine-readable contract for `check --json` output.
+ *
+ * Issue #124 surfaced that a `check --json` payload can carry three
+ * score-shaped numbers on different scales from two different sources,
+ * with no documented relationship — so a consumer cannot tell which one
+ * to gate CI on without reading source. This module IS that documentation:
+ * an exported field guide + JSON Schema, plus a drift-guard test that
+ * keeps it consistent with what `buildCheckOutput` actually emits.
+ *
+ * ## The three axes (they are orthogonal, not contradictory)
+ *
+ *   1. LOCAL-SCAN axis — `score` / `maxScore` / `findings` (and
+ *      `projectType`, `version`, `analystFindings`). These describe what
+ *      the *local static scan* measured on the fetched artifact. `score`
+ *      is 0..100 where 100 = the local scan found nothing. It is NOT a
+ *      registry trust verdict: a freshly-published package with no issues
+ *      a local scanner can see will read `score: 100` even though the
+ *      registry has never deep-scanned it.
+ *
+ *   2. REGISTRY-TRUST axis — `trustScore`, `trustLevel`, and `verdict`.
+ *      These are NOT three independent numbers, nor are they all the same
+ *      signal — the relationship is specific (verified against the
+ *      registry's `DetermineTrustLevel`, registry_trust_calculator.go):
+ *        - `trustScore` (0..1) is the continuous registry trust *input*.
+ *        - `trustLevel` (0..4 ordinal: Blocked, Warning, Listed, Scanned,
+ *          Verified) is DERIVED from `trustScore` PLUS hard gates — a
+ *          critical finding forces Blocked(0), behavioral/high-sev forces
+ *          Warning(1), and Verified(4) additionally requires SLSA L2+,
+ *          30+ days observation, and a verified signature. So a package
+ *          can have a high `trustScore` and still a low `trustLevel`.
+ *        - `verdict` is the string label of `trustLevel`
+ *          (0→"blocked", 1→"warning", 2→"listed", 3→"scanned", 4→"verified")
+ *          — the genuine redundant pair is `verdict` ↔ `trustLevel`.
+ *
+ *   3. REGISTRY-SCAN-STATE axis — `scanStatus`. Whether the *registry's*
+ *      server-side scan has run (`pending`, `completed`, `warnings`,
+ *      `failed`, …). `scanStatus: "pending"` alongside `score: 100` is
+ *      not a contradiction: the local scan ran (hence the score), the
+ *      registry's has not (hence pending).
+ *
+ * ## Which field do I gate CI on?
+ *
+ *   - "Did my local static checks pass on this artifact?" → gate on
+ *     `score` / `maxScore` (and inspect `findings`). Only meaningful when
+ *     `source === "local-scan"`.
+ *   - "Does the registry trust this package?" → gate on `trustLevel`
+ *     (or equivalently `verdict`). Prefer it over a raw `trustScore`
+ *     threshold: `trustLevel` folds in hard security gates (critical
+ *     findings, signature, SLSA, observation window) that a bare score
+ *     cutoff would miss — a package with `trustScore: 0.9` can still be
+ *     `trustLevel: 0` (Blocked) on a critical finding. Present only when
+ *     registry data was found.
+ *   - Do NOT treat `score: 100` as a trust signal, and do NOT compare a
+ *     0..100 `score` against a 0..1 `trustScore`.
+ *
+ * ## 1.0.0 migration (deferred breaking change — CHIEF-CA + CHIEF-CPO)
+ *
+ * The flat object lumps both layers together, which is the root of the
+ * ambiguity. The 1.0.0 restructure namespaces them:
+ *
+ *   { localScan: { score, maxScore, findings, … },
+ *     registry:  { trustScore, trustLevel, verdict, scanStatus, … } }
+ *
+ * Whether to keep both `verdict` and `trustLevel` (string vs ordinal of
+ * one signal) is a separate 1.0.0 decision. Until then the wire shape is
+ * frozen for the byte-equality parity contract and this guide is the contract.
+ */
+
+/** Which conceptual layer a field belongs to. */
+export type CheckFieldSource = "meta" | "local-scan" | "registry";
+
+/** Documentation for one field of the `check --json` output. */
+export interface CheckFieldDoc {
+  /** The conceptual axis this field belongs to (see module docs). */
+  source: CheckFieldSource;
+  /** Human description of what the field means. */
+  description: string;
+  /** The value's scale/domain, e.g. `"0..100"`, `"1..5 ordinal"`. */
+  scale?: string;
+  /** Whether a consumer should gate CI on this field, and for what question. */
+  gating?: string;
+}
+
+/**
+ * The canonical field guide. Every key `buildCheckOutput` can emit MUST
+ * appear here — `check-json-schema.test.ts` asserts the two never drift.
+ * Keys are listed in emission order (the byte-equality parity order).
+ */
+export const CHECK_FIELD_GUIDE: Record<string, CheckFieldDoc> = {
+  name: {
+    source: "meta",
+    description: "The package / repo / resource the check ran against.",
+  },
+  type: {
+    source: "meta",
+    description: "The kind of target checked.",
+    scale: '"npm-package" | "github-repo" | "pypi-package" | "skill"',
+  },
+  source: {
+    source: "meta",
+    description:
+      "Which path produced this result. Determines which other fields are present.",
+    scale: '"registry" | "local-scan" | "skill"',
+    gating:
+      'Branch on this first: `score` is only meaningful when source === "local-scan".',
+  },
+  projectType: {
+    source: "local-scan",
+    description: "Project type the local scanner detected (e.g. mcp-server).",
+  },
+  score: {
+    source: "local-scan",
+    description:
+      "Local static-scan result. 100 = the local scan found nothing. NOT a registry trust verdict.",
+    scale: "0..100",
+    gating:
+      'Gate on this for "did my local static checks pass". Only present when source === "local-scan".',
+  },
+  maxScore: {
+    source: "local-scan",
+    description: "Denominator for `score` (always 100 today; kept for forward-compat).",
+    scale: "0..100",
+  },
+  findings: {
+    source: "local-scan",
+    description: "Local-scan findings array. Empty when the scan found nothing.",
+  },
+  version: {
+    source: "local-scan",
+    description: "Resolved version of the scanned artifact, when known.",
+  },
+  trustLevel: {
+    source: "registry",
+    description:
+      "Canonical registry trust ordinal (Blocked, Warning, Listed, Scanned, Verified). Derived from trustScore PLUS hard gates (critical findings, behavioral violations, SLSA level, signature, observation window) — so it can be low even when trustScore is high.",
+    scale: "0..4 ordinal",
+    gating:
+      'Gate on this for "does the registry trust this package" — it folds in hard security gates a raw trustScore threshold would miss. Present only when registry data was found.',
+  },
+  trustScore: {
+    source: "registry",
+    description:
+      "Continuous registry trust score — the INPUT that (with hard gates) yields trustLevel. Not a standalone gate: a high trustScore does not imply a high trustLevel.",
+    scale: "0..1",
+    gating:
+      "Prefer trustLevel for gating. Use trustScore only for a finer-grained continuous threshold, and never alone.",
+  },
+  verdict: {
+    source: "registry",
+    description:
+      'String label of trustLevel ("blocked"/"warning"/"listed"/"scanned"/"verified") — the same signal as trustLevel, in words.',
+  },
+  scanStatus: {
+    source: "registry",
+    description:
+      "State of the registry's server-side scan (pending, completed, warnings, failed). Orthogonal to the local `score`.",
+  },
+  packageType: {
+    source: "registry",
+    description: "Registry's classification of the package.",
+  },
+  lastScannedAt: {
+    source: "registry",
+    description: "ISO timestamp of the registry's most recent scan, when available.",
+  },
+  communityScans: {
+    source: "registry",
+    description: "Count of community-contributed scans the registry has aggregated.",
+  },
+  cveCount: {
+    source: "registry",
+    description: "Number of known CVEs the registry associates with the package.",
+  },
+  analystFindings: {
+    source: "local-scan",
+    description: "Optional NanoMind analyst annotations layered on the local scan.",
+  },
+  narrative: {
+    source: "meta",
+    description:
+      "Optional rich-context narrative (skill + mcp v1). Always the last key so byte-equality holds when absent.",
+  },
+};
+
+/**
+ * JSON Schema (draft-07) for the `check --json` found-result object.
+ * Mechanically derivable from CHECK_FIELD_GUIDE — exported so machine
+ * consumers can validate payloads and read the per-field guidance from
+ * `description`.
+ */
+export const checkJsonSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  $id: "https://opena2a.org/schemas/check-json.json",
+  title: "check --json (found result)",
+  description:
+    "Output of `check <target> --json` when the target was found. Carries up to three orthogonal axes: local-scan (score/maxScore/findings), registry-trust (trustLevel/trustScore/verdict), and registry-scan-state (scanStatus). See CHECK_FIELD_GUIDE for which field to gate CI on.",
+  type: "object",
+  required: ["name", "source"],
+  additionalProperties: true,
+  properties: Object.fromEntries(
+    Object.entries(CHECK_FIELD_GUIDE).map(([field, doc]) => [
+      field,
+      {
+        description: `[${doc.source}] ${doc.description}${doc.scale ? ` (scale: ${doc.scale})` : ""}${doc.gating ? ` Gating: ${doc.gating}` : ""}`,
+      },
+    ]),
+  ),
+} as const;

--- a/packages/check-core/src/index.ts
+++ b/packages/check-core/src/index.ts
@@ -27,6 +27,13 @@ export { translateDownloadError } from "./translate-error.js";
 export { mapScanStatusForMeter } from "./scan-status.js";
 
 export {
+  CHECK_FIELD_GUIDE,
+  checkJsonSchema,
+  type CheckFieldDoc,
+  type CheckFieldSource,
+} from "./check-json-schema.js";
+
+export {
   buildCheckOutput,
   buildNotFoundOutput,
   type BuildCheckOutputInput,

--- a/packages/check-core/src/types.ts
+++ b/packages/check-core/src/types.ts
@@ -107,6 +107,21 @@ export interface CheckInput {
  * Canonical `check` output. Emitted as JSON directly by each CLI's
  * `--json` path. Matches hackmyagent's buildCheckJsonOutput order so the
  * byte-equality parity contract holds.
+ *
+ * This object can carry up to THREE orthogonal axes — do not confuse them
+ * (issue #124). The full contract, including which field to gate CI on,
+ * lives in `check-json-schema.ts` (`CHECK_FIELD_GUIDE` / `checkJsonSchema`):
+ *
+ *   - LOCAL-SCAN axis: `score`/`maxScore`/`findings` — 0..100, what the
+ *     local static scan measured. `score: 100` means "local scan found
+ *     nothing", NOT "the registry trusts this package".
+ *   - REGISTRY-TRUST axis: `trustScore` (0..1, continuous input),
+ *     `trustLevel` (0..4 ordinal, DERIVED from trustScore + hard gates —
+ *     gate on this), and `verdict` (the string label of `trustLevel`).
+ *     A high `trustScore` does not imply a high `trustLevel`.
+ *   - REGISTRY-SCAN-STATE axis: `scanStatus`. `scanStatus: "pending"` next
+ *     to `score: 100` is not a contradiction — local scan ran, registry's
+ *     server-side scan has not.
  */
 export interface CheckOutput {
   name: string;
@@ -115,14 +130,18 @@ export interface CheckOutput {
 
   /** Scan-sourced fields (present when scan data is attached). */
   projectType?: string;
+  /** Local-scan result, 0..100. NOT a registry trust verdict — see CHECK_FIELD_GUIDE. */
   score?: number;
   maxScore?: number;
   findings?: unknown[];
   version?: string;
 
   /** Registry-sourced fields (present when registry.found === true). */
+  /** Canonical registry trust ordinal (0..4: Blocked..Verified). Gate registry trust on this. */
   trustLevel?: number;
+  /** Continuous trust input (0..1) that, with hard gates, yields trustLevel. A high score ≠ a high level. */
   trustScore?: number;
+  /** String label of trustLevel ("blocked".."verified"). */
   verdict?: string;
   scanStatus?: string;
   packageType?: string;


### PR DESCRIPTION
Closes #124.

`check --json` can carry three score-shaped numbers on different scales from two sources with no documented relationship, so a consumer can't tell which to gate CI on. [CHIEF-CA] Option 1: document the contract (no wire change).

## What's added
- `CHECK_FIELD_GUIDE` + `checkJsonSchema` exports in `@opena2a/check-core` — per-field source/scale/gating across the three orthogonal axes (local-scan `score`/`maxScore`, registry-trust `trustScore`/`trustLevel`/`verdict`, registry-scan-state `scanStatus`).
- Enriched `CheckOutput` JSDoc + README three-axis model + a 1.0.0 namespacing migration note.
- `check-json-schema.test.ts` drift guard: emitter keys ⊆ guide, no stale keys, emission order, skill-path covered.

## Notes
- Adversarial review corrected a key fact: `trustLevel` is **0..4** (Blocked..Verified), NOT "1..5", and is derived from `trustScore` + hard gates — verified against the registry's `DetermineTrustLevel`. Gating guidance is on `trustLevel`/`verdict`, not a raw `trustScore` cutoff.
- No wire-shape change (byte-equality parity contract frozen until 1.0.0). No version bump (publish-time `npm version`).
- 104 tests green; HMA 98/100 on the package (one pre-existing LOW).