### PR TITLE
check-core 0.3.0: carry --nanomind escalations through check --json

### DIFF
--- a/packages/check-core/CHANGELOG.md
+++ b/packages/check-core/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to `@opena2a/check-core`.
 
+## 0.3.0 — 2026-06-10
+
+Carries the --nanomind advisory escalation channel through `check --json`
+(Phase A P1 analyst-wiring follow-up). Producers running `check
+<npm|pypi|github> --nanomind --json` previously computed
+`analystEscalations`/`coverageSweep` and then dropped them at
+`buildCheckOutput`.
+
+### Added
+- `ScanResult.analystEscalations?` / `ScanResult.coverageSweep?` —
+  optional advisory fields from the abstention-gated analyst coverage
+  sweep. Escalate-only channel: never part of score, findings, or exit
+  code.
+- `CheckOutput.analystEscalations?` / `CheckOutput.coverageSweep?` —
+  emitted after `analystFindings` (escalations only when non-empty;
+  sweep accounting whenever the sweep ran), before `narrative`.
+- `CHECK_FIELD_GUIDE` + JSON Schema entries for both fields, with
+  explicit do-not-gate-CI guidance on `analystEscalations`.
+
+### Parity
+- Byte-equality contract unaffected: parity fixtures never pass
+  `--nanomind`, so the new keys are absent there.
+
 ## 0.2.0 — 2026-04-27
 
 Adds the rich-context narrative wire types, the static secret-rotation

