### PR TITLE
fix(deps): bump hono and js-yaml in lockfile to clear npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2637,9 +2637,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2736,9 +2736,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
## What

Surgical `package-lock.json` bump of two transitive dependencies that had drifted behind available patches, tripping the `Security / dependency-audit` CI job (`npm audit --audit-level=high`).

| Package | Before | After | Severity | Why it was vulnerable |
|---|---|---|---|---|
| `hono` | 4.12.18 | **4.12.26** | **high** | serve-static path traversal, CORS credentials reflection, body-limit bypass, et al. (9 advisories) |
| `js-yaml` | 4.1.1 | **4.2.0** | moderate | quadratic-complexity DoS via merge keys |

Both dependency ranges (`hono ^4` / `^4.11.4` via `@hono/node-server` in the MCP SDK; `js-yaml ^4`) already permitted the patched versions — the lockfile was simply stale.

## How (and why it's a 12-line diff)

- **hono** → `npm update hono --package-lock-only` (side-effect-free, 1 entry).
- **js-yaml** → targeted edit of its single deduped lock entry. A blanket `npm update js-yaml` re-walked the `aim-core` subtree and re-nested `@opena2a/check-core@0.2.0` under `hackmyagent`, **diverging** it from the workspace `check-core@0.3.0` used by `opena2a-cli` — a change to the parity-critical `hackmyagent`↔`check-core` relationship that does not belong in a dependency bump. The targeted edit leaves check-core resolution **identical to `origin/main`**.

## Verification

- `npm ci` → exit 0 (lock consistent with package.json; integrity hashes authenticated on download)
- `npm audit --audit-level=high` → **exit 0** (CI gate now green)
- `npm run build` → 11/11 packages
- `npm test` → all suites pass (1239 cli tests + others)
- check-core install tree unchanged vs `origin/main` — parity contract preserved

## Out of scope

- Remaining **low**-severity `esbuild` advisory is a dev-only vite/vitest/tsx toolchain dep below the `high` gate threshold; bumping it risks the build toolchain for a dev-server-only issue. Left untouched.