### PR TITLE
fix(cli): native *_CLI_PREFIX wiring + registry --json passthrough (#191)

### DIFF
--- a/packages/cli/__tests__/adapters/format-flag.test.ts
+++ b/packages/cli/__tests__/adapters/format-flag.test.ts
@@ -3,19 +3,23 @@ import { ADAPTER_REGISTRY } from '../../src/adapters/registry.js';
 
 /**
  * issue #191: the router injects `--format <fmt>` for non-text output, but
- * `ai-trust check` (the `registry` adapter) has no such flag and exits with
- * "unknown option '--format'". The adapter must opt out via
- * `acceptsFormatFlag: false` so the router skips injection (and surfaces a
- * one-line note instead of crashing).
+ * `ai-trust check` (the `registry` adapter) has no `--format` flag — it emits
+ * JSON via a bare `--json`. The adapter declares `jsonOutputFlag: '--json'` so
+ * the router injects `--json` for json output (instead of `--format json`,
+ * which would crash with "unknown option '--format'") and notes any other
+ * unsupported format.
  */
-describe('AdapterConfig.acceptsFormatFlag — #191 registry --json crash', () => {
-  it('registry (ai-trust check) opts out of --format injection', () => {
-    expect(ADAPTER_REGISTRY['registry'].acceptsFormatFlag).toBe(false);
+describe('AdapterConfig.jsonOutputFlag — #191 registry --json', () => {
+  it('registry (ai-trust check) emits JSON via --json, not --format', () => {
+    expect(ADAPTER_REGISTRY['registry'].jsonOutputFlag).toBe('--json');
+    // No longer a blanket opt-out: json IS supported now (via --json).
+    expect(ADAPTER_REGISTRY['registry'].acceptsFormatFlag).toBeUndefined();
   });
 
-  it('scan (hackmyagent) keeps default --format support (does not opt out)', () => {
-    // undefined or true both mean "inject --format"; just assert it is not false,
+  it('scan (hackmyagent) keeps default --format support (no jsonOutputFlag)', () => {
+    // undefined acceptsFormatFlag + no jsonOutputFlag means "inject --format",
     // so hackmyagent's working `--format json` path is not regressed.
+    expect(ADAPTER_REGISTRY['scan'].jsonOutputFlag).toBeUndefined();
     expect(ADAPTER_REGISTRY['scan'].acceptsFormatFlag).not.toBe(false);
   });
 });

--- a/packages/cli/src/adapters/registry.ts
+++ b/packages/cli/src/adapters/registry.ts
@@ -27,9 +27,11 @@ export const ADAPTER_REGISTRY: Record<string, AdapterConfig> = {
     packageName: 'ai-trust',
     subcommand: 'check',
     description: 'Query OpenA2A Trust Registry for package security data',
-    // `ai-trust check` exposes no `--format`/`--json` option; injecting
-    // `--format json` makes it exit with "unknown option '--format'" (#191).
-    acceptsFormatFlag: false,
+    // `ai-trust check` emits JSON via a bare `--json` (not `--format json`),
+    // so the router injects `--json` for `opena2a registry <pkg> --json` and
+    // skips `--format` injection (which would crash with "unknown option
+    // '--format'"). sarif is unsupported and surfaces a one-line note (#191).
+    jsonOutputFlag: '--json',
   },
   train: {
     name: 'train',

--- a/packages/cli/src/adapters/types.ts
+++ b/packages/cli/src/adapters/types.ts
@@ -22,10 +22,17 @@ export interface AdapterConfig {
   /**
    * Whether the bundled tool accepts a `--format <fmt>` flag for structured
    * output. Default (undefined) = true. Set false for tools that reject it so
-   * the router does not inject `--format json` and crash the delegated call
-   * (e.g. `ai-trust check` has no `--format`/`--json` option -- issue #191).
+   * the router does not inject `--format json` and crash the delegated call.
    */
   acceptsFormatFlag?: boolean;
+  /**
+   * Flag the bundled tool uses to emit JSON when it does NOT take `--format`
+   * (e.g. `ai-trust check` emits JSON via a bare `--json`, issue #191). When
+   * set, the router injects this flag for `--json`/`format: 'json'` instead of
+   * `--format json`, and surfaces a one-line note for unsupported formats
+   * (e.g. sarif). Takes precedence over `acceptsFormatFlag` for json output.
+   */
+  jsonOutputFlag?: string;
 }
 
 export interface RunOptions {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -41,18 +41,25 @@ const NON_TRACKED_COMMANDS = new Set<string>(['telemetry', 'help']);
 // Per-invocation start times keyed by subcommand name (preAction → postAction).
 const telemetryStartedAt = new Map<string, number>();
 
-// Tell downstream tools (hackmyagent, secretless) to use 'opena2a' in user-facing messages.
-// HMA_CLI_PREFIX is the *binary-level* prefix — HMA appends verbs to it
-// ("${prefix} rollback <dir>"), so it must be just "opena2a" here. The full
-// command strings for the `check` next-steps footer (HMA_CHECK_COMMAND,
-// HMA_FULL_SCAN_HINT) are set per-spawn in spawnHmaCheck / spawnHmaCheckFromRouter.
+// Tell downstream bundled tools to render their command citations in
+// `opena2a …` form. Each `*_CLI_PREFIX` holds the EXACT command-path string
+// that replaces the tool's own invocation token; the tool appends its verb
+// (`${prefix} <verb>`). The value reflects where the tool sits in opena2a's
+// command tree, so the prefixes are NOT all bare "opena2a":
+//   - hackmyagent verbs (secure/scan/check) are opena2a TOP-LEVEL commands, so
+//     HMA_CLI_PREFIX is just "opena2a" ("${prefix} secure"). The full check
+//     next-steps strings (HMA_CHECK_COMMAND, HMA_FULL_SCAN_HINT) are still set
+//     per-spawn in spawnHmaCheck / spawnHmaCheckFromRouter.
+//   - secretless is reached as `opena2a secrets <verb>`.
+//   - cryptoserve is reached as `opena2a crypto <verb>`.
+//   - ai-trust's `check` command IS opena2a's top-level `registry <pkg>`
+//     (no `check` verb), so the prefix stands in for the whole `ai-trust check`.
+// These mirror util/rebrand.ts exactly, so once each bundled tool honors its
+// var natively (issue #191) the consumer-side rebrander is a no-op safety net.
 process.env.HMA_CLI_PREFIX = 'opena2a';
-// Forward-compat: ai-trust and cryptoserve do not yet honor a prefix env (so
-// opena2a-cli also rebrands their delegated stdout, see util/rebrand.ts), but
-// set the analogous vars now so the rebrand becomes a no-op once they do.
-// Tracked upstream in their repos.
-process.env.AI_TRUST_CLI_PREFIX = 'opena2a';
-process.env.CRYPTOSERVE_CLI_PREFIX = 'opena2a';
+process.env.SECRETLESS_CLI_PREFIX = 'opena2a secrets';
+process.env.CRYPTOSERVE_CLI_PREFIX = 'opena2a crypto';
+process.env.AI_TRUST_CLI_PREFIX = 'opena2a registry';
 
 async function main(): Promise<void> {
   // Tier-1 anonymous usage telemetry \u2014 default ON; opt-out via OPENA2A_TELEMETRY=off

--- a/packages/cli/src/router.ts
+++ b/packages/cli/src/router.ts
@@ -373,11 +373,21 @@ export async function dispatchCommand(
   }
 
   // Inject global flags into adapter args so downstream tools receive them.
-  // Skip adapters whose bundled tool rejects `--format` (e.g. ai-trust check),
-  // which would otherwise crash with "unknown option '--format'" (#191). For
-  // those, surface a one-line note so a user piping --json isn't left guessing.
+  // Adapters fall into three cases for structured output:
+  //   - jsonOutputFlag set (e.g. ai-trust check `--json`): inject that flag for
+  //     json; any other format (sarif) is unsupported -> one-line note.
+  //   - acceptsFormatFlag === false: tool rejects `--format` entirely -> note.
+  //   - default: inject `--format <fmt>` (hackmyagent, cryptoserve, ...).
   if (globalOptions.format && globalOptions.format !== 'text' && !adapterArgs.includes('--format') && !adapterArgs.includes('--json')) {
-    if (adapter.config.acceptsFormatFlag === false) {
+    if (adapter.config.jsonOutputFlag) {
+      if (globalOptions.format === 'json') {
+        adapterArgs.push(adapter.config.jsonOutputFlag);
+      } else {
+        process.stderr.write(
+          `Note: 'opena2a ${command}' does not support ${globalOptions.format} output yet; showing text.\n`,
+        );
+      }
+    } else if (adapter.config.acceptsFormatFlag === false) {
       process.stderr.write(
         `Note: 'opena2a ${command}' does not support ${globalOptions.format} output yet; showing text.\n`,
       );


### PR DESCRIPTION
Consumer-side half of #191: make opena2a-cli set each bundled tool's `*_CLI_PREFIX` to the exact `opena2a` command path so the tools render their citations natively, turning `util/rebrand.ts` into a no-op safety net.

## Changes
- Export `SECRETLESS_CLI_PREFIX='opena2a secrets'` (new); set `CRYPTOSERVE_CLI_PREFIX='opena2a crypto'` and `AI_TRUST_CLI_PREFIX='opena2a registry'` (were bare `opena2a`). Each prefix is the full command-path that replaces the tool's own invocation token, reflecting its depth in opena2a's tree (hackmyagent verbs are top-level → `opena2a`).
- `registry` adapter: `ai-trust check` now emits JSON via a bare `--json` (not `--format json`), so it declares `jsonOutputFlag: '--json'`. The router injects `--json` for `opena2a registry <pkg> --json` instead of the old "not supported yet" stopgap, and notes any other unsupported format (sarif).
- Update `format-flag.test.ts` to the new contract.

## Verification
Built each bundled tool from its branch and ran with these exact env values: all emit `opena2a …` form with zero leaked binary names, and `rebrandBundledCommands` is a confirmed no-op on every surface. `registry <pkg> --json` returns valid camelCase JSON with clean stderr. Full cli suite green (1230).

Pairs with the upstream tool PRs (hackmyagent / secretless-ai / ai-trust / cryptoserve). Pins bump after those publish.