### PR TITLE
ci(release): publish @opena2a/atx-verify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
       - 'check-core-v*'
       - 'telemetry-v*'
       - 'credential-patterns-v*'
+      - 'atx-verify-v*'
 
 permissions:
   contents: write
@@ -81,6 +82,7 @@ jobs:
           publish_if_new packages/check-core @opena2a/check-core
           publish_if_new packages/telemetry @opena2a/telemetry
           publish_if_new packages/credential-patterns @opena2a/credential-patterns
+          publish_if_new packages/atx-verify @opena2a/atx-verify
           echo "=== Published this run ==="
           cat /tmp/published.txt
           echo "=== Skipped (version already on npm) ==="


### PR DESCRIPTION
Adds `@opena2a/atx-verify` (merged in #212) to the release workflow: an `atx-verify-v*` tag trigger + an idempotent `publish_if_new` step. Two-line CI-config change.

**Prerequisite for the first publish:** Trusted Publishing must be configured for `@opena2a/atx-verify` on npmjs.com (one-time, per the org publish runbook) before the first `atx-verify-v*` tag-push, or the publish job fails with OIDC verification error.