### PR TITLE
feat(atx-verify): key-to-issuer binding via optional keyId (0.2.0)

### DIFF
--- a/packages/atx-verify/README.md
+++ b/packages/atx-verify/README.md
@@ -50,7 +50,16 @@ import { LocalAtxVerifier, type AtxTrustAnchors } from "@opena2a/atx-verify";
 
 const anchors: AtxTrustAnchors = {
   trustedIssuers: ["did:opena2a:authority:opena2a.org"],
-  publicKeys: [{ algorithm: "Ed25519", publicKeyHex: "<32-byte hex>" }],
+  publicKeys: [
+    {
+      algorithm: "Ed25519",
+      publicKeyHex: "<32-byte hex>",
+      // Recommended: a DID-URL keyId binds the key to its controller so it can
+      // only verify credentials issued by that DID. Required to be safe with a
+      // MULTI-issuer anchor set (see "Key-to-issuer binding" below).
+      keyId: "did:opena2a:authority:opena2a.org#key-1",
+    },
+  ],
   crl: { entries: [] },
 };
 
@@ -63,6 +72,20 @@ if (result.valid) {
   //   | UNTRUSTED_ISSUER | SIGNATURE_INVALID | MALFORMED
 }
 ```
+
+## Key-to-issuer binding
+
+A signature is only accepted from a key controlled by the credential's issuer.
+A configured key whose `keyId` is a DID-URL (contains `#`) is **bound** to its
+controller DID and may only verify credentials issued by that DID — or, for
+v1.1 (where `issuerChain` is signed), by an authority named in the chain. This
+prevents one trusted issuer's key from satisfying a credential issued under a
+different issuer's DID.
+
+A key with no `keyId`, or a `keyId` without a `#` fragment, is treated as
+**unbound** and stays eligible for any issuer — safe for a single-issuer anchor
+set, but supply DID-URL `keyId`s whenever the anchor set holds keys for more
+than one issuer.
 
 ## Conformance
 

