### PR TITLE
fix(protect/review/init): detect catalog credential breadth via shared patterns (#130)

### DIFF
--- a/packages/cli/__tests__/util/credential-catalog-detection.test.ts
+++ b/packages/cli/__tests__/util/credential-catalog-detection.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  collectCatalogMatches,
+  catalogSeverityForCategory,
+  BREADTH_DETECT_IDS,
+  loadCanonicalPatterns,
+  loadCanonicalAllowlist,
+  quickCredentialScan,
+  type CanonicalCredentialPattern,
+  type IsKnownExample,
+  type CredentialMatch,
+} from '../../src/util/credential-patterns.js';
+
+// Issue #130: protect/review/init detected only ~7 local patterns while `scan`
+// finds ~57. The catalog breadth pass closes that gap via a fail-safe include
+// list of strong-prefix patterns — additive, deduped against local matches,
+// severity-by-category, FP-prone value-shape-only patterns excluded.
+
+// Real-shaped (non-placeholder) values the LOCAL 7 patterns miss. Built by
+// concatenation so GitHub Push Protection doesn't flag this test source.
+const SLACK = ['xoxb-', '1234567890-1234567890-', 'aBcdEfGhIjKlMnOpQrStUvWx'].join('');
+const STRIPE = ['sk_', 'live_', 'aBcdEfGhIjKlMnOpQrStUvWx'].join('');
+const SENDGRID = ['SG', '.aBcdEfGhIjKlMnOpQrStUv.', 'aBcdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfG'].join('');
+const GITLAB = ['glpat-', 'aBcdEfGhIjKlMnOpQrSt'].join('');
+
+let catalog: CanonicalCredentialPattern[];
+let isKnownExample: IsKnownExample | null;
+
+beforeAll(async () => {
+  catalog = await loadCanonicalPatterns();
+  isKnownExample = await loadCanonicalAllowlist();
+});
+
+const collect = (lines: string[], filePath: string, seen = new Set<string>()): CredentialMatch[] => {
+  const matches: CredentialMatch[] = [];
+  collectCatalogMatches(lines, filePath, catalog, isKnownExample, seen, matches);
+  return matches;
+};
+
+describe('catalogSeverityForCategory', () => {
+  it('maps account-takeover categories to critical', () => {
+    for (const c of ['ai-ml', 'cloud', 'payment', 'auth']) {
+      expect(catalogSeverityForCategory(c)).toBe('critical');
+    }
+  });
+  it('maps repo/messaging/database to high and monitoring to medium', () => {
+    for (const c of ['developer', 'communication', 'database']) {
+      expect(catalogSeverityForCategory(c)).toBe('high');
+    }
+    expect(catalogSeverityForCategory('monitoring')).toBe('medium');
+  });
+  it('defaults an unknown/absent category to high (fail-safe, not silent)', () => {
+    expect(catalogSeverityForCategory(undefined)).toBe('high');
+    expect(catalogSeverityForCategory('something-new')).toBe('high');
+  });
+});
+
+describe('BREADTH_DETECT_IDS — fail-safe include list', () => {
+  it('every included id is a real catalog pattern (no typos / stale ids)', () => {
+    const ids = new Set(catalog.map(p => p.id));
+    for (const id of BREADTH_DETECT_IDS) {
+      expect(ids.has(id), `BREADTH_DETECT_IDS has '${id}' not in the catalog`).toBe(true);
+    }
+  });
+  it('excludes the FP-prone value-shape-only patterns (Phase 4.5)', () => {
+    for (const id of ['supabase', 'telegram-bot', 'twilio', 'grafana', 'mongodb', 'postgres', 'mysql', 'redis']) {
+      expect(BREADTH_DETECT_IDS.has(id), `'${id}' must NOT be in the breadth list`).toBe(false);
+    }
+  });
+  it('excludes loose-floor short underscore prefixes (gsk_/r8_/hf_/fw_ match benign mixedCase identifiers)', () => {
+    for (const id of ['groq', 'replicate', 'huggingface', 'fireworks']) {
+      expect(BREADTH_DETECT_IDS.has(id), `'${id}' must NOT be in the breadth list`).toBe(false);
+    }
+    // Concrete proof: a benign mixedCase identifier with the hf_ prefix must not be flagged.
+    const matches: CredentialMatch[] = [];
+    collectCatalogMatches(['const hf_modelDownloadProgressBar = init();'], '/x/m.ts', catalog, isKnownExample, new Set(), matches);
+    expect(matches).toHaveLength(0);
+  });
+  it('excludes patterns a local scanner already owns / non-migratable markers', () => {
+    for (const id of ['aws-access', 'aws-secret', 'google', 'pem-private-key', 'gcp-service-account', 'anthropic']) {
+      expect(BREADTH_DETECT_IDS.has(id), `'${id}' must NOT be in the breadth list`).toBe(false);
+    }
+  });
+
+  it('excludes azure (name-gated, no capture group → m[0] is `Name=value`, would corrupt on migrate)', () => {
+    // The azure regex matches `AccountKey=<base64>=` with no group 1, so m[0]
+    // carries the name token; migrating it would vault the wrong value and break
+    // the surrounding connection string. Must stay HMA-semantic only.
+    expect(BREADTH_DETECT_IDS.has('azure')).toBe(false);
+    const line = 'DefaultEndpointsProtocol=https;AccountName=foo;AccountKey=' + 'a'.repeat(43) + '=;EndpointSuffix=core';
+    const matches: CredentialMatch[] = [];
+    collectCatalogMatches([line], '/x/conn.ts', catalog, isKnownExample, new Set(), matches);
+    expect(matches.some(m => m.findingId === 'CRED-CAT-azure')).toBe(false);
+  });
+});
+
+describe('collectCatalogMatches', () => {
+  it('loads a real catalog + allowlist (precondition)', () => {
+    expect(catalog.length).toBeGreaterThan(20);
+    expect(typeof isKnownExample).toBe('function');
+  });
+
+  it('detects catalog types the local 7 patterns miss, with category severity', () => {
+    const matches = collect([
+      `const slack = "${SLACK}";`,
+      `const stripe = "${STRIPE}";`,
+      `const sendgrid = "${SENDGRID}";`,
+      `const gitlab = "${GITLAB}";`,
+    ], '/x/config.js');
+
+    const byValue = (v: string) => matches.find(m => m.value === v);
+    expect(byValue(SLACK)).toMatchObject({ title: 'Slack Token', severity: 'high', findingId: 'CRED-CAT-slack', line: 1 });
+    expect(byValue(STRIPE)).toMatchObject({ title: 'Stripe Live Key', severity: 'critical' });
+    expect(byValue(SENDGRID)).toMatchObject({ title: 'SendGrid Key', severity: 'high', envVar: 'SENDGRID_API_KEY' });
+    expect(byValue(GITLAB)).toMatchObject({ title: 'GitLab PAT', severity: 'high', line: 4 });
+  });
+
+  it('surfaces BOTH real secrets of the same pattern on one line (no first-match-only under-report)', () => {
+    const g1 = ['glpat-', 'Aa1Bb2Cc3Dd4Ee5Ff6Gg'].join('');
+    const g2 = ['glpat-', 'Zz9Yy8Xx7Ww6Vv5Uu4Tt'].join('');
+    const matches = collect([`const a = "${g1}", b = "${g2}";`], '/x/c.js');
+    expect(matches.map(m => m.value).sort()).toEqual([g1, g2].sort());
+  });
+
+  it('skips values already in `seen` (dedup vs local keeps the richer local label)', () => {
+    const matches = collect([`const slack = "${SLACK}";`], '/x/config.js', new Set([`${SLACK}:/x/config.js`]));
+    expect(matches).toHaveLength(0);
+  });
+
+  it('skips env-var references (process.env / ${...}) but flags the hardcoded literal', () => {
+    const matches = collect([
+      `const a = process.env.SLACK_TOKEN || "${SLACK}";`,
+      `const b = process.env.SLACK_TOKEN;`,
+    ], '/x/config.js');
+    expect(matches.every(m => m.line === 1)).toBe(true);
+  });
+
+  it('suppresses placeholder / example values (allowlist via isKnownExample)', () => {
+    const placeholder = ['xoxb-', '0000000000-0000000000-', 'EXAMPLEEXAMPLEEXAMPLE000'].join('');
+    expect(collect([`const fake = "${placeholder}";`], '/x/config.js')).toHaveLength(0);
+  });
+
+  // Phase 4.5: value-shape-only patterns must NOT fire on benign content.
+  // Tokens built by concatenation so GitHub Push Protection (which scans source
+  // bytes) doesn't flag these deliberately-credential-shaped benign fixtures.
+  it('does NOT false-positive on benign content (twilio SK+md5, telegram id:hash, bare conn string)', () => {
+    const twilioShaped = ['SK', 'd41d8cd98f00b204e9800998ecf8427e'].join('');     // SK + an MD5 (etag)
+    const telegramShaped = ['1623456789', ':', 'abcdefghijklmnopqrstuvwxyzABCDEFGHI'].join(''); // numeric:35
+    const grafanaShaped = ['glc_', 'aBcdEfGhIjKlMnOpQrStUvWxYz012345'].join('');
+    const benign = [
+      `const etag = "${twilioShaped}";`,
+      `const cacheKey = "${telegramShaped}";`,
+      'const url = "postgres://localhost/mydb";',                     // credential-less conn string
+      `const blob = "${grafanaShaped}";`,
+    ];
+    expect(collect(benign, '/x/util.js')).toHaveLength(0);
+  });
+
+  it('is a no-op when the allowlist failed to load (degrade, not crash)', () => {
+    const matches: CredentialMatch[] = [];
+    collectCatalogMatches([`const s = "${SLACK}";`], '/x/c.js', catalog, null, new Set(), matches);
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe('quickCredentialScan — catalog breadth integration', () => {
+  let tmpDir: string;
+  beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-cat-')); });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('finds catalog types AND keeps the local label for an overlapping provider (no double-report)', async () => {
+    const ANTHROPIC = ['sk-ant-api03-', 'aBcdEfGhIjKlMnOpQrStUvWx'].join('');
+    fs.writeFileSync(path.join(tmpDir, 'config.js'), [
+      `const anthropic = "${ANTHROPIC}";`, // local CRED-001
+      `const slack = "${SLACK}";`,          // catalog
+      `const stripe = "${STRIPE}";`,        // catalog
+    ].join('\n'));
+
+    const matches = await quickCredentialScan(tmpDir);
+
+    // Anthropic appears exactly once, via the rich local pattern (not the catalog).
+    const anth = matches.filter(m => m.value === ANTHROPIC);
+    expect(anth).toHaveLength(1);
+    expect(anth[0].findingId).toBe('CRED-001');
+
+    // Catalog breadth: slack + stripe are now detected.
+    expect(matches.find(m => m.value === SLACK)?.findingId).toBe('CRED-CAT-slack');
+    expect(matches.find(m => m.value === STRIPE)?.findingId).toBe('CRED-CAT-stripe');
+  });
+});

--- a/packages/cli/src/commands/protect.ts
+++ b/packages/cli/src/commands/protect.ts
@@ -142,6 +142,8 @@ import {
   isPlaceholderSecretValue,
   refineCredentialLabel,
   loadCanonicalPatterns,
+  loadCanonicalAllowlist,
+  collectCatalogMatches,
   type CredentialMatch,
 } from '../util/credential-patterns.js';
 import {
@@ -720,8 +722,10 @@ export async function protect(options: ProtectOptions): Promise<number> {
 async function scanForCredentials(targetDir: string): Promise<CredentialMatch[]> {
   const matches: CredentialMatch[] = [];
   const seen = new Set<string>(); // dedup by value+file
-  // Loaded once before the walk so per-value label refinement stays synchronous.
+  // Loaded once before the walk so per-value label refinement + catalog
+  // detection stay synchronous inside the walkFiles callback.
   const catalog = await loadCanonicalPatterns();
+  const isKnownExample = await loadCanonicalAllowlist();
 
   walkFiles(targetDir, (filePath) => {
     let content: string;
@@ -784,6 +788,11 @@ async function scanForCredentials(targetDir: string): Promise<CredentialMatch[]>
         }
       }
     }
+
+    // Breadth pass: catch the catalog credential types the local patterns miss
+    // (Slack, Stripe, Groq, GitLab, …), deduped against the local matches above
+    // so overlapping providers keep their richer local label (#130).
+    collectCatalogMatches(lines, filePath, catalog, isKnownExample, seen, matches);
   });
 
   return matches;

--- a/packages/cli/src/util/credential-patterns.ts
+++ b/packages/cli/src/util/credential-patterns.ts
@@ -317,6 +317,187 @@ export function refineCredentialLabel(
   };
 }
 
+/**
+ * Severity for a canonical-catalog credential, keyed by its `category`. The
+ * `@opena2a/credential-patterns` catalog carries no severity, so protect/review
+ * derive one here. Account-takeover-class secrets (LLM keys, cloud/infra,
+ * payment, auth) are critical; repo/registry and messaging tokens are high;
+ * observability keys are medium. [CHIEF-CDS] — change behind a Phase 4.5 review.
+ */
+export const CATALOG_CATEGORY_SEVERITY: Record<string, string> = {
+  'ai-ml': 'critical',
+  'cloud': 'critical',
+  'payment': 'critical',
+  'auth': 'critical',
+  'developer': 'high',
+  'communication': 'high',
+  'database': 'high',
+  'monitoring': 'medium',
+};
+
+/** Severity for a catalog category; unknown/absent categories default to `high`. */
+export function catalogSeverityForCategory(category?: string): string {
+  return CATALOG_CATEGORY_SEVERITY[category ?? ''] ?? 'high';
+}
+
+/**
+ * Catalog pattern IDs the migration scanner surfaces — a fail-SAFE, opt-in
+ * allowlist (NOT an exclude-list). `protect` auto-migrates (rewrites files), so
+ * a new catalog pattern must be reviewed before it can drive that flow; an
+ * exclude-list would auto-enrol every future addition.
+ *
+ * INCLUDED: patterns whose match is a STRONG, near-unique credential signal by
+ * itself (distinctive prefix/structure). EXCLUDED on purpose:
+ *   - Value-shape-only patterns that match benign content (Phase 4.5 review):
+ *     `supabase` (any HS256 JWT incl. PUBLIC anon keys, mislabelled "Service
+ *     Key"), `telegram-bot` (`numeric:35char` cache keys/snowflakes), `twilio`
+ *     (`SK`+32hex == any MD5/etag), `grafana` (`glc_`+base64 blob), and the
+ *     connection strings `mongodb`/`postgres`/`mysql`/`redis` (`://[^\s]{10,}`
+ *     matches even a credential-LESS `postgres://localhost/db`). These need
+ *     name/context gating only HMA's semantic layer has — they stay HMA-only.
+ *   - Patterns a dedicated local scanner already owns with richer framing:
+ *     `aws-access`/`aws-secret` (local DRIFT-002/CRED-005), `google` (local
+ *     DRIFT-001 "Gemini drift"), `anthropic`/`openai-legacy` (local CRED-001/2).
+ *     Keeping them here would only risk severity drift vs the local decision.
+ *   - Name-gated patterns whose match[0] is `Name=value` (NOT a bare secret) and
+ *     that ship no capture group, so `m[1] ?? m[0]` is the whole
+ *     `AccountKey=<base64>=` span: `azure`. protect would vault the wrong value
+ *     AND corrupt the surrounding `;`-delimited connection string on rewrite
+ *     (Phase 4.5 re-review). Same rationale as `aws-secret` — HMA's semantic
+ *     layer owns name-gated values. EVERY included pattern below is a pure
+ *     value-shape prefix whose m[0] IS the migratable secret.
+ *   - `pem-private-key` (key material — {@link scanCryptoKeyFiles}, extension-
+ *     based) and `gcp-service-account` (structural JSON marker, not migratable).
+ *   - Short underscore vendor prefixes with a loose floor — `groq` (gsk_),
+ *     `replicate` (r8_), `huggingface` (hf_), `fireworks` (fw_), all
+ *     `<prefix>[alnum]{20,}` — match a separator-free mixedCase identifier of
+ *     that vendor's SDK (a benign `hf_modelDownloadProgressBar` fires). The
+ *     floor sits far below the real key length, so for an AUTO-MIGRATING
+ *     scanner the FP-rewrite risk outweighs the breadth gain; `scan` (HMA
+ *     semantic) still surfaces them. Tightening the catalog floors to the real
+ *     key length would let them back in safely (package-side follow-up).
+ *
+ * The kept prefixes are either hyphenated (rare in identifiers: `sk-proj-`,
+ * `sk-or-v1-`, `pplx-`, `glpat-`), long (`dckr_pat_`, `lin_api_`, `sntrys_`),
+ * or carry a high length floor (`pypi-`{50,}, `nfp_`{40,}, `npm_`{36}), so a
+ * benign identifier of that exact shape is implausible.
+ */
+export const BREADTH_DETECT_IDS = new Set([
+  // ai-ml (anthropic/openai-legacy owned by local; groq/replicate/huggingface/
+  // fireworks excluded — loose-floor short underscore prefixes, see above)
+  'openai-proj', 'openrouter', 'perplexity',
+  // cloud (aws-access/aws-secret owned by local; azure name-gated; supabase a JWT FP)
+  'aws-sts', 'digitalocean', 'heroku', 'fly-io', 'netlify',
+  // communication (telegram-bot/twilio are shape-only FPs)
+  'slack', 'slack-webhook', 'slack-app', 'discord-bot', 'discord-webhook', 'sendgrid',
+  // developer (github-pat/app `gh[ps]_` owned by local CRED-003; gho_/ghr_/fine are not)
+  'github-fine', 'github-oauth', 'github-refresh', 'gitlab', 'gitlab-pipeline',
+  'gitlab-runner', 'npm', 'pypi', 'dockerhub', 'bitbucket',
+  // payment
+  'stripe-test', 'stripe-restricted', 'stripe', 'stripe-webhook', 'square',
+  // auth (google AIza owned by local DRIFT-001; pem-private-key is key material)
+  'google-oauth', 'firebase-fcm',
+  // monitoring (grafana glc_ blob is a shape-only FP)
+  'newrelic', 'newrelic-insight', 'sentry', 'linear',
+]);
+
+/** Signature of the package's `isKnownExample` allowlist predicate. */
+export type IsKnownExample = (line: string, match: RegExpMatchArray) => boolean;
+
+/**
+ * Lazily import the package's allowlist predicate (`isKnownExample`), which
+ * recognises the SAME known-example / placeholder / low-entropy / localhost+demo
+ * values the catalog ships. Memoised; resolves to `null` if the ESM-only package
+ * can't be loaded so callers degrade to local-pattern-only detection rather than
+ * crash.
+ */
+let _isKnownExample: Promise<IsKnownExample | null> | null = null;
+export function loadCanonicalAllowlist(): Promise<IsKnownExample | null> {
+  if (!_isKnownExample) {
+    _isKnownExample = import('@opena2a/credential-patterns')
+      .then(m => (m.isKnownExample as IsKnownExample) ?? null)
+      .catch(() => null);
+  }
+  return _isKnownExample;
+}
+
+/** True when the matched value is already an env-var reference (process.env.X, ${X}, …). */
+export function isEnvVarReference(line: string, matchIndex: number): boolean {
+  const before = line.slice(0, matchIndex);
+  return /process\.env\.\w*$/.test(before) ||
+    /\$\{?\w*$/.test(before) ||
+    /os\.environ\[['"]?\w*$/.test(before) ||
+    /getenv\(['"]?\w*$/.test(before);
+}
+
+/** Derive a unique env-var name from a prefix, numbering collisions (BASE, BASE_2, …). */
+export function deriveEnvVarName(base: string, existingMatches: CredentialMatch[]): string {
+  const existing = existingMatches.filter(m => m.envVar.startsWith(base));
+  return existing.length === 0 ? base : `${base}_${existing.length + 1}`;
+}
+
+/**
+ * Detect credentials in `lines` using the canonical `@opena2a/credential-patterns`
+ * catalog (issue #130: protect/review/init detected only ~7 local patterns while
+ * `scan` finds ~57). Additive + deduped against `seen` (`value:filePath`), so a
+ * value the local patterns already flagged keeps its richer local label and is
+ * NOT re-reported here. Mutates `matches` and `seen` in place.
+ *
+ * Only patterns in the fail-safe {@link BREADTH_DETECT_IDS} allowlist run, so
+ * value-shape-only FP-prone matchers (Supabase JWTs, telegram `id:hash`, twilio
+ * `SK`+hex, bare connection strings, grafana blobs) are left to HMA's semantic
+ * layer. ALL real matches per line are surfaced (not just the first), each
+ * filtered through the package's `isKnownExample` allowlist (known-example /
+ * placeholder / low-entropy / localhost+demo values). Degrades to a no-op if the
+ * allowlist predicate failed to load.
+ */
+export function collectCatalogMatches(
+  lines: string[],
+  filePath: string,
+  catalog: CanonicalCredentialPattern[],
+  isKnownExample: IsKnownExample | null,
+  seen: Set<string>,
+  matches: CredentialMatch[],
+): void {
+  if (!isKnownExample || catalog.length === 0) return;
+  const breadth = catalog.filter(cp => BREADTH_DETECT_IDS.has(cp.id));
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    for (const cp of breadth) {
+      // Promote to /g so matchAll yields EVERY occurrence on the line — two real
+      // secrets of the same pattern on one line must both surface (the local
+      // pass iterates exhaustively too; the breadth pass must not under-report).
+      const re = cp.regex.flags.includes('g')
+        ? cp.regex
+        : new RegExp(cp.regex.source, cp.regex.flags + 'g');
+      re.lastIndex = 0;
+      for (const m of line.matchAll(re)) {
+        if (isKnownExample(line, m)) continue;
+        const value = m[1] ?? m[0];
+        const dedupKey = `${value}:${filePath}`;
+        if (seen.has(dedupKey)) continue;
+        // Already an env-var reference (process.env.X / ${X}) — not an exposure.
+        if (m.index != null && isEnvVarReference(line, m.index)) continue;
+        seen.add(dedupKey);
+        const envVar = deriveEnvVarName(cp.envPrefix, matches);
+        matches.push({
+          value,
+          filePath,
+          line: i + 1,
+          findingId: `CRED-CAT-${cp.id}`,
+          envVar,
+          severity: catalogSeverityForCategory(cp.category),
+          title: cp.name,
+          // The catalog ships no prose, so neutral-but-correct copy keyed off the
+          // precise provider name (vs inventing provider-specific claims).
+          explanation: `${cp.name} hardcoded in source. Anyone who can read this file can use it to access the associated account.`,
+          businessImpact: 'Grants access to the associated service. Migrate to an environment variable and rotate the credential.',
+        });
+      }
+    }
+  }
+}
+
 const CASE_INSENSITIVE_FS = process.platform === 'darwin' || process.platform === 'win32';
 
 /**
@@ -423,8 +604,10 @@ export function walkFiles(dir: string, callback: (filePath: string) => void): vo
 export async function quickCredentialScan(targetDir: string): Promise<CredentialMatch[]> {
   const matches: CredentialMatch[] = [];
   const seen = new Set<string>();
-  // Loaded once before the walk so per-value label refinement stays synchronous.
+  // Loaded once before the walk so per-value label refinement + catalog
+  // detection stay synchronous inside the walkFiles callback.
   const catalog = await loadCanonicalPatterns();
+  const isKnownExample = await loadCanonicalAllowlist();
 
   walkFiles(targetDir, (filePath) => {
     let content: string;
@@ -486,6 +669,11 @@ export async function quickCredentialScan(targetDir: string): Promise<Credential
         }
       }
     }
+
+    // Breadth pass: catch the catalog credential types the local patterns miss
+    // (Slack, Stripe, Groq, GitLab, …), deduped against the local matches above
+    // so overlapping providers keep their richer local label (#130).
+    collectCatalogMatches(lines, filePath, catalog, isKnownExample, seen, matches);
   });
 
   return matches;


### PR DESCRIPTION
Closes #130.

protect/review/init detected only ~7 local credential patterns while `scan` finds ~57, so the headline "migrate credentials to a vault" command was blind to Slack/Stripe/GitLab/SendGrid/etc. tokens its sibling scanner flags. Adds a consumer-side breadth pass (Option C) over the canonical `@opena2a/credential-patterns` catalog, shared by `quickCredentialScan` (review/init) and protect's `scanForCredentials`.

## Design [CHIEF-CDS]+[CHIEF-CA]
- Additive + deduped by `value:filePath` against the local matches (which run first), so an overlapping provider keeps its richer local label/prose and is never double-reported.
- FP safety via the package's `isKnownExample` allowlist; **0 false positives** verified across benign / leaky-env-example / the CLI's own source.
- Severity from catalog `category`: ai-ml/cloud/payment/auth → critical, developer/communication/database → high, monitoring → medium; unknown → high (fail-safe).
- **Fail-SAFE include list** (`BREADTH_DETECT_IDS`), NOT an exclude list: protect auto-migrates (rewrites files), so a pattern must be reviewed before it can drive that flow.

## Two adversarial reviews shaped the include list
1. Initial "all 57 patterns" draft → P1 FP class: value-shape-only matchers fire on benign code — `supabase` (any HS256 JWT incl. PUBLIC anon keys, mislabelled "Service Key"), `telegram-bot` (`numeric:35char`), `twilio` (`SK`+32hex == any MD5/etag), `grafana` blobs, and connection strings (`://[^\s]{10,}` matches a credential-less `postgres://localhost/db`). All excluded.
2. Re-review of the final code → **HIGH**: `azure` is name-gated with no capture group, so `m[0]` is the whole `AccountKey=<base64>=` span — protect would vault the wrong value and **corrupt the `;`-delimited connection string** on rewrite. Excluded. Also excluded the loose-floor short underscore prefixes `groq`/`replicate`/`huggingface`/`fireworks` (`<prefix>[alnum]{20,}` matches a benign mixedCase identifier like `hf_modelDownloadProgressBar`) — too risky for an auto-migrating scanner; `scan` (HMA semantic) still surfaces them.

Also excluded: `aws-access`/`aws-secret`/`google` (owned by local DRIFT-002/CRED-005/DRIFT-001 with richer framing), `pem-private-key` (key material — `scanCryptoKeyFiles`, would double-report `.key`/`.pem`), `gcp-service-account` (structural marker). The breadth pass iterates ALL matches per line (not just the first).

## Verification
e2e: protect on a real-shaped fixture finds Slack/Stripe(critical)/GitLab/SendGrid while ignoring an etag/db-id/localhost-url/anon-JWT/azure-conn-string/`hf_`-identifier. Full cli suite green (1208). 17 catalog-detection tests incl. FP-exclusion (azure, loose prefixes, value-shape-only) + multi-match-per-line.

Known latent (pre-existing, shared with the local pass): `deriveEnvVarName` uses `startsWith` for collision numbering; no current prefix collision exists.