### PR TITLE
shield: fail closed on non-absolute configguard event targets (#111)

### DIFF
--- a/packages/cli/__tests__/shield/findings-path-scoping.test.ts
+++ b/packages/cli/__tests__/shield/findings-path-scoping.test.ts
@@ -75,19 +75,52 @@ describe('filterEventsToTarget — configguard scoping', () => {
     expect(filtered).toHaveLength(1);
   });
 
-  it('keeps configguard events whose target is empty or relative (defensive — writer-side fix in #110)', () => {
-    // guard.ts no longer emits sig.filePath (relative) as the target — #110
-    // landed the fix to emit `path.join(targetDir, sig.filePath)` (absolute).
-    // The filter still cannot scope relative paths reliably, so it keeps
-    // them defensively. Any future writer that emits relative is filed as
-    // its own bug.
+  it('drops configguard events whose target is empty or relative (fail-closed — #111)', () => {
+    // Post-#110 every finding-producing configguard writer emits an absolute
+    // target. A non-absolute configguard target is a legacy or injected log
+    // line that cannot be proven in scope, so it is dropped (issue #111).
     const events = [
       makeEvent({ target: '' }),
       makeEvent({ target: 'package.json' }),
       makeEvent({ target: '.opena2a/config.yaml' }),
     ];
     const filtered = filterEventsToTarget(events, '/Users/foo/projectA');
-    expect(filtered).toHaveLength(3);
+    expect(filtered).toHaveLength(0);
+  });
+
+  it('#111: drops an injected configguard event with a relative-traversal target when scanning any directory', () => {
+    // Attacker writes a forged event to ~/.opena2a/shield/events.jsonl with a
+    // relative-traversal target to manufacture a SHIELD-INT-001 critical.
+    // The filter must drop it regardless of which directory is being scanned.
+    const injected = makeEvent({
+      source: 'configguard',
+      outcome: 'blocked',
+      action: 'tamper-detected',
+      target: '../../etc/passwd',
+    });
+    for (const scanDir of ['/Users/foo/projectA', '/tmp/empty', '.', '/']) {
+      expect(filterEventsToTarget([injected], scanDir)).toHaveLength(0);
+    }
+  });
+
+  it('#111: an injected relative-traversal configguard event does NOT classify to SHIELD-INT-001', () => {
+    // End-to-end: the forged event must not survive scoping into a critical
+    // finding. classifyEvents over the *filtered* stream must yield nothing.
+    const injected = makeEvent({
+      source: 'configguard',
+      outcome: 'blocked',
+      action: 'tamper-detected',
+      target: '../../../../etc/passwd',
+    });
+    const scoped = filterEventsToTarget([injected], '/Users/foo/projectA');
+    const findings = classifyEvents(scoped);
+    expect(findings.find(f => f.finding.id === 'SHIELD-INT-001')).toBeUndefined();
+    expect(findings).toHaveLength(0);
+  });
+
+  it('#111: a windows-style relative traversal target is also dropped', () => {
+    const injected = makeEvent({ source: 'configguard', outcome: 'blocked', target: '..\\..\\windows\\system32' });
+    expect(filterEventsToTarget([injected], '/Users/foo/projectA')).toHaveLength(0);
   });
 
   it('#110: guard.watch absolute-path events scope correctly to the scan target', () => {

--- a/packages/cli/src/shield/findings.ts
+++ b/packages/cli/src/shield/findings.ts
@@ -297,7 +297,7 @@ export function classifyEvent(event: ShieldEvent): FindingDefinition | null {
  * a configguard event whose absolute target is the scanned dir itself.
  * Defending against arbitrary forged events requires verifying the event
  * hash chain (`verifyEventChain`) at review time and excluding events past
- * a break — the deeper "Option 2" in issue #111, tracked as a follow-up.
+ * a break — the deeper "Option 2" of issue #111, tracked as issue #204.
  * The fail-closed rule below closes only the relative/non-absolute
  * configguard manufacture vector (#111 Option 1).
  *

--- a/packages/cli/src/shield/findings.ts
+++ b/packages/cli/src/shield/findings.ts
@@ -290,6 +290,17 @@ export function classifyEvent(event: ShieldEvent): FindingDefinition | null {
  * inherits 288 cross-project tamper events and the report looks broken
  * (issue #109 sub-item 1).
  *
+ * SCOPE BOUNDARY — this is a path-scoping filter, NOT a forged-log
+ * defense. It cannot stop an attacker who can write to events.jsonl from
+ * forging events under a non-configguard `source` (e.g. `source:'shield'`
+ * + `category:'integrity'` + `severity:'critical'` => SHIELD-INT-002), or
+ * a configguard event whose absolute target is the scanned dir itself.
+ * Defending against arbitrary forged events requires verifying the event
+ * hash chain (`verifyEventChain`) at review time and excluding events past
+ * a break — the deeper "Option 2" in issue #111, tracked as a follow-up.
+ * The fail-closed rule below closes only the relative/non-absolute
+ * configguard manufacture vector (#111 Option 1).
+ *
  * Scope of this filter (intentionally narrow):
  * - Only `event.source === 'configguard'` events with an absolute-path
  *   `target` are subject to scoping. Those events use `target` as the
@@ -301,10 +312,17 @@ export function classifyEvent(event: ShieldEvent): FindingDefinition | null {
  *   indicator. Filtering those by path would suppress legitimate
  *   cross-cutting findings (e.g. an ARP event for `/usr/bin/curl`
  *   spawned inside the scan target).
- * - ConfigGuard events with a non-absolute `target` (`guard watch`
- *   emits relative paths like `package.json`) are kept. They cannot
- *   be reliably scoped without writer-side changes; that's tracked
- *   as a residual issue separate from this PR.
+ * - ConfigGuard events with a non-absolute `target` are DROPPED, not
+ *   kept (symmetric scoping, fail-closed — issue #111). Post-#110 every
+ *   finding-producing configguard writer (guard.ts verify/watch) emits
+ *   an absolute target via `path.join(targetDir, sig.filePath)` with an
+ *   already-resolved `targetDir`. A non-absolute target on a configguard
+ *   event is therefore a legacy or injected/corrupted log line — e.g. an
+ *   attacker with write access to `~/.opena2a/shield/events.jsonl` can
+ *   inject `source:'configguard', outcome:'blocked', target:'../../etc/passwd'`
+ *   to manufacture a SHIELD-INT-001 critical. We cannot prove such a
+ *   target is in scope (its base directory is unknown), so we exclude it.
+ *   Same-project tampers remain visible via `guard diff` / `guard verify`.
  *
  * No filesystem I/O — `path.resolve` only consults `process.cwd()`
  * when `targetDir` is relative.
@@ -317,7 +335,9 @@ export function filterEventsToTarget(
   return events.filter(event => {
     if (event.source !== 'configguard') return true;
     const target = event.target ?? '';
-    if (!isAbsolutePathLike(target)) return true;
+    // Fail closed: a configguard event whose target is not absolute-path-like
+    // cannot be proven in-scope, so it is dropped (issue #111).
+    if (!isAbsolutePathLike(target)) return false;
     const normalizedEventTarget = path.resolve(target);
     if (normalizedEventTarget === normalizedTarget) return true;
     const rel = path.relative(normalizedTarget, normalizedEventTarget);


### PR DESCRIPTION
Closes #111 (Option 1). Follow-up Option 2 tracked in #204.

`filterEventsToTarget` kept any configguard event whose target was not absolute-path-like, on the principle it couldn't prove a relative target out of scope. That let an attacker (or corrupted log) with write access to `~/.opena2a/shield/events.jsonl` inject:

```
{ source: 'configguard', outcome: 'blocked', target: '../../etc/passwd' }
```

which passed the filter unconditionally and classified as SHIELD-INT-001 (critical), inflating the cross-target finding count the path-scoping filter exists to suppress (#109).

## Change
Flip to symmetric, fail-closed scoping: drop configguard events whose target is not absolute-path-like. Post-#110 every finding-producing configguard writer (`guard verify`/`watch`, policy, snapshot) emits an absolute target from an already-resolved `targetDir`, so this drops only legacy or injected log lines — **zero legitimate collateral** (verified against every writer). `path.resolve` collapses `..`/`.` before the scope comparison, so a relative path dressed as absolute can't escape into a false in-scope match.

## Scope boundary (→ #204)
This is a path-scoping filter, NOT a forged-log defense. A write-capable attacker can still forge an event under a non-configguard source (SHIELD-INT-002) or with the scanned dir as the absolute target. Defending against arbitrary forged events requires verifying the event hash chain (`verifyEventChain`) at review time and excluding events past a break — documented in-code as the SCOPE BOUNDARY and tracked as **#204**.

## Review
Phase 4.5 adversarial review: no CRITICAL/HIGH; detection-narrowing confirmed clean (no real finding dropped); injection path covered by tests. 28 path-scoping + 262 shield tests green. Regression tests: relative/empty/traversal targets dropped for any scan dir; injected `../../etc/passwd` does not classify to SHIELD-INT-001; in-scope tamper still fires.