--- a/packages/atx-verify/package.json
+++ b/packages/atx-verify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/atx-verify",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Spec-compliant offline verifier for ATX (Agent Trust eXtension) credentials — Ed25519 signature verification over the canonical payload (v1.0 pipe / v1.1 JCS RFC 8785), expiry, revocation, issuer-trust, and issuer-chain checks. Byte-for-byte interoperable with the Go and Python reference verifiers.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/atx-verify/src/__fixtures__/cross-issuer-key.json
+++ b/packages/atx-verify/src/__fixtures__/cross-issuer-key.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/cross-issuer-key",
+  "description": "An ATX v1.0 credential issued by the primary authority (issuerDid = did:opena2a:authority:opena2a.org) but signed by a DIFFERENT trusted authority's key (did:opena2a:authority:partner.example#key-1). The signature is valid over the canonical payload and the signing authority is independently trusted, yet that key is not controlled by the credential's issuer and is not in its issuerChain. A verifier MUST bind each signature to a key controlled by the credential's issuer and MUST REJECT with a signature-validation reason, so a trusted authority cannot impersonate another. A verifier that tries every configured key would wrongly ACCEPT.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    },
+    {
+      "role": "issuer-secondary",
+      "path": "vectors/issuer-secondary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "2043fa51c3d9e4a21a535ccb38bdc4fb56083737d22059d69475e7e43c47f582",
+      "keyId": "did:opena2a:authority:partner.example#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:partner.example"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      },
+      {
+        "role": "issuer-secondary",
+        "path": "vectors/issuer-secondary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "2043fa51c3d9e4a21a535ccb38bdc4fb56083737d22059d69475e7e43c47f582",
+        "keyId": "did:opena2a:authority:partner.example#key-1"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "SIGNATURE_INVALID",
+    "reasonContains": "signature"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:opena2a.org-root"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:partner.example#key-1",
+        "algorithm": "Ed25519",
+        "value": "TYFaUp36vaF5R1RqgDirhkDSArRhH2wZRG4Cttb+LCgUVX7P00vCYap5DRd4rQtwaVKK3d1GPChqI48ErRC0Cg=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/atx.keybinding.test.ts
+++ b/packages/atx-verify/src/atx.keybinding.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Key↔issuer binding: a configured key whose keyId names a controller DID may
+ * only verify signatures for credentials issued by that controller (or, for
+ * v1.1, a signed issuerChain authority). One trusted issuer cannot impersonate
+ * another. Keys without a DID-URL keyId stay unbound (back-compat).
+ */
+import { describe, it, expect } from 'vitest';
+import * as crypto from 'node:crypto';
+import {
+  LocalAtxVerifier,
+  canonicalPayload,
+  canonicalPayloadV11,
+  type Atx,
+  type AtxTrustAnchors,
+} from './atx.js';
+
+const ISSUER_A = 'did:opena2a:authority:a.example';
+const ISSUER_B = 'did:opena2a:authority:b.example';
+const CLOCK = new Date('2026-05-25T00:00:00Z');
+
+function keypair(): { privateKey: crypto.KeyObject; pubHex: string } {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+  const jwk = publicKey.export({ format: 'jwk' }) as { x: string };
+  return { privateKey, pubHex: Buffer.from(jwk.x, 'base64url').toString('hex') };
+}
+
+function atxBase(overrides: Partial<Atx> = {}): Atx {
+  return {
+    atcVersion: '1.0',
+    agentId: 'agent-1',
+    agentDid: 'did:opena2a:agent:a/agent-1',
+    version: '1.0.0',
+    contentHash: 'sha256:abc',
+    issuerDid: ISSUER_A,
+    issuerChain: [ISSUER_A],
+    trustLevel: 2,
+    trustScore: 0.9,
+    issuedAt: '2026-05-20T00:00:00Z',
+    expiresAt: '2026-06-20T00:00:00Z',
+    capabilities: ['orders:read'],
+    signatures: [],
+    ...overrides,
+  };
+}
+
+function signWith(atx: Atx, key: crypto.KeyObject, keyId: string): Atx {
+  const payload = atx.atcVersion === '1.1' ? canonicalPayloadV11(atx) : canonicalPayload(atx);
+  return {
+    ...atx,
+    signatures: [{ keyId, algorithm: 'Ed25519', value: crypto.sign(null, payload, key).toString('base64') }],
+  };
+}
+
+function anchors(extra: Partial<AtxTrustAnchors>): AtxTrustAnchors {
+  return {
+    trustedIssuers: [ISSUER_A, ISSUER_B],
+    publicKeys: [],
+    crl: { entries: [] },
+    now: () => CLOCK,
+    ...extra,
+  };
+}
+
+describe('key-to-issuer binding', () => {
+  it('rejects a credential issued by A but signed by trusted issuer B (v1.0)', () => {
+    const a = keypair();
+    const b = keypair();
+    const atx = signWith(atxBase({ issuerDid: ISSUER_A }), b.privateKey, `${ISSUER_B}#key-1`);
+    const result = new LocalAtxVerifier(
+      anchors({
+        publicKeys: [
+          { algorithm: 'Ed25519', publicKeyHex: a.pubHex, keyId: `${ISSUER_A}#key-1` },
+          { algorithm: 'Ed25519', publicKeyHex: b.pubHex, keyId: `${ISSUER_B}#key-1` },
+        ],
+      }),
+    ).verify(atx);
+    expect(result.valid).toBe(false);
+    expect(result.rejectCategory).toBe('SIGNATURE_INVALID');
+  });
+
+  it('rejects the same cross-issuer case under v1.1 (B not in signed issuerChain)', () => {
+    const a = keypair();
+    const b = keypair();
+    const atx = signWith(
+      atxBase({ atcVersion: '1.1', issuerDid: ISSUER_A, issuerChain: [ISSUER_A] }),
+      b.privateKey,
+      `${ISSUER_B}#key-1`,
+    );
+    const result = new LocalAtxVerifier(
+      anchors({
+        publicKeys: [
+          { algorithm: 'Ed25519', publicKeyHex: a.pubHex, keyId: `${ISSUER_A}#key-1` },
+          { algorithm: 'Ed25519', publicKeyHex: b.pubHex, keyId: `${ISSUER_B}#key-1` },
+        ],
+      }),
+    ).verify(atx);
+    expect(result.valid).toBe(false);
+    expect(result.rejectCategory).toBe('SIGNATURE_INVALID');
+  });
+
+  it('accepts a v1.1 cross-org cosignature when the signer is in the signed issuerChain', () => {
+    const b = keypair();
+    // issuer is A, but B is a cosigning authority named in the (signed) issuerChain.
+    const atx = signWith(
+      atxBase({ atcVersion: '1.1', issuerDid: ISSUER_A, issuerChain: [ISSUER_A, ISSUER_B] }),
+      b.privateKey,
+      `${ISSUER_B}#key-1`,
+    );
+    const result = new LocalAtxVerifier(
+      anchors({
+        publicKeys: [{ algorithm: 'Ed25519', publicKeyHex: b.pubHex, keyId: `${ISSUER_B}#key-1` }],
+      }),
+    ).verify(atx);
+    expect(result.valid).toBe(true);
+  });
+
+  it('treats a key with no DID-URL keyId as unbound (back-compat)', () => {
+    const a = keypair();
+    const atx = signWith(atxBase({ issuerDid: ISSUER_A }), a.privateKey, 'legacy-key');
+    const result = new LocalAtxVerifier(
+      anchors({
+        // keyId without '#': unbound, eligible for any issuer.
+        publicKeys: [{ algorithm: 'Ed25519', publicKeyHex: a.pubHex, keyId: 'legacy-key' }],
+      }),
+    ).verify(atx);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/packages/atx-verify/src/atx.ts
+++ b/packages/atx-verify/src/atx.ts
@@ -95,6 +95,16 @@ export interface AtxPublicKey {
   algorithm: 'Ed25519' | 'ML-DSA-65' | string;
   /** hex-encoded raw public key (32 bytes for Ed25519). */
   publicKeyHex: string;
+  /**
+   * Optional DID-URL identifying the key and its controller, e.g.
+   * `did:opena2a:authority:opena2a.org#key-1`. When present (contains `#`), the
+   * key is BOUND to its controller DID: it may only verify signatures for
+   * credentials issued by that controller (or, for v1.1, an issuerChain
+   * authority). This stops one trusted issuer's key from satisfying a credential
+   * issued under a different DID. A key without a `#` fragment is unbound and is
+   * eligible for any issuer (back-compat for single-issuer anchor sets).
+   */
+  keyId?: string;
 }
 
 /** Trust anchors the verifier evaluates against (in production: fetched from AIM/Registry). */
@@ -207,8 +217,18 @@ export class LocalAtxVerifier implements AtxVerifier {
     } else {
       payload = canonicalPayload(atx);
     }
+    // Key↔issuer binding: a key may verify a signature for this credential only
+    // if it is controlled by one of the credential's authorities — the issuer,
+    // plus the issuerChain authorities for v1.1 (where the chain is signed; v1.0
+    // chain is unsigned/forgeable, so only the issuer counts). A key whose keyId
+    // is not a DID-URL (no '#') is unbound and stays eligible (back-compat).
+    const authoritySet = new Set<string>([atx.issuerDid]);
+    if (isV11) {
+      for (const did of atx.issuerChain ?? []) authoritySet.add(did);
+    }
     const edKeys = this.anchors.publicKeys
       .filter((k) => k.algorithm === 'Ed25519')
+      .filter((k) => keyEligible(k.keyId, authoritySet))
       .map((k) => ed25519FromRawHex(k.publicKeyHex))
       .filter((k): k is crypto.KeyObject => k !== null);
 
@@ -265,6 +285,26 @@ export class LocalAtxVerifier implements AtxVerifier {
 
 function reject(rejectCategory: RejectCategory, reason: string): AtxVerificationResult {
   return { valid: false, rejectCategory, reason };
+}
+
+/**
+ * Whether a key may verify a signature for an issuer in `authoritySet`. Binding
+ * applies only to keys whose keyId is a DID-URL (contains '#', naming a
+ * controller DID): such a key is eligible only if its controller is in the set.
+ * A key without a '#' fragment (or no keyId) expresses no controller and is
+ * treated as unbound (legacy single-issuer configs), so it stays eligible.
+ */
+function keyEligible(keyId: string | undefined, authoritySet: Set<string>): boolean {
+  if (!keyId || !keyId.includes('#')) {
+    return true;
+  }
+  return authoritySet.has(controllerDid(keyId));
+}
+
+/** The DID portion of a keyId DID-URL (everything before the first '#'). */
+function controllerDid(keyId: string): string {
+  const i = keyId.indexOf('#');
+  return i >= 0 ? keyId.slice(0, i) : keyId;
 }
 
 /**

--- a/packages/atx-verify/src/conformance.test.ts
+++ b/packages/atx-verify/src/conformance.test.ts
@@ -24,7 +24,7 @@ interface Fixture {
   verifierState: {
     clockRfc3339: string;
     trustedIssuers: string[];
-    publicKeys: Array<{ algorithm: string; publicKeyHex: string }>;
+    publicKeys: Array<{ algorithm: string; publicKeyHex: string; keyId?: string }>;
     crl?: { entries: Array<{ agentId: string; reason?: string }> };
   };
   expected: { verifyResult: 'ACCEPT' | 'REJECT'; rejectCategory?: string };
@@ -38,6 +38,7 @@ const FIXTURE_FILES = [
   'expired.json',
   'revoked.json',
   'wrong-issuer.json',
+  'cross-issuer-key.json',
 ] as const;
 
 function loadFixture(file: string): Fixture {
@@ -50,7 +51,7 @@ function anchorsFromFixture(f: Fixture): AtxTrustAnchors {
   return {
     trustedIssuers: f.verifierState.trustedIssuers,
     publicKeys: f.verifierState.publicKeys.map(
-      (k): AtxPublicKey => ({ algorithm: k.algorithm, publicKeyHex: k.publicKeyHex }),
+      (k): AtxPublicKey => ({ algorithm: k.algorithm, publicKeyHex: k.publicKeyHex, keyId: k.keyId }),
     ),
     crl: f.verifierState.crl,
     now: () => clock,


### PR DESCRIPTION
## Summary

Closes the multi-issuer attribution gap surfaced by AIM SDK PR #299 (Phase 4.5). `LocalAtxVerifier` tried each signature against **every** configured key, so with a multi-issuer anchor set one trusted issuer's key could satisfy a credential issued under a different issuer DID.

## Fix

`AtxPublicKey` gains an optional `keyId`. A key whose `keyId` is a DID-URL (contains `#`) is **bound** to its controller DID and may only verify credentials issued by that DID — or, for v1.1 (signed `issuerChain`), an issuerChain authority. Keys without a `#` fragment stay unbound (back-compat for single-issuer anchor sets). `verify()` filters eligible keys by the credential's authority set before checking signatures.

Mirrors the conformance reference verifiers and `opena2a-registry/pkg/atcverify` — all four implementations verified semantically identical by an adversarial review (no CRITICAL/HIGH).

## Changes

- `AtxPublicKey.keyId?` (optional — additive, non-breaking shape change).
- `verify()` key↔issuer eligibility filter.
- `conformance.test.ts` threads `keyId` and adds the `cross-issuer-key` fixture.
- Self-contained binding tests incl. the positive v1.1 cross-org (signed-chain) accept case and unbound back-compat.
- Version **0.1.1 → 0.2.0** (minor: additive optional field).

## Tests

`npm run build` + `vitest run`: **27/27 pass**.

## Rollout

After merge: publish `@opena2a/atx-verify@0.2.0` via Trusted Publishing, then update consumers (secretless broker, `@opena2a/aim-sdk`) to pass `keyId` in anchors and drop the interim single-issuer caveat.

🤖 Verifier-path change; reviewed via adversarial pass across all four implementations.