--- a/packages/check-core/package.json
+++ b/packages/check-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/check-core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Data-shape and orchestration primitives for the `check` command across OpenA2A CLIs. One implementation of input classification, registry → scan-on-miss flow, download-error translation, and canonical CheckOutput schema — consumed by hackmyagent, opena2a-cli, and ai-trust.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/check-core/src/check-json-schema.test.ts
+++ b/packages/check-core/src/check-json-schema.test.ts
@@ -19,6 +19,8 @@ describe("check-json contract", () => {
     findings: [],
     version: "4.18.2",
     analystFindings: [{ id: "x" }],
+    analystEscalations: [{ file: "notes.txt", routed: "attack" }],
+    coverageSweep: { candidates: 1, swept: 1, skipped: 0, nullVerdicts: 0, policy: "abstention-gated" },
   };
 
   // Every optional field set, so any newly-copied field in output.ts

--- a/packages/check-core/src/check-json-schema.ts
+++ b/packages/check-core/src/check-json-schema.ts
@@ -176,6 +176,18 @@ export const CHECK_FIELD_GUIDE: Record<string, CheckFieldDoc> = {
     source: "local-scan",
     description: "Optional NanoMind analyst annotations layered on the local scan.",
   },
+  analystEscalations: {
+    source: "local-scan",
+    description:
+      "Advisory escalations from the --nanomind analyst coverage sweep (abstention-gated). Each names a file the structural scan did NOT flag but the analyst routed to attack/abstain — for human review. Never part of score, findings, or exit code; present only when --nanomind ran and the sweep escalated something.",
+    gating:
+      "Do NOT gate CI on this — it is an advisory human-review channel, not a verdict.",
+  },
+  coverageSweep: {
+    source: "local-scan",
+    description:
+      "Coverage-sweep accounting (candidates, swept, skipped, nullVerdicts, policy) so a capped or daemon-degraded sweep is never silently partial. Present only when --nanomind ran.",
+  },
   narrative: {
     source: "meta",
     description:

--- a/packages/check-core/src/output.test.ts
+++ b/packages/check-core/src/output.test.ts
@@ -115,6 +115,42 @@ describe("buildCheckOutput", () => {
     expect(out.analystFindings).toBeUndefined();
   });
 
+  it("omits analystEscalations and coverageSweep when absent (parity shape unchanged)", () => {
+    const out = buildCheckOutput({
+      name: "express",
+      type: "npm-package",
+      scan: { ...baseScan, analystEscalations: [] },
+    });
+    expect("analystEscalations" in out).toBe(false);
+    expect("coverageSweep" in out).toBe(false);
+  });
+
+  it("emits analystEscalations and coverageSweep after analystFindings (--nanomind path)", () => {
+    const sweep = { candidates: 3, swept: 3, skipped: 0, nullVerdicts: 0, policy: "abstention-gated" };
+    const escalations = [{ file: "notes.txt", routed: "attack", attackClass: "injection" }];
+    const out = buildCheckOutput({
+      name: "express",
+      type: "npm-package",
+      scan: { ...baseScan, analystFindings: [{ id: "x" }], analystEscalations: escalations, coverageSweep: sweep },
+    });
+    expect(out.analystEscalations).toEqual(escalations);
+    expect(out.coverageSweep).toEqual(sweep);
+    const keys = Object.keys(out);
+    expect(keys.indexOf("analystEscalations")).toBeGreaterThan(keys.indexOf("analystFindings"));
+    expect(keys.indexOf("coverageSweep")).toBe(keys.indexOf("analystEscalations") + 1);
+  });
+
+  it("emits coverageSweep even when the sweep escalated nothing (accounting is not optional)", () => {
+    const sweep = { candidates: 2, swept: 2, skipped: 0, nullVerdicts: 0, policy: "abstention-gated" };
+    const out = buildCheckOutput({
+      name: "express",
+      type: "npm-package",
+      scan: { ...baseScan, coverageSweep: sweep },
+    });
+    expect(out.coverageSweep).toEqual(sweep);
+    expect("analystEscalations" in out).toBe(false);
+  });
+
   it("does not merge registry when found=false", () => {
     const out = buildCheckOutput({
       name: "ghost",

--- a/packages/check-core/src/output.ts
+++ b/packages/check-core/src/output.ts
@@ -38,7 +38,8 @@ export interface BuildCheckOutputInput {
  *   projectType, score, maxScore, findings, version,     (scan path)
  *   trustLevel, trustScore, verdict, scanStatus,          (registry)
  *   packageType, lastScannedAt, communityScans, cveCount,
- *   analystFindings
+ *   analystFindings,
+ *   analystEscalations, coverageSweep                     (--nanomind only)
  */
 export function buildCheckOutput(input: BuildCheckOutputInput): CheckOutput {
   const { name, type, scan, registry, narrative } = input;
@@ -69,6 +70,16 @@ export function buildCheckOutput(input: BuildCheckOutputInput): CheckOutput {
 
   if (scan?.analystFindings && scan.analystFindings.length) {
     out.analystFindings = scan.analystFindings;
+  }
+
+  // --nanomind-only advisory channel: escalations (when non-empty) then the
+  // sweep accounting (when present). Parity fixtures never pass --nanomind,
+  // so these keys are absent there and the byte-equality contract holds.
+  if (scan?.analystEscalations && scan.analystEscalations.length) {
+    out.analystEscalations = scan.analystEscalations;
+  }
+  if (scan?.coverageSweep !== undefined) {
+    out.coverageSweep = scan.coverageSweep;
   }
 
   // narrative is the LAST key so the byte-equality parity contract

--- a/packages/check-core/src/types.ts
+++ b/packages/check-core/src/types.ts
@@ -45,6 +45,15 @@ export interface ScanResult {
   findings: unknown[];
   analystFindings?: Array<Record<string, unknown>>;
   version?: string;
+  /**
+   * Advisory analyst escalations from the --nanomind coverage sweep
+   * (abstention-gated: escalate-only, never part of score/exit). Only
+   * producers running with --nanomind populate these; parity fixtures
+   * (no --nanomind) never carry them.
+   */
+  analystEscalations?: Array<Record<string, unknown>>;
+  /** Coverage-sweep accounting (candidates/swept/skipped/nullVerdicts/policy). */
+  coverageSweep?: Record<string, unknown>;
 }
 
 /**
@@ -151,6 +160,16 @@ export interface CheckOutput {
 
   /** Optional analyst annotations from NanoMind. */
   analystFindings?: Array<Record<string, unknown>>;
+
+  /**
+   * Advisory analyst escalations from the --nanomind coverage sweep.
+   * Emitted AFTER `analystFindings` and only when non-empty, so the
+   * byte-equality parity contract (fixtures never pass --nanomind)
+   * is unaffected.
+   */
+  analystEscalations?: Array<Record<string, unknown>>;
+  /** Coverage-sweep accounting; emitted only when the sweep ran (--nanomind). */
+  coverageSweep?: Record<string, unknown>;
 
   /**
    * Optional rich-context narrative (skill + mcp v1). Always emitted


### PR DESCRIPTION
## Summary
- Adds optional `analystEscalations` / `coverageSweep` to `ScanResult` and `CheckOutput` so producers running `check <npm|pypi|github> --nanomind --json` stop dropping the advisory analyst channel at `buildCheckOutput`.
- Emission order: after `analystFindings` (escalations only when non-empty; sweep accounting whenever the sweep ran), before `narrative` — the 0.1.0 byte-equality parity contract is unaffected because parity fixtures never pass `--nanomind`.
- `CHECK_FIELD_GUIDE` + JSON Schema entries for both fields, with explicit do-not-gate-CI guidance on `analystEscalations` (advisory human-review channel, never score/exit).
- Version 0.3.0 + CHANGELOG.

## Testing
- 107 package tests green (8 files), including new output-ordering and schema tests.
- Full monorepo suite green (20/20 turbo tasks).
- Parity unaffected: fixtures never pass `--nanomind`, keys absent.

## Follow-up (separate PR, after npm publish)
hackmyagent adoption: exact pin `"@opena2a/check-core": "0.3.0"`, wire `coverageSweep` into the check `--json` paths.