### PR TITLE
fix(cli): rebrand bundled-tool help/usage for import + python adapters (#191)

### DIFF
--- a/packages/cli/__tests__/adapters/format-flag.test.ts
+++ b/packages/cli/__tests__/adapters/format-flag.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { ADAPTER_REGISTRY } from '../../src/adapters/registry.js';
+
+/**
+ * issue #191: the router injects `--format <fmt>` for non-text output, but
+ * `ai-trust check` (the `registry` adapter) has no such flag and exits with
+ * "unknown option '--format'". The adapter must opt out via
+ * `acceptsFormatFlag: false` so the router skips injection (and surfaces a
+ * one-line note instead of crashing).
+ */
+describe('AdapterConfig.acceptsFormatFlag — #191 registry --json crash', () => {
+  it('registry (ai-trust check) opts out of --format injection', () => {
+    expect(ADAPTER_REGISTRY['registry'].acceptsFormatFlag).toBe(false);
+  });
+
+  it('scan (hackmyagent) keeps default --format support (does not opt out)', () => {
+    // undefined or true both mean "inject --format"; just assert it is not false,
+    // so hackmyagent's working `--format json` path is not regressed.
+    expect(ADAPTER_REGISTRY['scan'].acceptsFormatFlag).not.toBe(false);
+  });
+});

--- a/packages/cli/__tests__/adapters/import-rebrand.test.ts
+++ b/packages/cli/__tests__/adapters/import-rebrand.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { withRebrandedStdout } from '../../src/adapters/import.js';
+
+/**
+ * issue #191 (defense-in-depth): an import-adapter tool that exposes a
+ * programmatic `run`/`main` writes its Commander help straight to
+ * process.stdout, bypassing the streaming rebrander a spawned child gets.
+ * `withRebrandedStdout` intercepts those writes, line-rebrands them, and
+ * restores the original writer in `finally`.
+ */
+describe('withRebrandedStdout — programmatic-path interception', () => {
+  const original = process.stdout.write;
+  afterEach(() => {
+    process.stdout.write = original;
+  });
+
+  it('rebrands string writes emitted by the wrapped fn', async () => {
+    const spy = vi.fn().mockReturnValue(true);
+    process.stdout.write = spy as unknown as typeof process.stdout.write;
+
+    await withRebrandedStdout(async () => {
+      process.stdout.write('Usage: cryptoserve <command>\n');
+      process.stdout.write('  $ secretless-ai scan\n');
+    });
+
+    const written = spy.mock.calls.map((c) => c[0]).join('');
+    expect(written).toContain('Usage: opena2a crypto <command>');
+    expect(written).toContain('opena2a secrets scan');
+    expect(written).not.toContain('cryptoserve <command>');
+  });
+
+  it('rebrands Buffer writes too', async () => {
+    const spy = vi.fn().mockReturnValue(true);
+    process.stdout.write = spy as unknown as typeof process.stdout.write;
+
+    await withRebrandedStdout(async () => {
+      process.stdout.write(Buffer.from('hackmyagent secure\n'));
+    });
+
+    expect(spy.mock.calls.map((c) => c[0]).join('')).toContain('opena2a secure');
+  });
+
+  it('restores the original writer even when the wrapped fn throws', async () => {
+    const spy = vi.fn().mockReturnValue(true);
+    process.stdout.write = spy as unknown as typeof process.stdout.write;
+
+    await expect(
+      withRebrandedStdout(async () => {
+        process.stdout.write('cryptoserve login\n');
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    // The line written before the throw was still rebranded and emitted...
+    expect(spy.mock.calls.map((c) => c[0]).join('')).toContain('opena2a crypto login');
+
+    // ...and the patch was removed: a subsequent write is no longer rebranded
+    // (it reaches the underlying writer verbatim).
+    spy.mockClear();
+    process.stdout.write('cryptoserve login\n');
+    expect(spy).toHaveBeenCalledWith('cryptoserve login\n');
+  });
+
+  it('is non-reentrant: a nested call does not leak the patch (restores cleanly)', async () => {
+    const spy = vi.fn().mockReturnValue(true);
+    process.stdout.write = spy as unknown as typeof process.stdout.write;
+
+    await withRebrandedStdout(async () => {
+      // Inner call must NOT re-patch / capture the already-patched writer as its
+      // "original" -- doing so would restore to a patched fn and leak forever.
+      await withRebrandedStdout(async () => {
+        process.stdout.write('cryptoserve login\n');
+      });
+    });
+
+    // After both calls unwind, a fresh write is no longer rebranded -> the
+    // process-global was fully restored, not left double-patched.
+    spy.mockClear();
+    process.stdout.write('cryptoserve login\n');
+    expect(spy).toHaveBeenCalledWith('cryptoserve login\n');
+  });
+});

--- a/packages/cli/__tests__/util/rebrand.test.ts
+++ b/packages/cli/__tests__/util/rebrand.test.ts
@@ -92,3 +92,87 @@ describe('createLineRebrander (streaming, line-buffered)', () => {
     expect(r.flush()).toBe('tail without newline: opena2a registry x');
   });
 });
+
+// issue #191: import-adapter (secretless-ai) + python-adapter (cryptoserve)
+// help/usage surfaces, plus the adversarial non-citation cases that a bare
+// program-name rule would corrupt.
+describe('rebrandBundledCommands — #191 import/python surfaces', () => {
+  describe('secretless-ai (all verbs -> opena2a secrets)', () => {
+    it('rewrites verbs (bare and npx) to opena2a secrets <verb>', () => {
+      expect(rebrandBundledCommands('npx secretless-ai scan')).toBe('opena2a secrets scan');
+      expect(rebrandBundledCommands('secretless-ai init')).toBe('opena2a secrets init');
+      expect(rebrandBundledCommands('secretless-ai verify --all')).toBe('opena2a secrets verify --all');
+    });
+
+    it('keeps hyphenated subcommands intact (longest-first)', () => {
+      expect(rebrandBundledCommands('secretless-ai scan-history')).toBe('opena2a secrets scan-history');
+      expect(rebrandBundledCommands('secretless-ai clean-history')).toBe('opena2a secrets clean-history');
+    });
+  });
+
+  describe('cryptoserve (all verbs -> opena2a crypto)', () => {
+    it('rewrites verbs (bare and npx) to opena2a crypto <verb>', () => {
+      expect(rebrandBundledCommands('cryptoserve login')).toBe('opena2a crypto login');
+      expect(rebrandBundledCommands('cryptoserve scan . --push')).toBe('opena2a crypto scan . --push');
+      expect(rebrandBundledCommands('cryptoserve hash-password')).toBe('opena2a crypto hash-password');
+    });
+
+    it('rewrites the bare-program Usage line (placeholder, not a real verb)', () => {
+      expect(rebrandBundledCommands('  Usage: cryptoserve <command> [options]'))
+        .toBe('  Usage: opena2a crypto <command> [options]');
+    });
+  });
+
+  describe('hackmyagent check verb (added in #191)', () => {
+    it('rewrites check to opena2a check', () => {
+      expect(rebrandBundledCommands('$ hackmyagent check <package>')).toBe('$ opena2a check <package>');
+    });
+  });
+
+  describe('ADVERSARIAL — must NOT corrupt non-citation tool mentions', () => {
+    it('preserves a Python import statement (verbatim from cryptoserve help)', () => {
+      // `import` is not a cryptoserve CLI verb, so `cryptoserve import` never matches.
+      const code = 'from cryptoserve import CryptoServe';
+      expect(rebrandBundledCommands(code)).toBe(code);
+    });
+
+    it('preserves a class constructor reference', () => {
+      const code = 'crypto = CryptoServe(app_name="my-app")';
+      expect(rebrandBundledCommands(code)).toBe(code);
+    });
+
+    it('preserves package-install lines', () => {
+      expect(rebrandBundledCommands('npm install secretless-ai')).toBe('npm install secretless-ai');
+      expect(rebrandBundledCommands('pip install cryptoserve')).toBe('pip install cryptoserve');
+      expect(rebrandBundledCommands('npm i -g hackmyagent')).toBe('npm i -g hackmyagent');
+    });
+
+    it('preserves JS module specifiers (a quote, not a verb, follows the name)', () => {
+      const code = "import { AttackScanner } from 'hackmyagent';";
+      expect(rebrandBundledCommands(code)).toBe(code);
+      const code2 = "const sl = require('secretless-ai');";
+      expect(rebrandBundledCommands(code2)).toBe(code2);
+    });
+
+    it('preserves bare program mentions with no following verb', () => {
+      expect(rebrandBundledCommands('Powered by cryptoserve.')).toBe('Powered by cryptoserve.');
+      expect(rebrandBundledCommands('See the secretless-ai docs')).toBe('See the secretless-ai docs');
+    });
+
+    it('does NOT rewrite a tool token embedded in a larger token (left anchor)', () => {
+      // `\b` would match inside these at the `-`/`/` boundary; the lookbehind
+      // requires a true token start, so a scoped/forked name or path survives.
+      expect(rebrandBundledCommands('my-secretless-ai scan')).toBe('my-secretless-ai scan');
+      expect(rebrandBundledCommands('@myorg/secretless-ai scan')).toBe('@myorg/secretless-ai scan');
+      expect(rebrandBundledCommands('tools/cryptoserve scan')).toBe('tools/cryptoserve scan');
+      expect(rebrandBundledCommands('my-ai-trust check x')).toBe('my-ai-trust check x');
+    });
+
+    it('does NOT half-rewrite a real-but-unmapped hyphenated subcommand (right anchor)', () => {
+      // `hackmyagent check-metadata` is a real HMA verb opena2a does not expose;
+      // it must stay intact, not become the nonexistent `opena2a check-metadata`.
+      expect(rebrandBundledCommands('hackmyagent check-metadata')).toBe('hackmyagent check-metadata');
+      expect(rebrandBundledCommands('hackmyagent scan-soul')).toBe('hackmyagent scan-soul');
+    });
+  });
+});

--- a/packages/cli/src/adapters/import.ts
+++ b/packages/cli/src/adapters/import.ts
@@ -1,6 +1,61 @@
 import { resolve, join, dirname } from 'node:path';
 import { existsSync } from 'node:fs';
 import type { Adapter, AdapterConfig, RunOptions, RunResult } from './types.js';
+import { createLineRebrander } from '../util/rebrand.js';
+
+/**
+ * Run `fn` with `process.stdout.write` intercepted so the bundled tool's direct
+ * writes are rebranded to opena2a form (issue #191). Import-adapter tools that
+ * expose a programmatic `run`/`main` write their Commander help straight to
+ * process.stdout, bypassing the streaming rebrander a spawned child gets. We
+ * line-buffer through `createLineRebrander` and restore the original writer in
+ * `finally` (even on throw) so the patch can never leak past the delegated call.
+ *
+ * NOTE: the current bundled tools (hackmyagent, secretless-ai) expose no
+ * `run`/`main`, so they fall through to the SpawnAdapter path which rebrands
+ * natively. This wrapper is defense-in-depth so the fix does not silently
+ * regress if a bundled tool later adds a programmatic entry point.
+ *
+ * CONSTRAINTS:
+ *  - NON-REENTRANT: it patches a process-global. If a patch is already active
+ *    (nested/overlapping call) we run `fn` WITHOUT re-patching, so the saved
+ *    "original" can never be a still-patched writer (which would leak the patch
+ *    permanently and double-rebrand all later output).
+ *  - NOT for interactive entry points: output is line-buffered, so a no-newline
+ *    prompt (`Continue? [y/N] `) is withheld until `fn` resolves. An in-process
+ *    tool that prompts then blocks on stdin would deadlock. Only wrap
+ *    non-interactive help/scan-style programmatic APIs.
+ */
+let stdoutPatchActive = false;
+
+export async function withRebrandedStdout<T>(fn: () => Promise<T>): Promise<T> {
+  if (stdoutPatchActive) {
+    // A rebrand patch is already installed by an outer call; don't double-patch.
+    return await fn();
+  }
+  const original = process.stdout.write.bind(process.stdout);
+  const rebrander = createLineRebrander();
+  stdoutPatchActive = true;
+  // Patch only the string/Buffer signatures; preserve the original return
+  // (backpressure boolean) and any encoding/callback arguments.
+  process.stdout.write = ((chunk: unknown, ...rest: unknown[]): boolean => {
+    if (typeof chunk === 'string') {
+      return (original as (c: unknown, ...r: unknown[]) => boolean)(rebrander.push(chunk), ...rest);
+    }
+    if (Buffer.isBuffer(chunk)) {
+      return (original as (c: unknown, ...r: unknown[]) => boolean)(rebrander.push(chunk.toString()), ...rest);
+    }
+    return (original as (c: unknown, ...r: unknown[]) => boolean)(chunk, ...rest);
+  }) as typeof process.stdout.write;
+  try {
+    return await fn();
+  } finally {
+    const tail = rebrander.flush();
+    if (tail) original(tail);
+    process.stdout.write = original;
+    stdoutPatchActive = false;
+  }
+}
 
 /**
  * ImportAdapter handles workspace packages that are imported directly.
@@ -25,13 +80,16 @@ export class ImportAdapter implements Adapter {
 
       // If the module has a CLI entry point, use it
       if (typeof mod.run === 'function') {
-        const result = await mod.run(options.args, {
+        const call = () => mod.run(options.args, {
           verbose: options.verbose,
           quiet: options.quiet,
           ci: options.ci,
           format: options.format,
           cwd: options.cwd,
         });
+        const result = options.rebrand && !options.quiet
+          ? await withRebrandedStdout(call)
+          : await call();
         return {
           exitCode: result?.exitCode ?? 0,
           stdout: result?.stdout ?? '',
@@ -41,7 +99,12 @@ export class ImportAdapter implements Adapter {
 
       // If it has a main function
       if (typeof mod.main === 'function') {
-        await mod.main(options.args);
+        const call = () => mod.main(options.args);
+        if (options.rebrand && !options.quiet) {
+          await withRebrandedStdout(call);
+        } else {
+          await call();
+        }
         return { exitCode: 0, stdout: '', stderr: '' };
       }
 

--- a/packages/cli/src/adapters/python.ts
+++ b/packages/cli/src/adapters/python.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import type { Adapter, AdapterConfig, RunOptions, RunResult } from './types.js';
+import { createLineRebrander } from '../util/rebrand.js';
 
 export class PythonAdapter implements Adapter {
   readonly config: AdapterConfig;
@@ -30,11 +31,15 @@ export class PythonAdapter implements Adapter {
 
       let stdout = '';
       let stderr = '';
+      // Rebrand cryptoserve command citations (Usage lines, `cryptoserve <verb>`)
+      // to opena2a form when asked (issue #191). Line-buffered so streaming is
+      // preserved; never enabled in JSON mode (the router gates it off).
+      const rebrander = options.rebrand ? createLineRebrander() : null;
 
       child.stdout?.on('data', (data: Buffer) => {
         const chunk = data.toString();
         stdout += chunk;
-        if (!options.quiet) process.stdout.write(chunk);
+        if (!options.quiet) process.stdout.write(rebrander ? rebrander.push(chunk) : chunk);
       });
 
       child.stderr?.on('data', (data: Buffer) => {
@@ -44,10 +49,12 @@ export class PythonAdapter implements Adapter {
       });
 
       child.on('error', (err) => {
+        if (rebrander && !options.quiet) process.stdout.write(rebrander.flush());
         resolve({ exitCode: 1, stdout, stderr: stderr + err.message });
       });
 
       child.on('close', (code) => {
+        if (rebrander && !options.quiet) process.stdout.write(rebrander.flush());
         resolve({ exitCode: code ?? 1, stdout, stderr });
       });
     });

--- a/packages/cli/src/adapters/registry.ts
+++ b/packages/cli/src/adapters/registry.ts
@@ -27,6 +27,9 @@ export const ADAPTER_REGISTRY: Record<string, AdapterConfig> = {
     packageName: 'ai-trust',
     subcommand: 'check',
     description: 'Query OpenA2A Trust Registry for package security data',
+    // `ai-trust check` exposes no `--format`/`--json` option; injecting
+    // `--format json` makes it exit with "unknown option '--format'" (#191).
+    acceptsFormatFlag: false,
   },
   train: {
     name: 'train',

--- a/packages/cli/src/adapters/types.ts
+++ b/packages/cli/src/adapters/types.ts
@@ -19,6 +19,13 @@ export interface AdapterConfig {
   description: string;
   /** Commander aliases for this command (e.g. scan exposes `secure` so HMA's prefix-substituted Next Steps text resolves). */
   aliases?: string[];
+  /**
+   * Whether the bundled tool accepts a `--format <fmt>` flag for structured
+   * output. Default (undefined) = true. Set false for tools that reject it so
+   * the router does not inject `--format json` and crash the delegated call
+   * (e.g. `ai-trust check` has no `--format`/`--json` option -- issue #191).
+   */
+  acceptsFormatFlag?: boolean;
 }
 
 export interface RunOptions {

--- a/packages/cli/src/router.ts
+++ b/packages/cli/src/router.ts
@@ -372,9 +372,18 @@ export async function dispatchCommand(
     return 1;
   }
 
-  // Inject global flags into adapter args so downstream tools receive them
+  // Inject global flags into adapter args so downstream tools receive them.
+  // Skip adapters whose bundled tool rejects `--format` (e.g. ai-trust check),
+  // which would otherwise crash with "unknown option '--format'" (#191). For
+  // those, surface a one-line note so a user piping --json isn't left guessing.
   if (globalOptions.format && globalOptions.format !== 'text' && !adapterArgs.includes('--format') && !adapterArgs.includes('--json')) {
-    adapterArgs.push('--format', globalOptions.format);
+    if (adapter.config.acceptsFormatFlag === false) {
+      process.stderr.write(
+        `Note: 'opena2a ${command}' does not support ${globalOptions.format} output yet; showing text.\n`,
+      );
+    } else {
+      adapterArgs.push('--format', globalOptions.format);
+    }
   }
   if (globalOptions.deep && !adapterArgs.includes('--deep')) {
     adapterArgs.push('--deep');
@@ -394,12 +403,24 @@ export async function dispatchCommand(
   }
 
   // Rebrand bundled-tool command citations in delegated stdout to opena2a form
-  // (issue #190). Only for spawn adapters (ai-trust `registry`/`publish`) and
-  // never in JSON mode, where rewriting could corrupt machine-readable output.
-  const rebrand = adapter.config.method === 'spawn'
+  // (issues #190, #191). Applies to every adapter method that streams a bundled
+  // tool's stdout through us: spawn (ai-trust registry/publish), import
+  // (hackmyagent scan / secretless-ai secrets -- both fall through to the spawn
+  // fallback today), and python (cryptoserve crypto). Never in JSON/SARIF mode,
+  // where rewriting could corrupt machine-readable output -- and that includes a
+  // tool-native `--format json|sarif` passed straight through in adapterArgs
+  // (which never sets globalOptions.format), not just the opena2a `--json` flag.
+  const fmtIdx = adapterArgs.indexOf('--format');
+  const passthroughStructured = fmtIdx >= 0
+    && (adapterArgs[fmtIdx + 1] === 'json' || adapterArgs[fmtIdx + 1] === 'sarif');
+  const rebrandableMethod = adapter.config.method === 'spawn'
+    || adapter.config.method === 'import'
+    || adapter.config.method === 'python';
+  const rebrand = rebrandableMethod
     && globalOptions.format !== 'json'
     && globalOptions.format !== 'sarif'
-    && !adapterArgs.includes('--json');
+    && !adapterArgs.includes('--json')
+    && !passthroughStructured;
 
   const result = await adapter.run({
     args: adapterArgs,

--- a/packages/cli/src/util/rebrand.ts
+++ b/packages/cli/src/util/rebrand.ts
@@ -1,36 +1,108 @@
 /**
  * Rebrand bundled-tool command citations to their `opena2a`-prefixed form.
  *
- * opena2a-cli bundles hackmyagent / ai-trust / cryptoserve and delegates to
- * them. Those tools (and the Registry data they return) sometimes cite their
- * own binary name in next-step suggestions and usage lines. A user who
- * installed `opena2a` should be told the `opena2a` command, not a bundled
- * binary they may not know exists (issue #190; same intent as HMA_CLI_PREFIX).
+ * opena2a-cli bundles hackmyagent / secretless-ai / ai-trust / cryptoserve and
+ * delegates to them. Those tools (and the Registry data they return) cite their
+ * own binary name in usage lines, help text, and next-step suggestions. A user
+ * who installed `opena2a` should be told the `opena2a` command, not a bundled
+ * binary they may not know exists (issues #190, #191; same intent as the
+ * HMA_CLI_PREFIX / *_CLI_PREFIX env vars exported in index.ts).
  *
- * Only commands with a FAITHFUL `opena2a` equivalent are rewritten. Bundled
- * subcommands opena2a-cli does not expose 1:1 (e.g. `ai-trust audit`) are left
- * unchanged -- suggesting a command that does not resolve would be worse than
- * leaving the original. This function is pure string substitution; it never
- * touches JSON output (callers must skip it in --json mode).
+ * DESIGN — verb-anchored, never bare program names. Each rule rewrites a
+ * `<tool> <verb>` PAIR where `<verb>` is one the matching `opena2a` command
+ * forwards faithfully (the adapter passes the verb straight through, so
+ * `opena2a crypto login` really runs `cryptoserve login`). We deliberately do
+ * NOT rewrite a bare tool token, because the tool's package name legitimately
+ * appears in contexts that are NOT command citations and must survive intact:
+ *   - Python:  `from cryptoserve import CryptoServe`  (cryptoserve's own help)
+ *   - JS:      `import { x } from 'secretless-ai'`
+ *   - install: `npm install secretless-ai`, `pip install cryptoserve`
+ * Anchoring on the verb set means `cryptoserve import` / `secretless-ai'` /
+ * a trailing `cryptoserve\n` never match. Only commands with a FAITHFUL
+ * `opena2a` equivalent are rewritten; bundled subcommands opena2a-cli does not
+ * expose 1:1 (e.g. `ai-trust audit`) are left unchanged -- suggesting a command
+ * that does not resolve would be worse than leaving the original.
+ *
+ * This function is pure string substitution; it never touches JSON output
+ * (callers must skip it in --json / --format json|sarif mode).
  */
 
-// Order matters: longer / npx-prefixed forms first so they win over the
-// shorter bare forms below.
+/**
+ * hackmyagent verbs opena2a forwards faithfully. CONSERVATIVE on purpose: the
+ * `scan` adapter exposes `scan`/`secure`, and the router routes `check <pkg>`
+ * to HMA. Other HMA verbs (harden-soul, trust, detect, ...) have opena2a
+ * commands whose semantics may differ, so we do not claim them.
+ */
+const HMA_VERBS = ['secure', 'scan', 'check'] as const;
+
+/**
+ * secretless-ai verbs. The `secrets` adapter forwards args verbatim (no
+ * subcommand), so EVERY secretless-ai verb maps faithfully to
+ * `opena2a secrets <verb>`. (`broker` is also reachable as `opena2a broker`,
+ * but `opena2a secrets broker` works too, so the generic mapping is safe.)
+ */
+const SECRETLESS_VERBS = [
+  'backend', 'broker', 'cache', 'clean-history', 'clean', 'doctor', 'engine',
+  'env', 'hook', 'import', 'install', 'mcp-status', 'mcp-unprotect', 'migrate',
+  'protect-mcp', 'rules', 'run', 'scan-history', 'scan', 'scope', 'secret',
+  'setup', 'status', 'verify', 'warm', 'watch', 'init',
+] as const;
+
+/**
+ * cryptoserve verbs. The `crypto` python adapter forwards args verbatim, so
+ * every cryptoserve verb maps faithfully to `opena2a crypto <verb>`. `help` is
+ * excluded (too common a bare word; `opena2a crypto --help` is the real form).
+ */
+const CRYPTOSERVE_VERBS = [
+  'hash-password', 'backups', 'backup', 'cbom', 'certs', 'contexts', 'decrypt',
+  'deps', 'encrypt', 'gate', 'info', 'login', 'logout', 'pqc', 'promote',
+  'push', 'restore', 'scan', 'status', 'token', 'verify', 'wizard',
+] as const;
+
+/**
+ * Build a `(?:npx )?<tool> (<verb>|...)` rule whose replacement is
+ * `<prefix> $1`. Verbs are sorted longest-first so a real hyphenated verb
+ * (`scan-history`) wins over its prefix (`scan`). The optional `npx ` is
+ * consumed so the rewritten form never carries it.
+ *
+ * Two anchors keep this from corrupting non-citations:
+ *   - Left: `(?<![\w@/.-])` instead of a bare `\b`, so an EMBEDDING prefix does
+ *     not leak through. `\b` matches inside `my-secretless-ai` / `@org/cryptoserve`
+ *     / `tools/cryptoserve` (the boundary sits at the `-` or `/`), which would
+ *     rewrite a scoped/forked package name or a path. The lookbehind requires
+ *     the tool token to start at a true word/path boundary.
+ *   - Right: `(?![\w-])` after the verb, so a real-but-unmapped hyphenated
+ *     subcommand is left intact rather than half-rewritten. Without it,
+ *     `hackmyagent check-metadata` (a real HMA verb opena2a does NOT expose)
+ *     becomes the nonexistent `opena2a check-metadata`. Same discipline as the
+ *     ai-trust `check(?![\w-])` rule below.
+ */
+function buildVerbRule(
+  tool: string,
+  verbs: readonly string[],
+  prefix: string,
+): readonly [RegExp, string] {
+  const escaped = tool.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const alt = [...verbs].sort((a, b) => b.length - a.length).join('|');
+  return [new RegExp(`(?:npx )?(?<![\\w@/.-])${escaped}\\s+(${alt})(?![\\w-])`, 'g'), `${prefix} $1`];
+}
+
+// Order: verb-pair rules first, then the bare-program Usage line for tools
+// whose usage placeholder (`<command>`) is not a real verb the rules catch.
 const REBRAND_RULES: ReadonlyArray<readonly [RegExp, string]> = [
-  // hackmyagent -- scan adapter exposes both `scan` (primary) and `secure` (alias)
-  [/\bnpx hackmyagent secure\b/g, 'opena2a secure'],
-  [/\bnpx hackmyagent scan\b/g, 'opena2a scan'],
-  [/\bhackmyagent secure\b/g, 'opena2a secure'],
-  [/\bhackmyagent scan\b/g, 'opena2a scan'],
+  buildVerbRule('hackmyagent', HMA_VERBS, 'opena2a'),
+  buildVerbRule('secretless-ai', SECRETLESS_VERBS, 'opena2a secrets'),
+  buildVerbRule('cryptoserve', CRYPTOSERVE_VERBS, 'opena2a crypto'),
   // ai-trust -- registry adapter delegates to `ai-trust check`, so
   // `ai-trust check <pkg>` maps faithfully to `opena2a registry <pkg>`.
   // The `(?![\w-])` guard avoids rewriting a hyphenated subcommand we do not
   // expose (e.g. a future `ai-trust check-deps` must NOT become a nonexistent
   // `opena2a registry-deps`); leave such tokens untouched rather than break them.
-  [/\bnpx ai-trust check(?![\w-])/g, 'opena2a registry'],
-  [/\bai-trust check(?![\w-])/g, 'opena2a registry'],
-  // cryptoserve -- crypto adapter
-  [/\bnpx cryptoserve\b/g, 'opena2a crypto'],
+  [/(?:npx )?(?<![\w@/.-])ai-trust check(?![\w-])/g, 'opena2a registry'],
+  // cryptoserve's usage line cites the bare program with a `<command>`
+  // placeholder (not a real verb), so the verb rule above does not catch it.
+  // `Usage: cryptoserve <command>` -> `Usage: opena2a crypto <command>`.
+  [/\bUsage:(\s+)cryptoserve\b/g, 'Usage:$1opena2a crypto'],
 ];
 
 /** Rewrite faithful bundled-tool command citations in a string to opena2a form. */


### PR DESCRIPTION
Closes #191.

opena2a-cli delegates `scan`/`secrets` (hackmyagent / secretless-ai, import adapters) and `crypto` (cryptoserve, python adapter) to bundled tools whose `--help`/usage cited the bundled binary names verbatim (`Usage: hackmyagent secure`, `npx secretless-ai scan`, `cryptoserve login`). The streaming rebrander only ran for spawn adapters, so these surfaces leaked.

## Changes
- Enable the line-rebrander for import + python adapter methods (gated off JSON/SARIF and tool-native `--format json` passthrough). Import adapters fall through to the SpawnAdapter fallback (which already rebrands); `python.ts` gains the same wiring.
- Expand `REBRAND_RULES` with faithful `<tool> <verb>` pairs (hackmyagent check, every secretless-ai verb → `opena2a secrets <verb>`, every cryptoserve verb → `opena2a crypto <verb>`, the bare cryptoserve `Usage:` line).
- **Verb-anchored, never bare program names** (`(?<![\w@/.-])` + `(?![\w-])`), so non-citations survive intact: `from cryptoserve import CryptoServe`, `npm install secretless-ai`, `my-secretless-ai scan`, `hackmyagent check-metadata`, JS module specifiers.
- `ImportAdapter.withRebrandedStdout` covers the dormant programmatic run/main path (non-reentrant guard prevents patch leakage).
- Fix the `registry --json` crash: `ai-trust check` has no `--format`/`--json` option, so `opena2a registry <pkg> --json` exited with "unknown option '--format'". New `AdapterConfig.acceptsFormatFlag` opts the registry adapter out and surfaces a one-line note instead.

## Review
Adversarial review caught and I fixed 2 P2 regex bugs (embedding-prefix corruption + `hackmyagent check-metadata` → broken `opena2a check-metadata`) and a monkeypatch reentrancy leak. New tests cover rebrand rules incl. adversarial non-citations + both anchors, programmatic-path interception + reentrancy, and the format-flag opt-out. Full cli suite green (1209). Walkthrough: 0 leaked citations on secure/secrets/crypto help, `registry --json` no longer crashes.

## Deferred upstream (separate repos)
Native `*_CLI_PREFIX` honoring in the bundled tools' Commander programs, cryptoserve banner suppression under `--ci`/non-TTY, and `opena2a registry audit` passthrough + ai-trust JSON output.