### PR TITLE
chore(deps): bump hackmyagent 0.23.6 → 0.23.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2526,20 +2526,20 @@
       }
     },
     "node_modules/hackmyagent": {
-      "version": "0.23.6",
-      "resolved": "https://registry.npmjs.org/hackmyagent/-/hackmyagent-0.23.6.tgz",
-      "integrity": "sha512-tDPQOHfpN+RfLkM4aPg+rZ/ZRzOIUF9zYhcyEV8EMKGrhB7E8qGPk5+4FYbPbFt5IYgKMa2tvOyjgmhJ5ACNgg==",
+      "version": "0.23.11",
+      "resolved": "https://registry.npmjs.org/hackmyagent/-/hackmyagent-0.23.11.tgz",
+      "integrity": "sha512-WS4Q1LrlPICGnTtRYZjCXeShQE8P7RcKPA6VbxbPz5FgB0C1WzOKH+835ZVd/SY/MTlodDxIEB09e+Xv4UO9fg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@noble/ed25519": "^2.3.0",
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/aim-core": "^0.1.2",
-        "@opena2a/check-core": "0.2.0",
-        "@opena2a/cli-ui": "0.5.1",
+        "@opena2a/check-core": "0.3.0",
+        "@opena2a/cli-ui": "0.5.2",
         "@opena2a/contribute": "^0.1.0",
         "@opena2a/credential-patterns": "0.1.1",
-        "@opena2a/registry-client": "0.1.0",
+        "@opena2a/registry-client": "0.2.0",
         "@opena2a/shared": "^0.1.0",
         "@opena2a/telemetry": "0.3.0",
         "ai-trust": "^0.2.6",
@@ -2567,29 +2567,11 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/hackmyagent/node_modules/@opena2a/cli-ui": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.5.1.tgz",
-      "integrity": "sha512-QfiZUEQS8HIHQKthZrXSGyO4OP3t2/AhR1/YDvglkbDstg6lG2GL5/O2UjH+8PlIBRhBzSvMpJt0OuCoVVuHoQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "chalk": "^5.3.0"
-      }
-    },
     "node_modules/hackmyagent/node_modules/@opena2a/credential-patterns": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@opena2a/credential-patterns/-/credential-patterns-0.1.1.tgz",
       "integrity": "sha512-7yfSCcxqhgGHIEysLtBP8pEaMeY+44Y9dnhQDZTDPt/d5qFL7EDrugQHd8ysEiNYtE+U6GBmu7IGb6kO3ueyOw==",
       "license": "Apache-2.0"
-    },
-    "node_modules/hackmyagent/node_modules/@opena2a/registry-client": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/registry-client/-/registry-client-0.1.0.tgz",
-      "integrity": "sha512-1x9OIxMLlFM4XouRoIoCPidh0moAYcE4F44pL0D7/y8a2MiSrUoE8B7KxMRvHitplmYnZ+hma5JM53mpQ13mCw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      }
     },
     "node_modules/hackmyagent/node_modules/commander": {
       "version": "12.1.0",
@@ -4306,7 +4288,7 @@
         "@opena2a/telemetry": "0.3.0",
         "ai-trust": "^0.2.23",
         "commander": "^13.1.0",
-        "hackmyagent": "0.23.6",
+        "hackmyagent": "0.23.11",
         "secretless-ai": "^0.14.1"
       },
       "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "@opena2a/telemetry": "0.3.0",
     "ai-trust": "^0.2.23",
     "commander": "^13.1.0",
-    "hackmyagent": "0.23.6",
+    "hackmyagent": "0.23.11",
     "secretless-ai": "^0.14.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Bumps the pinned `hackmyagent` dependency in `packages/cli` from 0.23.6 to **0.23.11** (just published, SLSA-attested via Trusted Publishing).

## Why
Propagates the HMA 0.23.11 scanner fixes into `opena2a review` / `scan`, which delegate to HMA `secure`:
- **GIT-003 (`.env Not Ignored`) content-aware severity (hackmyagent#242).** A secret-less `.env` is now `HIGH` (preventive hygiene), not `CRITICAL`. This resolves the score/verdict incoherence from opena2a#221: `opena2a review` on a clean repo with a config-only `.env` now scores **90/100 "Good overall"** instead of a barely-weighted CRITICAL printing "Not safe to ship" beside a good composite.
- **MEM-006 local render-array push FP fix (hackmyagent#244).**

## Verification
- `npm run build` green.
- **Corpus scan↔secure parity: 12 passed, 0 failed** (`release-smoke:corpus`) — the bump does not drift the parity contract.
- `opena2a review` on a secret-less `.env` now renders **90/100 "Good overall. 2 items to harden"** (previously the CRITICAL made it incoherent).

Exact pin per the CLI-consolidation supply-chain rule (no caret).