### PR TITLE
fix(review): reconcile verdict line with composite band (#221)

### DIFF
--- a/packages/cli-ui/src/observations.test.ts
+++ b/packages/cli-ui/src/observations.test.ts
@@ -208,6 +208,136 @@ describe('buildVerdict', () => {
     expect(v.message).toContain('API key exposed in .env:2');
     expect(v.message).not.toContain('+ ');
   });
+
+  // #221: reconcile the severity verdict with the composite band so a
+  // good-band score never sits beside an absolute "Not safe as-is".
+  it('softens a high-only verdict to "Good overall" when the composite is in the good band', () => {
+    const v = buildVerdict(
+      { critical: 0, high: 1, medium: 0, low: 0 },
+      { kind: 'project' },
+      [{ severity: 'high', name: 'Incomplete .gitignore', file: '.gitignore' }],
+      93,
+    );
+    // No longer the absolute red verdict — coherent with a 93 composite.
+    expect(v.status).toBe('needs-fix');
+    expect(v.message).not.toContain('Not safe');
+    expect(v.message).toContain('Good overall (93/100)');
+    expect(v.message).toContain('1 item to harden');
+    expect(v.message).toContain('Incomplete .gitignore');
+    expect(v.message).toContain('Harden these, then rescan.');
+  });
+
+  it('pluralizes and names the lead when several high items remain in the good band', () => {
+    const v = buildVerdict(
+      { critical: 0, high: 3, medium: 0, low: 0 },
+      { kind: 'project' },
+      [
+        { severity: 'high', name: 'Incomplete .gitignore', file: '.gitignore' },
+        { severity: 'high', name: 'Unsigned config', file: 'mcp.json' },
+        { severity: 'high', name: 'No Shield policy', file: '.' },
+      ],
+      85,
+    );
+    expect(v.status).toBe('needs-fix');
+    expect(v.message).toContain('Good overall (85/100)');
+    expect(v.message).toContain('3 items to harden');
+    expect(v.message).toContain('Incomplete .gitignore');
+    expect(v.message).toContain('+ 2 more');
+  });
+
+  it('keeps "Not safe as-is" for a high finding when the composite is below the good band', () => {
+    const v = buildVerdict(
+      { critical: 0, high: 1, medium: 0, low: 0 },
+      { kind: 'project' },
+      [{ severity: 'high', name: 'Hardcoded credential', file: 'config.ts', line: 9 }],
+      42,
+    );
+    expect(v.status).toBe('unsafe');
+    expect(v.message).toContain('Not safe as-is');
+    expect(v.message).not.toContain('Good overall');
+  });
+
+  it('never softens when a critical is present, even with a high composite (defense in depth)', () => {
+    const v = buildVerdict(
+      { critical: 1, high: 1, medium: 0, low: 0 },
+      { kind: 'project' },
+      [
+        { severity: 'critical', name: 'RCE', file: 'index.js' },
+        { severity: 'high', name: 'Incomplete .gitignore', file: '.gitignore' },
+      ],
+      95,
+    );
+    expect(v.status).toBe('unsafe');
+    expect(v.message).toContain('Not safe to ship');
+    expect(v.message).not.toContain('Good overall');
+  });
+
+  it('uses depend/review guidance when softening a remote package in the good band', () => {
+    const v = buildVerdict(
+      { critical: 0, high: 1, medium: 0, low: 0 },
+      { kind: 'library', remote: true },
+      [{ severity: 'high', name: 'Broad MCP scope', file: 'mcp.json' }],
+      88,
+    );
+    expect(v.status).toBe('needs-fix');
+    expect(v.message).toContain('Good overall (88/100)');
+    expect(v.message).toContain('Review these before depending on it.');
+    expect(v.message).not.toContain('rescan');
+  });
+
+  it('does not soften on a non-finite composite (Infinity/NaN) — keeps "Not safe as-is"', () => {
+    for (const bad of [Infinity, -Infinity, NaN]) {
+      const v = buildVerdict(
+        { critical: 0, high: 1, medium: 0, low: 0 },
+        { kind: 'project' },
+        [{ severity: 'high', name: 'Incomplete .gitignore', file: '.gitignore' }],
+        bad,
+      );
+      expect(v.status).toBe('unsafe');
+      expect(v.message).toContain('Not safe as-is');
+      expect(v.message).not.toContain('Good overall');
+    }
+  });
+
+  it('rounds a non-integer composite in the softened message', () => {
+    const v = buildVerdict(
+      { critical: 0, high: 1, medium: 0, low: 0 },
+      { kind: 'project' },
+      [{ severity: 'high', name: 'Incomplete .gitignore', file: '.gitignore' }],
+      90.6,
+    );
+    expect(v.message).toContain('Good overall (91/100)');
+    expect(v.message).not.toContain('90.6');
+  });
+
+  it('does not soften at the band edge below 80 (79) but does at 80', () => {
+    const below = buildVerdict(
+      { critical: 0, high: 1, medium: 0, low: 0 },
+      { kind: 'project' },
+      [{ severity: 'high', name: 'Incomplete .gitignore', file: '.gitignore' }],
+      79,
+    );
+    const at = buildVerdict(
+      { critical: 0, high: 1, medium: 0, low: 0 },
+      { kind: 'project' },
+      [{ severity: 'high', name: 'Incomplete .gitignore', file: '.gitignore' }],
+      80,
+    );
+    expect(below.status).toBe('unsafe');
+    expect(below.message).toContain('Not safe as-is');
+    expect(at.status).toBe('needs-fix');
+    expect(at.message).toContain('Good overall (80/100)');
+  });
+
+  it('is back-compatible: a high finding with no composite stays "Not safe as-is"', () => {
+    const v = buildVerdict(
+      { critical: 0, high: 1, medium: 0, low: 0 },
+      { kind: 'project' },
+      [{ severity: 'high', name: 'Incomplete .gitignore', file: '.gitignore' }],
+    );
+    expect(v.status).toBe('unsafe');
+    expect(v.message).toContain('Not safe as-is');
+  });
 });
 
 describe('renderObservationsBlock with artifacts', () => {

--- a/packages/cli-ui/src/observations.ts
+++ b/packages/cli-ui/src/observations.ts
@@ -211,11 +211,33 @@ export interface VerdictFinding {
  *
  * Never uses letter grades. Anchors to an action per CISO philosophy rule
  * #10 (feedback_cli_ciso_philosophy.md).
+ *
+ * `compositeScore` (optional, 0-100) is the caller's overall *target-risk*
+ * number. When supplied, it reconciles the severity histogram with the headline
+ * score so the two stop disagreeing in direction (#221): a high-only verdict
+ * (NO criticals) on a project that scores in the good band (>= 80) is reframed
+ * from an absolute "Not safe as-is" to a coherent "Good overall (N/100) — M to
+ * harden" instead of sitting in red beside a green 93.
+ *
+ * [CHIEF-CDS] design posture: when a composite is supplied, IT is the source of
+ * truth for the verdict *direction*, because the caller's composite is already
+ * severity-weighted AND floor-aware — a confirmed credential/malicious finding
+ * drives the dominant-analyzer floor and pulls the composite below the band, so
+ * those never reach this branch and keep their "not safe" verdict. A HIGH that
+ * the composite still scores >= 80 is, by that measure, a low-risk item to
+ * harden — not a blocker. The finding is NOT hidden: it stays in the findings
+ * list, is named as the lead here, and the status is `needs-fix` (warning), not
+ * `safe`. This only ever *softens* a high-only verdict to a caution; it never
+ * returns `safe` and never inverts a low score upward. Criticals are excluded
+ * entirely (they keep "Not safe to ship") so a mis-rated danger is never
+ * softened on the strength of the composite alone. Omit `compositeScore` and the
+ * verdict is purely severity-driven (back-compat for callers without one).
  */
 export function buildVerdict(
   severity: { critical: number; high: number; medium: number; low: number },
   surface: SurfaceSummary,
   findings?: VerdictFinding[],
+  compositeScore?: number,
 ): { status: VerdictStatus; message: string } {
   const { critical, high, medium, low } = severity;
   const total = critical + high + medium + low;
@@ -267,6 +289,22 @@ export function buildVerdict(
   }
   if (high > 0) {
     const leadText = lead ? formatLead(lead) : `${high} high-severity issue${high > 1 ? 's' : ''}`;
+    // Reconcile with the composite: a good-band score (>= 80) with no criticals
+    // means the project is usable overall and these HIGHs are items to harden,
+    // not a "not safe" blocker (#221). Credential/malicious HIGHs floor the
+    // composite below 80, so they never reach this softened branch. Require a
+    // finite score so a malformed/Infinity composite cannot trip the softening
+    // (mirrors the floor's Number.isFinite guard in review.ts).
+    if (typeof compositeScore === 'number' && Number.isFinite(compositeScore) && compositeScore >= 80) {
+      const itemWord = total > 1 ? 'items' : 'item';
+      const guidance = remote
+        ? 'Review these before depending on it.'
+        : 'Harden these, then rescan.';
+      return {
+        status: 'needs-fix',
+        message: `Good overall (${Math.round(compositeScore)}/100). ${total} ${itemWord} to harden: ${leadText}${extraSuffix}. ${guidance}`,
+      };
+    }
     const guidance = remote
       ? 'Review before depending on it, or choose a vetted version.'
       : 'Fix, then rescan.';

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -552,6 +552,9 @@ export async function review(options: ReviewOptions): Promise<number> {
       { critical: sevCounts.critical, high: sevCounts.high, medium: sevCounts.medium, low: sevCounts.low },
       { kind: projectLabel },
       verdictFindings,
+      // Pass the composite (target-risk) score so the verdict line reconciles
+      // with the headline band instead of disagreeing in direction (#221).
+      compositeScore,
     );
     const { lines } = cliUi.renderObservationsBlock({
       surfaces: { kind: projectLabel },


### PR DESCRIPTION
## Problem (#221)

`opena2a review` prints two verdict signals side by side that could disagree in direction. A clean repo with one non-flooring HIGH (e.g. `.env not in .gitignore`) showed:

```
Score: 93/100 -- path to 100 available
Verdict  Not safe as-is. Incomplete .gitignore. Fix, then rescan.
```

A 93/strong composite beside an absolute red "Not safe as-is" is internally contradictory. The composite (target-risk, floor-aware) and the verdict line (severity histogram) answer different questions but are shown as if they agree. #219 (adoption-as-recovery) widened the gap.

## Decision — [CHIEF-CPO + CHIEF-CA + CHIEF-CDS]

Approach 1 (reconcile at the verdict layer in shared `@opena2a/cli-ui`), **not** Approach 2 (recalibrate the HMA finding severity).

- **Rationale:** both numbers are correct in their own frame; the defect is presentational. Reframing the high-only verdict fixes the entire *class* (any non-flooring HIGH on a good-band composite), preserves all detection (no narrowing), and lives in the one shared primitive.
- **Rejected (Approach 2):** lowering the HMA `GIT-002` HIGH is detection-narrowing (a real `.env` present + unignored *is* a legit HIGH), lives in another repo, and leaves the class unfixed.
- **[CHIEF-CDS] posture:** when a composite is supplied it is the source of truth for verdict *direction* — it is already severity-weighted AND floor-aware. A confirmed credential/malicious finding drives the dominant-analyzer floor below the band (`CRITICAL_BAND=30`), so those never reach the softened branch and keep "not safe". A HIGH the composite still scores ≥80 is a low-risk **item to harden**, not a blocker — and it is still named + listed, never hidden, never returned as `safe`.

## Change

`buildVerdict` takes an optional `compositeScore`. When a high-only verdict (no criticals) lands on a good-band composite (≥80):

```
Verdict  Good overall (91/100). 1 item to harden: Incomplete .gitignore. Harden these, then rescan.
```

Status becomes `needs-fix` (yellow), not `unsafe` (red). Criticals are excluded (keep "Not safe to ship"). Guard requires a finite score and rounds the displayed number. Param is optional → back-compat for callers that pass no composite (HMA `secure`, ai-trust).

## Adversarial review (Phase 4.5)

A subagent (diff + claims only, no reasoning) surfaced and I fixed:
- **[P1]** `Infinity >= 80` softened → added `Number.isFinite` guard (+ test).
- **[P3]** non-integer composite rendered raw → `Math.round` in message (+ test).
- **[P2]** the comment over-claimed a floor *guarantee* → rewrote it to the honest "composite is the source of truth for direction" posture and made it an explicit [CHIEF-CDS] decision.

Verified back-compat (no composite → unchanged), band edge (79 unsafe / 80 softens), critical-present never softens, credential/malicious stay "not safe".

## Verification

- cli-ui: 249 tests pass (12 new in `observations.test.ts`); cli: 1271 tests pass; `tsc --noEmit` clean.
- E2E coherence across 5 surfaces: hygiene-HIGH→"Good overall (91)", empty→"Usable with caveats (87)", credential→"Not safe to ship (15, floored)", malicious→"Not safe to ship (0)", critical→"Not safe to ship".

## Notes / out of scope

- JSON path returns before `buildVerdict` is called → zero JSON-consumer impact. Exit code is `compositeScore < 50` → unaffected by the status change. No consumer branches on `status === 'unsafe'` (only rendering reads it).
- A *non-flooring critical* (an unignored secret-less `.env` HMA-rated critical at composite 90) is deliberately **not** softened — the "Not safe to ship" line is a safety backstop, and that case is a separate floor/HMA-severity question.
- HMA `secure` can adopt the same coherence by passing its score after a `@opena2a/cli-ui` publish (follow-up; param is back-compat).

Closes #221