### PR TITLE
feat(atx-verify): new @opena2a/atx-verify shared package (extraction step 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -961,6 +961,10 @@
       "resolved": "packages/aim-core",
       "link": true
     },
+    "node_modules/@opena2a/atx-verify": {
+      "resolved": "packages/atx-verify",
+      "link": true
+    },
     "node_modules/@opena2a/check-core": {
       "resolved": "packages/check-core",
       "link": true
@@ -1765,6 +1769,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
       }
     },
     "node_modules/chai": {
@@ -4137,9 +4150,35 @@
         "undici-types": "~6.21.0"
       }
     },
+    "packages/atx-verify": {
+      "name": "@opena2a/atx-verify",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "canonicalize": "2.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.7.0",
+        "vitest": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/atx-verify/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "packages/check-core": {
       "name": "@opena2a/check-core",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opena2a/registry-client": "0.1.0"

--- a/packages/atx-verify/LICENSE
+++ b/packages/atx-verify/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/atx-verify/README.md
+++ b/packages/atx-verify/README.md
@@ -1,0 +1,76 @@
+# @opena2a/atx-verify
+
+Spec-compliant **offline** verifier for ATX (Agent Trust eXtension) credentials —
+the signed, portable credential that states what an agent *is*.
+
+This is the single shared TypeScript verifier for the OpenA2A ecosystem. It is
+**byte-for-byte interoperable** with the Go (`opena2a-registry/pkg/atcverify`)
+and Python (`atx-conformance`) reference verifiers; canonicalization agreement
+across Go == Python == TS is pinned by `atx-conformance/jcs-vectors`.
+
+## What it does
+
+`LocalAtxVerifier.verify(atx)` runs the full local check with no network call:
+
+1. schema version (`atcVersion` `1.0` or `1.1`)
+2. expiry
+3. revocation (the credential's `revoked` field + a cached/federated CRL)
+4. issuer trust (issuer DID against injected trust anchors)
+5. Ed25519 signature over the canonical payload
+
+Trust anchors (trusted issuers, public keys, CRL, clock) are **injected** — the
+library does no I/O. A consumer wires the live anchors (and, in production, the
+post-quantum half) via the `AtxVerifier` seam.
+
+## Signature coverage depends on `atcVersion`
+
+- **v1.0** (`canonicalPayload`) signs an 11-field pipe-delimited string covering
+  identity, issuer, trustLevel, trustScore, contentHash, buildAttestation, and
+  the validity window. It does **not** cover `capabilities`, `scanSummary`,
+  `issuerChain`, or `publisher` — a holder can edit those without breaking the
+  signature, so they MUST NOT be trusted for authorization.
+- **v1.1** (`canonicalPayloadV11`) signs `JCS(TBS)` (RFC 8785), which **does**
+  cover `capabilities`, `scanSummary`, `issuerChain`, `publisher`, and
+  `behavioralProfile`.
+
+The verified context exposes `signedCapabilities` (true iff v1.1) so callers can
+gate capability-based authorization on whether those fields are signed.
+
+## Scope
+
+Ed25519 is verified fully via Node's `crypto`. **ML-DSA-65** presence is recorded
+(`mldsaPresent`) but verification is delegated — Node's stdlib has no ML-DSA,
+matching the Python reference verifier. Wire the PQC half via the `AtxVerifier`
+seam in production.
+
+## Usage
+
+```ts
+import { LocalAtxVerifier, type AtxTrustAnchors } from "@opena2a/atx-verify";
+
+const anchors: AtxTrustAnchors = {
+  trustedIssuers: ["did:opena2a:authority:opena2a.org"],
+  publicKeys: [{ algorithm: "Ed25519", publicKeyHex: "<32-byte hex>" }],
+  crl: { entries: [] },
+};
+
+const result = new LocalAtxVerifier(anchors).verify(atx);
+if (result.valid) {
+  // result.context — backend-free; only authorize on capabilities when
+  // result.context.signedCapabilities is true (v1.1).
+} else {
+  // result.rejectCategory: UNSUPPORTED_VERSION | EXPIRED | REVOKED
+  //   | UNTRUSTED_ISSUER | SIGNATURE_INVALID | MALFORMED
+}
+```
+
+## Conformance
+
+`src/conformance.test.ts` runs the verifier against the OpenA2A ATX conformance
+fixtures (with their pinned signatures), and `src/atx.test.ts` pins the v1.1
+JCS baseline canonical bytes from `atx-conformance/jcs-vectors`. Any drift from
+the cross-language contract fails the package's own CI.
+
+## License
+
+Apache-2.0

--- a/packages/atx-verify/package.json
+++ b/packages/atx-verify/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@opena2a/atx-verify",
+  "version": "0.1.0",
+  "description": "Spec-compliant offline verifier for ATX (Agent Trust eXtension) credentials — Ed25519 signature verification over the canonical payload (v1.0 pipe / v1.1 JCS RFC 8785), expiry, revocation, issuer-trust, and issuer-chain checks. Byte-for-byte interoperable with the Go and Python reference verifiers.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run --passWithNoTests",
+    "lint": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "canonicalize": "2.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.8"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opena2a-org/opena2a.git",
+    "directory": "packages/atx-verify"
+  },
+  "homepage": "https://github.com/opena2a-org/opena2a/tree/main/packages/atx-verify",
+  "license": "Apache-2.0"
+}

--- a/packages/atx-verify/src/__fixtures__/baseline-valid.json
+++ b/packages/atx-verify/src/__fixtures__/baseline-valid.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/baseline-valid",
+  "description": "A baseline ATX v1.0 credential issued by a single trusted authority with one Ed25519 signature. Verifier MUST ACCEPT.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "ACCEPT"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:opena2a.org-root"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "T+tCrEORj2ipWjPwZIEHxvJUw2qIEWILz6HITxrVEnw9kpnaGmp5a1YGAnKuQZC3Vp4LEmyq6RqkQCIh/C/pAg=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/expired.json
+++ b/packages/atx-verify/src/__fixtures__/expired.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/expired",
+  "description": "An otherwise-valid ATX whose ExpiresAt is earlier than the verifier's pinned clock. Verifier MUST REJECT with an expiry reason.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "EXPIRED",
+    "reasonContains": "expired"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2024-12-25T00:00:00Z",
+    "expiresAt": "2025-01-01T00:00:00Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:opena2a.org-root"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "JOSQmvkgHjPMBHMOwR+EdoTSNGB0wbYZPNoEJpTmHxmfJtR3gHKUtGdBpL1YNauzzdwlouv+NEgocN6wKfJyCw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/revoked.json
+++ b/packages/atx-verify/src/__fixtures__/revoked.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/revoked",
+  "description": "A previously-valid ATX whose credential-level Revoked flag is set and whose AgentID also appears in the verifier's CRL. Verifier MUST REJECT with revocation reason. Both rejection paths are exercised.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ],
+    "crl": {
+      "version": 1,
+      "issuedAt": "2026-05-23T12:00:00Z",
+      "nextUpdate": "2026-05-30T12:00:00Z",
+      "entries": [
+        {
+          "agentId": "agent_conformance_test_001",
+          "revokedAt": "2026-05-23T12:00:00Z",
+          "reason": "key compromise (test)"
+        }
+      ],
+      "signature": "TEST_ONLY_UNSIGNED_CRL"
+    }
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "REVOKED",
+    "reasonContains": "revoked"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:opena2a.org-root"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "T+tCrEORj2ipWjPwZIEHxvJUw2qIEWILz6HITxrVEnw9kpnaGmp5a1YGAnKuQZC3Vp4LEmyq6RqkQCIh/C/pAg=="
+      }
+    ],
+    "revoked": true,
+    "revokedAt": "2026-05-23T12:00:00Z",
+    "revocationReason": "key compromise (test)",
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/tampered-signature.json
+++ b/packages/atx-verify/src/__fixtures__/tampered-signature.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/tampered-signature",
+  "description": "An ATX whose Ed25519 signature has been flipped by one bit after signing. All other fields are unchanged. Verifier MUST REJECT with a signature-validation reason.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "SIGNATURE_INVALID",
+    "reasonContains": "signature"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:opena2a.org-root"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "TutCrEORj2ipWjPwZIEHxvJUw2qIEWILz6HITxrVEnw9kpnaGmp5a1YGAnKuQZC3Vp4LEmyq6RqkQCIh/C/pAg=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/wrong-issuer.json
+++ b/packages/atx-verify/src/__fixtures__/wrong-issuer.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/wrong-issuer",
+  "description": "A syntactically valid ATX signed by a real keypair, but issued under a DID that is NOT in the verifier's trusted set. The signature itself is valid; the issuer is not. Verifier MUST REJECT with an untrusted-issuer reason.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-untrusted",
+      "path": "vectors/issuer-untrusted.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "278117fc144c72340f67d0f2316e8386ceffbf2b2428c9c51fef7c597f1d426e",
+      "keyId": "did:opena2a:authority:attacker.example#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "UNTRUSTED_ISSUER",
+    "reasonContains": "untrusted"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 1,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:attacker.example",
+    "issuerChain": [
+      "did:opena2a:authority:attacker.example"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:attacker.example#key-1",
+        "algorithm": "Ed25519",
+        "value": "7dzmtuVx5geTo2PsMEBxK+ETeMrzb2wVMPC7rswh0jpDYhfo0mdQPRfkQ4RUoo3FJMOz00pRDiG1u5dd+CT2CQ=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/atx.test.ts
+++ b/packages/atx-verify/src/atx.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect } from 'vitest';
+import * as crypto from 'node:crypto';
+import {
+  LocalAtxVerifier,
+  canonicalPayload,
+  canonicalPayloadV11,
+  normalizeRfc3339,
+  type Atx,
+  type AtxTrustAnchors,
+} from './atx.js';
+
+// ---------------------------------------------------------------------------
+// Shared test fixtures. Kept inside a *.test.ts file so they are excluded from
+// the build (tsconfig excludes src/**/*.test.ts) and never ship in dist.
+// ---------------------------------------------------------------------------
+
+export const TEST_ISSUER = 'did:opena2a:authority:opena2a.org';
+export const TEST_CLOCK = new Date('2026-06-01T12:00:00Z');
+
+export function makeKeypair(): { privateKey: crypto.KeyObject; pubHex: string } {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+  const jwk = publicKey.export({ format: 'jwk' }) as { x: string };
+  const pubHex = Buffer.from(jwk.x, 'base64url').toString('hex');
+  return { privateKey, pubHex };
+}
+
+/** Build a valid, Ed25519-signed ATX (and the matching public key hex). */
+export function makeSignedAtx(overrides: Partial<Atx> = {}): { atx: Atx; pubHex: string } {
+  const { privateKey, pubHex } = makeKeypair();
+  const base: Atx = {
+    atcVersion: '1.0',
+    agentId: 'aim_orders_reader',
+    agentDid: 'did:opena2a:agent:acme/orders-reader',
+    version: '1.0.0',
+    contentHash: 'sha256:abc123',
+    buildAttestation: 'sha256:def456',
+    issuerDid: TEST_ISSUER,
+    issuerChain: [TEST_ISSUER],
+    trustLevel: 4,
+    trustScore: 0.95,
+    issuedAt: '2026-05-25T00:00:00Z',
+    expiresAt: '2026-06-08T00:00:00Z',
+    capabilities: ['orders:read'],
+    scanSummary: { oasbLevel: 'L2' },
+    signatures: [],
+    ...overrides,
+  };
+  const sig = crypto.sign(null, canonicalPayload(base), privateKey);
+  base.signatures = [{ keyId: 'test#ed25519', algorithm: 'Ed25519', value: sig.toString('base64') }];
+  return { atx: base, pubHex };
+}
+
+export function makeTrustAnchors(
+  pubHex: string,
+  extra: Partial<AtxTrustAnchors> = {},
+): AtxTrustAnchors {
+  return {
+    trustedIssuers: [TEST_ISSUER],
+    publicKeys: [{ algorithm: 'Ed25519', publicKeyHex: pubHex }],
+    crl: { entries: [] },
+    now: () => TEST_CLOCK,
+    ...extra,
+  };
+}
+
+// ---------------------------------------------------------------------------
+
+describe('LocalAtxVerifier', () => {
+  it('accepts a valid Ed25519-signed ATX and derives a backend-free context', () => {
+    const { atx, pubHex } = makeSignedAtx();
+    const result = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+
+    expect(result.valid).toBe(true);
+    expect(result.context).toMatchObject({
+      agentId: 'aim_orders_reader',
+      issuerDid: TEST_ISSUER,
+      trustLevel: 4,
+      capabilities: ['orders:read'],
+      oasbLevel: 'L2',
+    });
+    // The derived context must not carry any backend/host/token fields.
+    expect(JSON.stringify(result.context)).not.toMatch(/token|secret|host|password|endpoint/i);
+  });
+
+  it('rejects an unsupported schema version', () => {
+    const { atx, pubHex } = makeSignedAtx({ atcVersion: '2.0' });
+    const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+    expect(r.valid).toBe(false);
+    expect(r.rejectCategory).toBe('UNSUPPORTED_VERSION');
+  });
+
+  it('rejects an expired ATX', () => {
+    const { atx, pubHex } = makeSignedAtx({ expiresAt: '2026-05-01T00:00:00Z' });
+    const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+    expect(r.valid).toBe(false);
+    expect(r.rejectCategory).toBe('EXPIRED');
+  });
+
+  it('rejects a revoked ATX (revoked field)', () => {
+    const { atx, pubHex } = makeSignedAtx({ revoked: true });
+    const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+    expect(r.valid).toBe(false);
+    expect(r.rejectCategory).toBe('REVOKED');
+  });
+
+  it('rejects an ATX whose agent is on the CRL', () => {
+    const { atx, pubHex } = makeSignedAtx();
+    const anchors = makeTrustAnchors(pubHex, {
+      crl: { entries: [{ agentId: 'aim_orders_reader', reason: 'compromise' }] },
+    });
+    const r = new LocalAtxVerifier(anchors).verify(atx);
+    expect(r.valid).toBe(false);
+    expect(r.rejectCategory).toBe('REVOKED');
+  });
+
+  it('rejects an untrusted issuer', () => {
+    const { atx, pubHex } = makeSignedAtx({ issuerDid: 'did:opena2a:authority:attacker.example' });
+    const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+    expect(r.valid).toBe(false);
+    expect(r.rejectCategory).toBe('UNTRUSTED_ISSUER');
+  });
+
+  it('rejects a tampered signature', () => {
+    const { atx, pubHex } = makeSignedAtx();
+    // Flip the payload after signing: change trustScore so canonical form no longer matches.
+    const tampered: Atx = { ...atx, trustScore: 0.10 };
+    const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(tampered);
+    expect(r.valid).toBe(false);
+    expect(r.rejectCategory).toBe('SIGNATURE_INVALID');
+  });
+
+  it('rejects when no public key matches', () => {
+    const { atx } = makeSignedAtx();
+    const other = makeKeypair();
+    const r = new LocalAtxVerifier(makeTrustAnchors(other.pubHex)).verify(atx);
+    expect(r.valid).toBe(false);
+    expect(r.rejectCategory).toBe('SIGNATURE_INVALID');
+  });
+
+  it('records ML-DSA-65 presence without silently skipping it', () => {
+    const { atx, pubHex } = makeSignedAtx();
+    atx.signatures.push({ keyId: 'test#pqc', algorithm: 'ML-DSA-65', value: 'AA==' });
+    const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+    expect(r.valid).toBe(true);
+    expect(r.mldsaPresent).toBe(true);
+  });
+});
+
+describe('canonical form', () => {
+  it('matches the documented Go/Python pipe-joined order with %.6f trustScore', () => {
+    const { atx } = makeSignedAtx({ trustScore: 0.5 });
+    const payload = canonicalPayload(atx).toString('utf-8');
+    expect(payload).toBe(
+      'aim_orders_reader|did:opena2a:agent:acme/orders-reader|1.0.0|sha256:abc123|' +
+        'sha256:def456|did:opena2a:authority:opena2a.org|4|0.500000|' +
+        '2026-05-25T00:00:00Z|2026-06-08T00:00:00Z|1.0',
+    );
+  });
+
+  it('normalizes RFC 3339 to seconds-precision UTC Z', () => {
+    expect(normalizeRfc3339('2026-06-08T00:00:00.123Z')).toBe('2026-06-08T00:00:00Z');
+    expect(normalizeRfc3339('2026-06-08T02:00:00+02:00')).toBe('2026-06-08T00:00:00Z');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ATX v1.1 (JCS / RFC 8785). The verifier signs JCS(TBS), so capabilities,
+// scanSummary, issuerChain, and publisher are integrity-protected.
+// ---------------------------------------------------------------------------
+
+// The credential that projects to the jcs-vectors baseline vector. Its canonical
+// bytes are pinned across all four implementations.
+const V11_BASELINE: Omit<Atx, 'signatures'> = {
+  atcVersion: '1.1',
+  agentId: 'agent_conformance_test_001',
+  agentDid: 'did:opena2a:agent:agent_conformance_test_001',
+  publisher: 'opena2a-conformance',
+  publisherDid: 'did:opena2a:publisher:opena2a-conformance',
+  version: '1.0.0',
+  contentHash: '0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff',
+  buildAttestation: 'https://slsa.dev/provenance/v1#opena2a-conformance',
+  issuerDid: 'did:opena2a:authority:opena2a.org',
+  issuerChain: ['did:opena2a:authority:opena2a.org-root', 'did:opena2a:authority:opena2a.org'],
+  trustLevel: 4,
+  trustScore: 87.5,
+  issuedAt: '2026-05-23T00:00:00Z',
+  expiresAt: '2099-12-31T23:59:59Z',
+  capabilities: ['read:public', 'write:owned'],
+  behavioralProfile: { checksum: 'sha256:ghi789', generatedAt: '2026-05-19T00:00:00Z', observationDays: 14 },
+  scanSummary: {
+    hma: 'passed',
+    criticalFindings: 0,
+    highFindings: 0,
+    secretless: 'clean',
+    cryptoServe: 'no-weak-crypto',
+    oasbLevel: 'L1',
+  },
+};
+
+// Pinned in atx-conformance/jcs-vectors/vectors/01-baseline.json. The verifier MUST
+// reproduce these exact bytes or it will reject credentials the registry signs.
+const V11_BASELINE_CANONICAL_HEX =
+  '7b226167656e74446964223a226469643a6f70656e6132613a6167656e743a6167656e745f636f6e666f726d616e63655f746573745f303031222c226167656e744964223a226167656e745f636f6e666f726d616e63655f746573745f303031222c2261746356657273696f6e223a22312e31222c226265686176696f72616c50726f66696c65223a7b22636865636b73756d223a227368613235363a676869373839222c2267656e6572617465644174223a22323032362d30352d31395430303a30303a30305a222c226f62736572766174696f6e44617973223a31347d2c226275696c644174746573746174696f6e223a2268747470733a2f2f736c73612e6465762f70726f76656e616e63652f7631236f70656e6132612d636f6e666f726d616e6365222c226361706162696c6974696573223a5b22726561643a7075626c6963222c2277726974653a6f776e6564225d2c22636f6e74656e7448617368223a2230303030313131313232323233333333343434343535353536363636373737373838383839393939616161616262626263636363646464646565656566666666222c22657870697265734174223a22323039392d31322d33315432333a35393a35395a222c226973737565644174223a22323032362d30352d32335430303a30303a30305a222c22697373756572436861696e223a5b226469643a6f70656e6132613a617574686f726974793a6f70656e6132612e6f72672d726f6f74222c226469643a6f70656e6132613a617574686f726974793a6f70656e6132612e6f7267225d2c22697373756572446964223a226469643a6f70656e6132613a617574686f726974793a6f70656e6132612e6f7267222c227075626c6973686572223a226f70656e6132612d636f6e666f726d616e6365222c227075626c6973686572446964223a226469643a6f70656e6132613a7075626c69736865723a6f70656e6132612d636f6e666f726d616e6365222c227363616e53756d6d617279223a7b22637269746963616c46696e64696e6773223a302c2263727970746f5365727665223a226e6f2d7765616b2d63727970746f222c226869676846696e64696e6773223a302c22686d61223a22706173736564222c226f6173624c6576656c223a224c31222c227365637265746c657373223a22636c65616e227d2c2274727573744c6576656c223a342c22747275737453636f7265223a2238372e353030303030222c2276657273696f6e223a22312e302e30227d';
+
+/** Sign a v1.1 ATX over its JCS(TBS) with a fresh key; mutate after signing for tamper tests. */
+function makeSignedV11Atx(mutate?: (a: Atx) => void): { atx: Atx; pubHex: string } {
+  const { privateKey, pubHex } = makeKeypair();
+  const atx: Atx = { ...V11_BASELINE, signatures: [] };
+  const sig = crypto.sign(null, canonicalPayloadV11(atx), privateKey);
+  atx.signatures = [{ keyId: 'test#ed25519', algorithm: 'Ed25519', value: sig.toString('base64') }];
+  if (mutate) mutate(atx);
+  return { atx, pubHex };
+}
+
+describe('ATX v1.1 (JCS)', () => {
+  it('reproduces the pinned jcs-vectors baseline canonical bytes', () => {
+    const atx: Atx = { ...V11_BASELINE, signatures: [] };
+    expect(canonicalPayloadV11(atx).toString('hex')).toBe(V11_BASELINE_CANONICAL_HEX);
+  });
+
+  it('accepts a valid v1.1 credential and marks capabilities as signed', () => {
+    const { atx, pubHex } = makeSignedV11Atx();
+    const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+    expect(r.valid).toBe(true);
+    expect(r.context?.signedCapabilities).toBe(true);
+    expect(r.context?.capabilities).toEqual(['read:public', 'write:owned']);
+  });
+
+  it('marks v1.0 capabilities as unsigned', () => {
+    const { atx, pubHex } = makeSignedAtx();
+    const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+    expect(r.valid).toBe(true);
+    expect(r.context?.signedCapabilities).toBe(false);
+  });
+
+  it('rejects a v1.1 credential whose capabilities were escalated after signing', () => {
+    const { atx, pubHex } = makeSignedV11Atx((a) => {
+      a.capabilities = ['read:public', 'write:owned', 'admin:all'];
+    });
+    const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+    expect(r.valid).toBe(false);
+    expect(r.rejectCategory).toBe('SIGNATURE_INVALID');
+  });
+
+  it('rejects tampering of other now-signed fields (scanSummary, issuerChain, publisher)', () => {
+    const mutations: Array<(a: Atx) => void> = [
+      (a) => { a.scanSummary = { ...a.scanSummary, oasbLevel: 'L3' }; },
+      (a) => { a.issuerChain = ['did:opena2a:authority:opena2a.org', 'did:opena2a:authority:opena2a.org-root']; },
+      (a) => { a.publisher = 'evil-corp'; },
+    ];
+    for (const mutate of mutations) {
+      const { atx, pubHex } = makeSignedV11Atx(mutate);
+      const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+      expect(r.valid).toBe(false);
+      expect(r.rejectCategory).toBe('SIGNATURE_INVALID');
+    }
+  });
+
+  it('fails closed on a 1.1 -> 1.0 downgrade', () => {
+    const { atx, pubHex } = makeSignedV11Atx((a) => { a.atcVersion = '1.0'; });
+    const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+    expect(r.valid).toBe(false);
+  });
+});

--- a/packages/atx-verify/src/atx.ts
+++ b/packages/atx-verify/src/atx.ts
@@ -1,0 +1,382 @@
+/**
+ * ATX (Agent Trust eXtension) verification — the signed, portable credential
+ * defined by ATP/ATX that states what an agent *is*.
+ *
+ * This verifier mirrors the OpenA2A reference verifiers
+ * (`opena2a-registry/pkg/atcverify/verify.go canonicalPayload()` and the Python
+ * port at `atx-conformance/verifiers/python/verify.py`) VERBATIM so a consumer
+ * accepts exactly the credentials the conformance suite accepts. Byte agreement
+ * across Go == Python == TS is pinned by `atx-conformance/jcs-vectors`.
+ *
+ * (ATX is the current name for the credential formerly called ATC; fixtures use
+ * the `atcVersion` field. This verifier dual-supports both signing forms.)
+ *
+ * Scope: Ed25519 is verified fully. ML-DSA-65 presence is recorded but
+ * verification is delegated — Node's stdlib has no ML-DSA, exactly as the Python
+ * reference verifier skips it. A production deployment wires the post-quantum
+ * half + the live trusted-issuer/CRL anchors via the {@link AtxVerifier} seam.
+ *
+ * SECURITY — signature coverage depends on atcVersion:
+ *  - v1.0 (canonicalPayload): the pipe-delimited string covers identity, issuer,
+ *    trustLevel, trustScore, contentHash, buildAttestation, and the validity
+ *    window. It does NOT cover `capabilities`, `scanSummary.oasbLevel`,
+ *    `issuerChain`, or `jurisdiction`. A holder of any validly-signed v1.0 ATX
+ *    can edit those without invalidating the signature, so they MUST NOT be
+ *    trusted for authorization.
+ *  - v1.1 (canonicalPayloadV11): the signature covers JCS(TBS), which includes
+ *    `capabilities`, `scanSummary`, `issuerChain`, and `publisher`. Those fields
+ *    are integrity-protected and safe to authorize on.
+ *
+ * The verified context exposes `signedCapabilities` (true iff v1.1) so callers
+ * can tell the two apart and gate capability-based authorization accordingly.
+ */
+
+import * as crypto from 'node:crypto';
+import { createRequire } from 'node:module';
+
+// `canonicalize` (RFC 8785) is a CommonJS module whose .d.ts declares an ESM
+// default export; under Node16 ESM resolution that default is not callable at
+// the type layer. createRequire pulls the real callable CJS export — the
+// documented workspace idiom for ESM packages consuming a CJS dependency. The
+// canonicalization output is identical to the Go/Python verifiers (byte
+// agreement pinned by atx-conformance/jcs-vectors).
+const require = createRequire(import.meta.url);
+const canonicalize = require('canonicalize') as (input: unknown) => string | undefined;
+
+/** Legacy schema version: signs the 11-field pipe string (Go quirk, replicated). */
+export const SUPPORTED_ATX_VERSION = '1.0';
+
+/**
+ * ATX v1.1: signs JCS(TBS) (RFC 8785) per atx-spec core.md §1.3a.2, bringing
+ * capabilities, scanSummary, issuerChain, publisher, and behavioralProfile under
+ * the signature. Verified here using the same canonicalizer (erdtman/canonicalize)
+ * and the same TBS projection the registry and conformance verifiers use; byte
+ * agreement is proven by atx-conformance/jcs-vectors.
+ */
+export const SUPPORTED_ATX_VERSION_V11 = '1.1';
+
+/** A signature reference on an ATX. */
+export interface AtxSignature {
+  keyId?: string;
+  algorithm: 'Ed25519' | 'ML-DSA-65' | string;
+  /** base64-encoded signature value. */
+  value: string;
+}
+
+/** The ATX credential (subset used for verification + context derivation). */
+export interface Atx {
+  atcVersion?: string;
+  agentId: string;
+  agentDid: string;
+  /** Publisher identity. Unsigned under v1.0; covered by the v1.1 signature. */
+  publisher?: string;
+  publisherDid?: string;
+  version: string;
+  contentHash: string;
+  buildAttestation?: string;
+  issuerDid: string;
+  issuerChain?: string[];
+  trustLevel: number;
+  trustScore: number;
+  issuedAt: string;
+  expiresAt: string;
+  capabilities?: string[];
+  /** Observed-behavior summary. Covered by the v1.1 signature. */
+  behavioralProfile?: { checksum?: string; generatedAt?: string; observationDays?: number } | null;
+  scanSummary?: { oasbLevel?: string; [k: string]: unknown };
+  /** Optional, optional-to-ignore jurisdiction claim (AAP §9). */
+  jurisdiction?: string[];
+  revoked?: boolean;
+  signatures: AtxSignature[];
+}
+
+/** A public key the verifier trusts, keyed by algorithm. */
+export interface AtxPublicKey {
+  algorithm: 'Ed25519' | 'ML-DSA-65' | string;
+  /** hex-encoded raw public key (32 bytes for Ed25519). */
+  publicKeyHex: string;
+}
+
+/** Trust anchors the verifier evaluates against (in production: fetched from AIM/Registry). */
+export interface AtxTrustAnchors {
+  trustedIssuers: string[];
+  publicKeys: AtxPublicKey[];
+  /** Cached, federated CRL. Revocation rides entirely on the ATX + CRL (AAP §6). */
+  crl?: { entries: Array<{ agentId: string; reason?: string }> };
+  /** Clock source (injectable for tests). Defaults to wall clock. */
+  now?: () => Date;
+}
+
+export type RejectCategory =
+  | 'UNSUPPORTED_VERSION'
+  | 'EXPIRED'
+  | 'REVOKED'
+  | 'UNTRUSTED_ISSUER'
+  | 'SIGNATURE_INVALID'
+  | 'MALFORMED';
+
+/** Context derived from a *verified* ATX. Contains no backend information. */
+export interface ResolutionContext {
+  agentId: string;
+  agentDid: string;
+  issuerDid: string;
+  issuerChain: string[];
+  trustLevel: number;
+  trustScore: number;
+  capabilities: string[];
+  oasbLevel?: string;
+  jurisdiction?: string[];
+  /**
+   * True when the credential is v1.1+, i.e. capabilities/scanSummary/issuerChain
+   * are covered by the signature and may be trusted for authorization. False for
+   * v1.0, where those fields are forgeable by the holder. Callers gating
+   * capability-based authorization should require this.
+   */
+  signedCapabilities: boolean;
+}
+
+export interface AtxVerificationResult {
+  valid: boolean;
+  /** Present when valid: the context to resolve authorization against. */
+  context?: ResolutionContext;
+  /** Present when invalid. */
+  rejectCategory?: RejectCategory;
+  reason?: string;
+  /** Whether an ML-DSA-65 signature was present (and therefore delegated, not skipped silently). */
+  mldsaPresent?: boolean;
+}
+
+/** The verification interface. Lets a consumer swap a local verifier for an AIM-backed one. */
+export interface AtxVerifier {
+  verify(atx: Atx): AtxVerificationResult;
+}
+
+/**
+ * Local ATX verifier. Cryptographically real (Ed25519) and interoperable with the
+ * conformance fixtures; trust anchors are injected. A production counterpart
+ * fetches `trustedIssuers`, `publicKeys`, and the `crl` from AIM's verification
+ * endpoint and adds ML-DSA-65 via the {@link AtxVerifier} seam.
+ */
+export class LocalAtxVerifier implements AtxVerifier {
+  constructor(private readonly anchors: AtxTrustAnchors) {}
+
+  verify(atx: Atx): AtxVerificationResult {
+    const now = (this.anchors.now ?? (() => new Date()))();
+
+    // Step 1: schema version. Dispatch on atcVersion: "1.0" verifies the legacy
+    // pipe form, "1.1" verifies JCS(TBS) (atx-spec §1.3a).
+    if (atx.atcVersion !== SUPPORTED_ATX_VERSION && atx.atcVersion !== SUPPORTED_ATX_VERSION_V11) {
+      return reject('UNSUPPORTED_VERSION', `unsupported atxVersion ${String(atx.atcVersion)}`);
+    }
+    const isV11 = atx.atcVersion === SUPPORTED_ATX_VERSION_V11;
+
+    // Step 2: expiry.
+    const expires = new Date(atx.expiresAt);
+    if (Number.isNaN(expires.getTime())) {
+      return reject('MALFORMED', 'expiresAt is not a valid timestamp');
+    }
+    if (now.getTime() > expires.getTime()) {
+      return reject('EXPIRED', `expired at ${normalizeRfc3339(atx.expiresAt)}`);
+    }
+
+    // Step 3: revocation (ATX field + federated CRL).
+    if (atx.revoked) {
+      return reject('REVOKED', 'credential revoked field is true');
+    }
+    for (const entry of this.anchors.crl?.entries ?? []) {
+      if (entry.agentId === atx.agentId) {
+        return reject('REVOKED', `agent appears on CRL: ${entry.reason ?? ''}`);
+      }
+    }
+
+    // Step 4: issuer trust.
+    if (!this.anchors.trustedIssuers.includes(atx.issuerDid)) {
+      return reject('UNTRUSTED_ISSUER', `issuer DID ${atx.issuerDid} is not trusted`);
+    }
+
+    // Step 5: signature verification (Ed25519 fully; ML-DSA-65 presence recorded).
+    // A v1.1 TBS that fails to canonicalize is a malformed credential, not a
+    // verifier error: reject closed rather than throwing.
+    let payload: Buffer;
+    if (isV11) {
+      try {
+        payload = canonicalPayloadV11(atx);
+      } catch (err) {
+        return reject('MALFORMED', `v1.1 canonicalization failed: ${(err as Error).message}`);
+      }
+    } else {
+      payload = canonicalPayload(atx);
+    }
+    const edKeys = this.anchors.publicKeys
+      .filter((k) => k.algorithm === 'Ed25519')
+      .map((k) => ed25519FromRawHex(k.publicKeyHex))
+      .filter((k): k is crypto.KeyObject => k !== null);
+
+    let edVerified = false;
+    let mldsaPresent = false;
+
+    for (const sig of atx.signatures ?? []) {
+      if (sig.algorithm === 'Ed25519') {
+        let sigBytes: Buffer;
+        try {
+          sigBytes = Buffer.from(sig.value, 'base64');
+        } catch {
+          return reject('SIGNATURE_INVALID', `signature ${sig.keyId ?? ''} has invalid base64`);
+        }
+        const ok = edKeys.some((key) => {
+          try {
+            return crypto.verify(null, payload, key, sigBytes);
+          } catch {
+            return false;
+          }
+        });
+        if (!ok) {
+          return reject('SIGNATURE_INVALID', `Ed25519 signature ${sig.keyId ?? ''} did not verify`);
+        }
+        edVerified = true;
+      } else if (sig.algorithm === 'ML-DSA-65') {
+        // Presence recorded; PQC verification delegated (see module docstring). Not silently skipped.
+        mldsaPresent = true;
+      }
+    }
+
+    if (!edVerified) {
+      return reject('SIGNATURE_INVALID', 'no Ed25519 signature verified');
+    }
+
+    return {
+      valid: true,
+      mldsaPresent,
+      context: {
+        agentId: atx.agentId,
+        agentDid: atx.agentDid,
+        issuerDid: atx.issuerDid,
+        issuerChain: atx.issuerChain ?? [atx.issuerDid],
+        trustLevel: atx.trustLevel,
+        trustScore: atx.trustScore,
+        capabilities: atx.capabilities ?? [],
+        oasbLevel: atx.scanSummary?.oasbLevel,
+        jurisdiction: atx.jurisdiction,
+        signedCapabilities: isV11,
+      },
+    };
+  }
+}
+
+function reject(rejectCategory: RejectCategory, reason: string): AtxVerificationResult {
+  return { valid: false, rejectCategory, reason };
+}
+
+/**
+ * Mirror of `opena2a-registry/pkg/atcverify/verify.go canonicalPayload()`:
+ *   fmt.Sprintf("%s|%s|%s|%s|%s|%s|%d|%.6f|%s|%s|%s", ...)
+ * with atxVersion hardcoded to "1.0".
+ */
+export function canonicalPayload(atx: Atx): Buffer {
+  const fields = [
+    atx.agentId,
+    atx.agentDid,
+    atx.version,
+    atx.contentHash,
+    atx.buildAttestation ?? '',
+    atx.issuerDid,
+    String(Math.trunc(atx.trustLevel)),
+    Number(atx.trustScore).toFixed(6),
+    normalizeRfc3339(atx.issuedAt),
+    normalizeRfc3339(atx.expiresAt),
+    SUPPORTED_ATX_VERSION,
+  ];
+  return Buffer.from(fields.join('|'), 'utf-8');
+}
+
+/**
+ * Project an ATX into the v1.1 TBS and return JCS(TBS) (RFC 8785). Unlike
+ * canonicalPayload, this covers capabilities, scanSummary, issuerChain,
+ * publisher, and behavioralProfile. The projection (canonical empties,
+ * always-full scanSummary, %.6f string trustScore, root-first issuerChain) and
+ * the canonicalizer match opena2a-registry/pkg/atcverify and the conformance
+ * verifiers exactly; byte agreement is pinned by atx-conformance/jcs-vectors.
+ */
+export function canonicalPayloadV11(atx: Atx): Buffer {
+  const scan = (atx.scanSummary ?? {}) as Record<string, unknown>;
+  const tbs: Record<string, unknown> = {
+    atcVersion: atx.atcVersion,
+    agentId: atx.agentId,
+    agentDid: atx.agentDid,
+    publisher: atx.publisher ?? '',
+    publisherDid: atx.publisherDid ?? '',
+    version: atx.version,
+    contentHash: atx.contentHash,
+    buildAttestation: atx.buildAttestation ?? '',
+    capabilities: atx.capabilities ?? [],
+    behavioralProfile: projectBehavioralProfile(atx.behavioralProfile),
+    scanSummary: {
+      hma: asString(scan.hma),
+      criticalFindings: asInt(scan.criticalFindings),
+      highFindings: asInt(scan.highFindings),
+      secretless: asString(scan.secretless),
+      cryptoServe: asString(scan.cryptoServe),
+      oasbLevel: asString(scan.oasbLevel),
+    },
+    // trustScore is the %.6f string form so trustLevel is the only JSON number.
+    trustScore: Number(atx.trustScore).toFixed(6),
+    trustLevel: Math.trunc(atx.trustLevel),
+    issuedAt: normalizeRfc3339(atx.issuedAt),
+    expiresAt: normalizeRfc3339(atx.expiresAt),
+    issuerDid: atx.issuerDid,
+    issuerChain: atx.issuerChain ?? [],
+  };
+  const canonical = canonicalize(tbs);
+  if (typeof canonical !== 'string') {
+    throw new Error('canonicalize returned non-string');
+  }
+  return Buffer.from(canonical, 'utf-8');
+}
+
+/** behavioralProfile -> null when absent, else the canonical three-field object. */
+function projectBehavioralProfile(
+  bp: Atx['behavioralProfile'],
+): null | { checksum: string; generatedAt: string; observationDays: number } {
+  if (bp === null || bp === undefined) {
+    return null;
+  }
+  return {
+    checksum: asString(bp.checksum),
+    generatedAt: bp.generatedAt ? normalizeRfc3339(bp.generatedAt) : '',
+    observationDays: asInt(bp.observationDays),
+  };
+}
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+function asInt(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) ? Math.trunc(v) : 0;
+}
+
+/** Normalize an RFC 3339 timestamp to UTC "YYYY-MM-DDTHH:MM:SSZ" (Go time.RFC3339 for UTC). */
+export function normalizeRfc3339(s: string): string {
+  const dt = new Date(s);
+  if (Number.isNaN(dt.getTime())) {
+    throw new Error(`invalid RFC 3339 timestamp: ${s}`);
+  }
+  return dt.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
+
+/** Build a Node KeyObject from a raw 32-byte Ed25519 public key (hex). */
+function ed25519FromRawHex(hex: string): crypto.KeyObject | null {
+  const raw = Buffer.from(hex, 'hex');
+  if (raw.length !== 32) return null;
+  try {
+    return crypto.createPublicKey({
+      key: Buffer.concat([ED25519_SPKI_PREFIX, raw]),
+      format: 'der',
+      type: 'spki',
+    });
+  } catch {
+    return null;
+  }
+}

--- a/packages/atx-verify/src/conformance.test.ts
+++ b/packages/atx-verify/src/conformance.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Conformance gate: run LocalAtxVerifier against the OpenA2A ATX conformance
+ * fixtures (verbatim copies from `atx-conformance/fixtures/`, including their
+ * PINNED Ed25519 signatures and issuer public keys). This proves the verifier
+ * accepts/rejects exactly the credentials the cross-language suite does — the
+ * same fixtures the Go and Python reference verifiers are gated against.
+ *
+ * We assert the machine contract (verifyResult + rejectCategory). We do NOT
+ * assert the fixtures' `reasonContains` — that is the reference verifiers'
+ * specific human wording; this verifier's reason strings are its own and the
+ * structured rejectCategory is the interoperable contract.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+  LocalAtxVerifier,
+  type Atx,
+  type AtxPublicKey,
+  type AtxTrustAnchors,
+} from './atx.js';
+
+interface Fixture {
+  name: string;
+  verifierState: {
+    clockRfc3339: string;
+    trustedIssuers: string[];
+    publicKeys: Array<{ algorithm: string; publicKeyHex: string }>;
+    crl?: { entries: Array<{ agentId: string; reason?: string }> };
+  };
+  expected: { verifyResult: 'ACCEPT' | 'REJECT'; rejectCategory?: string };
+  atx: Atx;
+}
+
+/** Representative v1.0 fixtures lifted from atx-conformance/fixtures/. */
+const FIXTURE_FILES = [
+  'baseline-valid.json',
+  'tampered-signature.json',
+  'expired.json',
+  'revoked.json',
+  'wrong-issuer.json',
+] as const;
+
+function loadFixture(file: string): Fixture {
+  const url = new URL(`./__fixtures__/${file}`, import.meta.url);
+  return JSON.parse(readFileSync(url, 'utf-8')) as Fixture;
+}
+
+function anchorsFromFixture(f: Fixture): AtxTrustAnchors {
+  const clock = new Date(f.verifierState.clockRfc3339);
+  return {
+    trustedIssuers: f.verifierState.trustedIssuers,
+    publicKeys: f.verifierState.publicKeys.map(
+      (k): AtxPublicKey => ({ algorithm: k.algorithm, publicKeyHex: k.publicKeyHex }),
+    ),
+    crl: f.verifierState.crl,
+    now: () => clock,
+  };
+}
+
+describe('conformance fixtures (atx-conformance/fixtures, pinned signatures)', () => {
+  for (const file of FIXTURE_FILES) {
+    const f = loadFixture(file);
+    it(`${f.name} -> ${f.expected.verifyResult}${f.expected.rejectCategory ? ` (${f.expected.rejectCategory})` : ''}`, () => {
+      const result = new LocalAtxVerifier(anchorsFromFixture(f)).verify(f.atx);
+      expect(result.valid).toBe(f.expected.verifyResult === 'ACCEPT');
+      if (f.expected.verifyResult === 'REJECT' && f.expected.rejectCategory) {
+        expect(result.rejectCategory).toBe(f.expected.rejectCategory);
+      }
+    });
+  }
+});

--- a/packages/atx-verify/src/index.ts
+++ b/packages/atx-verify/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @opena2a/atx-verify — spec-compliant offline verifier for ATX (Agent Trust
+ * eXtension) credentials. Byte-for-byte interoperable with the Go
+ * (`opena2a-registry/pkg/atcverify`) and Python (`atx-conformance`) reference
+ * verifiers; canonicalization agreement is pinned by `atx-conformance/jcs-vectors`.
+ */
+export {
+  LocalAtxVerifier,
+  canonicalPayload,
+  canonicalPayloadV11,
+  normalizeRfc3339,
+  SUPPORTED_ATX_VERSION,
+  SUPPORTED_ATX_VERSION_V11,
+  type Atx,
+  type AtxSignature,
+  type AtxPublicKey,
+  type AtxTrustAnchors,
+  type AtxVerifier,
+  type AtxVerificationResult,
+  type ResolutionContext,
+  type RejectCategory,
+} from './atx.js';

--- a/packages/atx-verify/tsconfig.json
+++ b/packages/atx-verify/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## What

Introduces `@opena2a/atx-verify` — a spec-compliant **offline** verifier for ATX (Agent Trust eXtension) credentials, extracted from `secretless/src/broker/atx.ts` into a shared package.

**Why a shared package:** a complete, conformance-aligned TS verifier already lived in secretless's broker; the AIM agent SDK (which still does a blocking remote POST) needs the same capability. Copying it into the AIM SDK would create a second TS implementation — exactly the multi-impl drift the cross-language byte-agreement gate (`atx-conformance/jcs-vectors`, Go==Py==TS) exists to prevent. One shared verifier, consumed by both. [CHIEF-CA] decision recorded in `todo/2026-06-10-aim-local-verification-gap.md`.

## What it does

`LocalAtxVerifier.verify(atx)` — schema-version dispatch, expiry, revocation (field + CRL), issuer-trust, Ed25519 signature over the canonical payload (v1.0 pipe / v1.1 JCS RFC 8785). Trust anchors injected → zero I/O. ML-DSA-65 presence recorded, verify delegated (matches the Python reference verifier). `signedCapabilities` tells callers whether capabilities/scanSummary/issuerChain are under the signature (v1.1) and thus safe to authorize on.

## Faithful extraction

Verification logic lifted **verbatim** from secretless. The only code-level changes are the ESM-Node16 import adaptations: `crypto`→`node:crypto`, and `import canonicalize`→`createRequire('canonicalize')` (a CJS default-export dep). Canonicalization output is **byte-identical** to the Go (`opena2a-registry/pkg/atcverify`) and Python (`atx-conformance`) verifiers.

## Conformance-gated at its own CI

- `src/conformance.test.ts` runs the real `atx-conformance/fixtures` (with their **pinned** Ed25519 signatures + RFC 8032 §7.1 issuer key): baseline-valid ACCEPT; tampered/expired/revoked/wrong-issuer REJECT with the correct category.
- `src/atx.test.ts` pins the v1.1 JCS baseline canonical bytes from `atx-conformance/jcs-vectors`. Any byte-level drift fails CI.
- 22 tests pass.

## Scope — this is EXTRACTION STEP 1

Follow-ons (each its own PR): publish `@opena2a/atx-verify` → swap secretless's broker to consume it and **delete its local copy** (kills the drift window) → AIM SDK adds a local-verify path using it → Java SDK is a separate port. **Until then secretless keeps its own copy and nothing changes for any consumer** — this PR only adds a new, unconsumed package.

## Testing

Monorepo build/test/lint green (11/22/16 turbo tasks). Package: 22 tests, build + tsc clean, HMA 98/100 (lone `.gitignore` subdir FP). Full `/pre-push-review` PASS incl. Phase 4.5 adversarial review (zero findings — extraction confirmed faithful + fail-closed, conformance gate confirmed real). Tarball ships only `dist`+`README`+`LICENSE` (no fixtures/keys).