### PR TITLE
release: @opena2a/atx-verify 0.1.1 (first attested publish)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4152,7 +4152,7 @@
     },
     "packages/atx-verify": {
       "name": "@opena2a/atx-verify",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "canonicalize": "2.1.0"

--- a/packages/atx-verify/package.json
+++ b/packages/atx-verify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/atx-verify",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Spec-compliant offline verifier for ATX (Agent Trust eXtension) credentials — Ed25519 signature verification over the canonical payload (v1.0 pipe / v1.1 JCS RFC 8785), expiry, revocation, issuer-trust, and issuer-chain checks. Byte-for-byte interoperable with the Go and Python reference verifiers.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump 0.1.0 → 0.1.1 so the first provenance-attested version (published via the release workflow's OIDC Trusted Publishing on the `atx-verify-v0.1.1` tag) supersedes the unattested bootstrap `0.1.0`. `0.1.0` (manual bootstrap to unlock TP) will be deprecated. Version + lockfile only.