### PR TITLE
Add `opena2a admin sensors` enrollment-inbox operator command

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **`opena2a admin sensors` — operator tooling for the telemetry sensor-network enrollment inbox.** A thin admin consumer over the Registry's internal vetting endpoints so a human admin can list self-serve enrollments awaiting approval (`list-pending`, aliases `pending`/`ls`), promote one to a verified sensor (`approve <sensorId>`), or reject/revoke one (`reject <sensorId>`) — without hand-rolling `curl` and the internal master key. The admin key is read from `--api-key`, then `OPENA2A_INTERNAL_API_KEY`, then `INTERNAL_API_KEY`, and is never printed (Bearer header only). Because the key is the Registry internal admin key, the destination is **host-pinned**: it is sent only to the default `https://api.oa2a.org` or a host the operator explicitly types via `--registry` — never inherited from an ambient `OPENA2A_REGISTRY_URL` or user-config `registry.url` (which an unrelated flow could have set), and an explicit non-default host prints a stderr warning before the key leaves the machine. `approve` is the only path that mints a verified sensor (ingest weight 0.85), so `approve`/`reject` confirm before acting and **refuse** to run non-interactively without `--yes`; the sensor id is validated as a UUID locally before any call. HTTP failures map to actionable, key-safe messages (401/403 → scope/key hint, 404 → not-pending). Supports `--json` for CI and `--registry <url>` (default `https://api.oa2a.org`). `list-pending` output cites the exact `approve`/`reject` next-step commands (no dead ends). Proven end-to-end against prod: correct key → live inbox, wrong key → 401. New `__tests__/commands/admin.test.ts` (20 tests covering auth gating, UUID validation, confirmation refusal, error mapping, and the Bearer wire shape).
+
 ## 0.10.11
 
 ### Changed

--- a/packages/cli/__tests__/commands/admin.test.ts
+++ b/packages/cli/__tests__/commands/admin.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  admin,
+  resolveApiKey,
+  _internals,
+  type AdminOptions,
+  type PendingEnrollment,
+} from '../../src/commands/admin.js';
+
+function captureStdout(fn: () => Promise<number>): Promise<{ exitCode: number; out: string; err: string }> {
+  const outChunks: string[] = [];
+  const errChunks: string[] = [];
+  const origOut = process.stdout.write;
+  const origErr = process.stderr.write;
+  process.stdout.write = ((chunk: any) => { outChunks.push(String(chunk)); return true; }) as any;
+  process.stderr.write = ((chunk: any) => { errChunks.push(String(chunk)); return true; }) as any;
+  const restore = () => { process.stdout.write = origOut; process.stderr.write = origErr; };
+  return fn().then(exitCode => { restore(); return { exitCode, out: outChunks.join(''), err: errChunks.join('') }; })
+    .catch(err => { restore(); throw err; });
+}
+
+const SAMPLE_ID = '11111111-2222-3333-4444-555555555555';
+
+function pending(): PendingEnrollment[] {
+  return [{ sensorId: SAMPLE_ID, publicKey: 'abcd1234', createdAt: '2026-06-26T00:00:00Z' }];
+}
+
+const ORIG_ENV = { ...process.env };
+
+beforeEach(() => {
+  // Isolate from any ambient admin key / registry override.
+  delete process.env.OPENA2A_INTERNAL_API_KEY;
+  delete process.env.INTERNAL_API_KEY;
+  delete process.env.OPENA2A_REGISTRY_URL;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.env = { ...ORIG_ENV };
+});
+
+describe('resolveApiKey', () => {
+  it('prefers the explicit flag, then namespaced env, then INTERNAL_API_KEY', () => {
+    expect(resolveApiKey('flag-key')).toBe('flag-key');
+    process.env.INTERNAL_API_KEY = 'legacy';
+    expect(resolveApiKey()).toBe('legacy');
+    process.env.OPENA2A_INTERNAL_API_KEY = 'namespaced';
+    expect(resolveApiKey()).toBe('namespaced');
+  });
+
+  it('returns null when no key is present or only whitespace', () => {
+    expect(resolveApiKey()).toBeNull();
+    process.env.INTERNAL_API_KEY = '   ';
+    expect(resolveApiKey()).toBeNull();
+  });
+});
+
+describe('admin sensors -- auth gating', () => {
+  it('refuses every subcommand without a key and never calls the API', async () => {
+    const spy = vi.spyOn(_internals, 'listPending');
+    const { exitCode, err } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['list-pending'] }));
+    expect(exitCode).toBe(1);
+    expect(err).toMatch(/admin key/i);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('emits the missing-key error as JSON in --json mode', async () => {
+    const { exitCode, out } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['list-pending'], json: true }));
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(out).error).toMatch(/admin key/i);
+  });
+});
+
+describe('admin sensors list-pending', () => {
+  it('renders pending enrollments with an approve next-step (no dead end)', async () => {
+    vi.spyOn(_internals, 'listPending').mockResolvedValue({ ok: true, status: 200, data: { pending: pending(), count: 1 } });
+    const { exitCode, out } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['list-pending'], apiKey: 'k' }));
+    expect(exitCode).toBe(0);
+    expect(out).toContain(SAMPLE_ID);
+    expect(out).toContain(`approve ${SAMPLE_ID}`);
+  });
+
+  it('shows an inbox-clear message on an empty list', async () => {
+    vi.spyOn(_internals, 'listPending').mockResolvedValue({ ok: true, status: 200, data: { pending: [], count: 0 } });
+    const { exitCode, out } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['pending'], apiKey: 'k' }));
+    expect(exitCode).toBe(0);
+    expect(out).toMatch(/Inbox clear/i);
+  });
+
+  it('emits machine-readable JSON with --json', async () => {
+    vi.spyOn(_internals, 'listPending').mockResolvedValue({ ok: true, status: 200, data: { pending: pending(), count: 1 } });
+    const { exitCode, out } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['ls'], apiKey: 'k', json: true }));
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(out);
+    expect(parsed.count).toBe(1);
+    expect(parsed.pending[0].sensorId).toBe(SAMPLE_ID);
+  });
+
+  it('maps a 401 to an actionable scope/key message', async () => {
+    vi.spyOn(_internals, 'listPending').mockResolvedValue({ ok: false, status: 401 });
+    const { exitCode, err } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['list-pending'], apiKey: 'bad' }));
+    expect(exitCode).toBe(1);
+    expect(err).toMatch(/invalid|scope|401/i);
+  });
+
+  it('reports a network failure without throwing', async () => {
+    vi.spyOn(_internals, 'listPending').mockRejectedValue(new Error('ECONNREFUSED'));
+    const { exitCode, err } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['list-pending'], apiKey: 'k', registryUrl: 'https://example.test' }));
+    expect(exitCode).toBe(1);
+    expect(err).toMatch(/Could not reach the registry/i);
+  });
+});
+
+describe('admin sensors approve', () => {
+  it('validates the sensor id is a UUID before any call', async () => {
+    const spy = vi.spyOn(_internals, 'approve');
+    const { exitCode, err } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['approve', 'not-a-uuid'], apiKey: 'k', yes: true }));
+    expect(exitCode).toBe(1);
+    expect(err).toMatch(/not a valid sensor id/i);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('requires a sensor id', async () => {
+    const { exitCode, err } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['approve'], apiKey: 'k', yes: true }));
+    expect(exitCode).toBe(1);
+    expect(err).toMatch(/sensor id is required/i);
+  });
+
+  it('approves with --yes and reports the verified state', async () => {
+    const spy = vi.spyOn(_internals, 'approve').mockResolvedValue({ ok: true, status: 200, data: { sensorId: SAMPLE_ID, state: 'verified' } });
+    const { exitCode, out } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['approve', SAMPLE_ID], apiKey: 'k', yes: true }));
+    expect(exitCode).toBe(0);
+    expect(spy).toHaveBeenCalledWith(expect.any(String), 'k', SAMPLE_ID);
+    expect(out).toMatch(/verified/i);
+  });
+
+  it('refuses to approve non-interactively without --yes and does not call the API', async () => {
+    const spy = vi.spyOn(_internals, 'approve');
+    const { exitCode, out } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['approve', SAMPLE_ID], apiKey: 'k', json: true }));
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(out).error).toMatch(/--yes/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('maps a 404 (not pending) to a clear message', async () => {
+    vi.spyOn(_internals, 'approve').mockResolvedValue({ ok: false, status: 404, error: 'enrollment is not pending' });
+    const { exitCode, err } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['approve', SAMPLE_ID], apiKey: 'k', yes: true }));
+    expect(exitCode).toBe(1);
+    expect(err).toMatch(/not pending|404/i);
+  });
+
+  it('a global --ci does NOT consent to the mint without --yes', async () => {
+    const spy = vi.spyOn(_internals, 'approve');
+    const { exitCode, err } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['approve', SAMPLE_ID], apiKey: 'k', ci: true }));
+    expect(exitCode).toBe(1);
+    expect(err).toMatch(/--yes/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('admin sensors reject', () => {
+  it('rejects a pending id with --yes and hits the DELETE service-account path', async () => {
+    vi.spyOn(_internals, 'listPending').mockResolvedValue({ ok: true, status: 200, data: { pending: pending(), count: 1 } });
+    const spy = vi.spyOn(_internals, 'reject').mockResolvedValue({ ok: true, status: 200, data: {} });
+    const { exitCode, out } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['reject', SAMPLE_ID], apiKey: 'k', yes: true }));
+    expect(exitCode).toBe(0);
+    expect(spy).toHaveBeenCalledWith(expect.any(String), 'k', SAMPLE_ID);
+    expect(out).toMatch(/revoked/i);
+  });
+
+  it('refuses to revoke an id that is NOT in the pending inbox (footgun guard)', async () => {
+    vi.spyOn(_internals, 'listPending').mockResolvedValue({ ok: true, status: 200, data: { pending: [], count: 0 } });
+    const spy = vi.spyOn(_internals, 'reject');
+    const { exitCode, err } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['reject', SAMPLE_ID], apiKey: 'k', yes: true }));
+    expect(exitCode).toBe(1);
+    expect(err).toMatch(/not a pending enrollment/i);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('refuses to reject non-interactively without --yes', async () => {
+    vi.spyOn(_internals, 'listPending').mockResolvedValue({ ok: true, status: 200, data: { pending: pending(), count: 1 } });
+    const spy = vi.spyOn(_internals, 'reject');
+    const { exitCode, out } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['reject', SAMPLE_ID], apiKey: 'k', json: true }));
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(out).error).toMatch(/--yes/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('admin -- usage', () => {
+  it('prints usage for an unknown subcommand', async () => {
+    const { out } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['frobnicate'], apiKey: 'k' }));
+    expect(out).toMatch(/Usage: opena2a admin sensors/);
+  });
+
+  it('accepts the bare `admin <verb>` shorthand (no `sensors` group word)', async () => {
+    vi.spyOn(_internals, 'listPending').mockResolvedValue({ ok: true, status: 200, data: { pending: [], count: 0 } });
+    const { exitCode, out } = await captureStdout(() =>
+      admin({ subcommand: 'list-pending', args: [], apiKey: 'k' }));
+    expect(exitCode).toBe(0);
+    expect(out).toMatch(/Inbox clear/i);
+  });
+});
+
+describe('admin -- key safety & host pinning', () => {
+  it('never prints the admin key to stdout or stderr', async () => {
+    const KEY = 'super-secret-admin-key-9f3a';
+    vi.spyOn(_internals, 'approve').mockResolvedValue({ ok: true, status: 200, data: { sensorId: SAMPLE_ID, state: 'verified' } });
+    const { out, err } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['approve', SAMPLE_ID], apiKey: KEY, yes: true }));
+    expect(out).not.toContain(KEY);
+    expect(err).not.toContain(KEY);
+  });
+
+  it('does NOT inherit an ambient OPENA2A_REGISTRY_URL (key stays host-pinned)', async () => {
+    process.env.OPENA2A_REGISTRY_URL = 'https://evil.example.com';
+    const spy = vi.spyOn(_internals, 'listPending').mockResolvedValue({ ok: true, status: 200, data: { pending: [], count: 0 } });
+    const { exitCode } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['list-pending'], apiKey: 'k' }));
+    expect(exitCode).toBe(0);
+    // Default registry, NOT the poisoned env value.
+    expect(spy).toHaveBeenCalledWith('https://api.oa2a.org', 'k');
+  });
+
+  it('warns when an explicit --registry points at a non-default host', async () => {
+    vi.spyOn(_internals, 'listPending').mockResolvedValue({ ok: true, status: 200, data: { pending: [], count: 0 } });
+    const { err } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['list-pending'], apiKey: 'k', registryUrl: 'https://my-registry.example.com' }));
+    expect(err).toMatch(/Warning/);
+    expect(err).toMatch(/trust this host/i);
+  });
+
+  it('does not warn for the default registry', async () => {
+    vi.spyOn(_internals, 'listPending').mockResolvedValue({ ok: true, status: 200, data: { pending: [], count: 0 } });
+    const { err } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['list-pending'], apiKey: 'k', registryUrl: 'https://api.oa2a.org' }));
+    expect(err).not.toMatch(/Warning/);
+  });
+
+  it('emits a JSON error for an invalid --registry in --json mode', async () => {
+    const spy = vi.spyOn(_internals, 'listPending');
+    const { exitCode, out } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['list-pending'], apiKey: 'k', registryUrl: 'not a url', json: true }));
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(out).error).toMatch(/Invalid registry URL/i);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('a non-interactive refusal prints one message (no duplicate Aborted)', async () => {
+    const { err, out } = await captureStdout(() =>
+      admin({ subcommand: 'sensors', args: ['approve', SAMPLE_ID], apiKey: 'k' }));
+    expect(err).toMatch(/Refusing to approve/);
+    expect(out).not.toMatch(/Aborted/);
+  });
+});
+
+describe('_internals.request -- wire shape', () => {
+  it('sends a Bearer auth header and parses JSON', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ pending: [], count: 0 }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const res = await _internals.request('GET', 'https://api.oa2a.org/internal/telemetry/sensors/pending', 'secret-key');
+    expect(res.ok).toBe(true);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe('GET');
+    expect(init.headers.Authorization).toBe('Bearer secret-key');
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the server error string on a non-2xx response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: 'key already enrolled' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const res = await _internals.request('POST', 'https://api.oa2a.org/x', 'k');
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(409);
+    expect(res.error).toBe('key already enrolled');
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/cli/src/commands/admin.ts
+++ b/packages/cli/src/commands/admin.ts
@@ -1,0 +1,536 @@
+/**
+ * opena2a admin sensors -- Operate the telemetry sensor-network enrollment inbox.
+ *
+ * Thin admin consumer over the Registry's internal vetting endpoints. Lets a
+ * human admin list self-serve enrollments awaiting approval, promote one to a
+ * verified telemetry sensor, or reject (revoke) one -- without hand-rolling curl
+ * and the internal master key.
+ *
+ * Usage:
+ *   opena2a admin sensors list-pending
+ *   opena2a admin sensors approve <sensorId>
+ *   opena2a admin sensors reject <sensorId>
+ *   opena2a admin sensors list-pending --json
+ *
+ * Auth: requires the Registry internal admin key, read from (in order)
+ *   --api-key <key>  |  OPENA2A_INTERNAL_API_KEY  |  INTERNAL_API_KEY
+ * The key is NEVER printed. Approving mints a VERIFIED sensor (ingest weight
+ * 0.85) -- the only path that does -- so approve/reject confirm before acting
+ * unless --yes is passed.
+ */
+
+import { bold, green, yellow, red, dim, cyan, gray } from '../util/colors.js';
+import { validateRegistryUrl } from '../util/validate-registry-url.js';
+
+// --- Types ---
+
+export interface AdminOptions {
+  subcommand?: string;
+  args?: string[];
+  registryUrl?: string;
+  apiKey?: string;
+  yes?: boolean;
+  ci?: boolean;
+  format?: 'text' | 'json';
+  json?: boolean;
+  verbose?: boolean;
+}
+
+export interface PendingEnrollment {
+  sensorId: string;
+  publicKey: string;
+  createdAt: string;
+}
+
+interface ApiResult<T> {
+  ok: boolean;
+  status: number;
+  data?: T;
+  /** Server-provided error string (already safe to echo), if any. */
+  error?: string;
+}
+
+// --- Constants ---
+
+const DEFAULT_REGISTRY_URL = 'https://api.oa2a.org';
+const REQUEST_TIMEOUT_MS = 15_000;
+// RFC 4122 UUID (any version). The sensorId is the service-account UUID.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// --- Testable internals (HTTP boundary; mock these in tests) ---
+
+export const _internals = {
+  async listPending(
+    registryUrl: string,
+    apiKey: string,
+  ): Promise<ApiResult<{ pending: PendingEnrollment[]; count: number }>> {
+    return _internals.request('GET', `${registryUrl}/internal/telemetry/sensors/pending`, apiKey);
+  },
+
+  async approve(
+    registryUrl: string,
+    apiKey: string,
+    sensorId: string,
+  ): Promise<ApiResult<{ sensorId: string; state: string }>> {
+    return _internals.request(
+      'POST',
+      `${registryUrl}/internal/telemetry/sensors/${encodeURIComponent(sensorId)}/approve`,
+      apiKey,
+    );
+  },
+
+  async reject(
+    registryUrl: string,
+    apiKey: string,
+    sensorId: string,
+  ): Promise<ApiResult<unknown>> {
+    return _internals.request(
+      'DELETE',
+      `${registryUrl}/internal/service-accounts/${encodeURIComponent(sensorId)}`,
+      apiKey,
+    );
+  },
+
+  async request<T>(
+    method: string,
+    url: string,
+    apiKey: string,
+  ): Promise<ApiResult<T>> {
+    const response = await fetch(url, {
+      method,
+      headers: {
+        // The internal master key OR a scoped service-account token. Bearer only;
+        // the value is never logged.
+        Authorization: `Bearer ${apiKey}`,
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+
+    let body: any = undefined;
+    try {
+      body = await response.json();
+    } catch {
+      /* empty / non-JSON body (e.g. some 204s) */
+    }
+
+    if (!response.ok) {
+      const error =
+        body && typeof body.error === 'string' ? body.error : undefined;
+      return { ok: false, status: response.status, error };
+    }
+    return { ok: true, status: response.status, data: body as T };
+  },
+
+  confirm(promptText: string): Promise<boolean> {
+    return new Promise((resolve) => {
+      process.stdout.write(promptText);
+      const { createInterface } =
+        require('node:readline') as typeof import('node:readline');
+      const rl = createInterface({ input: process.stdin, output: process.stdout, terminal: false });
+      rl.once('line', (answer: string) => {
+        rl.close();
+        const a = answer.trim().toLowerCase();
+        resolve(a === 'y' || a === 'yes');
+      });
+      rl.once('close', () => resolve(false));
+    });
+  },
+};
+
+// --- Helpers ---
+
+/**
+ * Resolve the registry base URL for an admin call. Throws if the value is not a
+ * valid registry URL (caught by the caller and rendered as a clean error).
+ *
+ * SECURITY: this command transmits the Registry internal admin key as a Bearer
+ * token, so the destination is deliberately NOT inherited from the ambient
+ * OPENA2A_REGISTRY_URL env var or the user-config `registry.url` -- either could
+ * be set by an unrelated flow and would silently exfiltrate the master key to a
+ * hostile host. The destination is either the hardcoded default or a host the
+ * operator EXPLICITLY types via --registry (a conscious choice, same as curl).
+ * Unlike the other registry commands, which legitimately follow ambient config.
+ */
+export function resolveRegistryUrl(explicit?: string): string {
+  if (explicit) {
+    const url = explicit.replace(/\/$/, '');
+    validateRegistryUrl(url);
+    return url;
+  }
+  return DEFAULT_REGISTRY_URL;
+}
+
+/** True for the canonical production registry or a localhost dev/self-host. */
+function isTrustedAdminHost(registryUrl: string): boolean {
+  let host: string;
+  try {
+    host = new URL(registryUrl).hostname;
+  } catch {
+    return false;
+  }
+  return (
+    host === 'api.oa2a.org' ||
+    host === 'localhost' ||
+    host === '127.0.0.1' ||
+    host === '::1'
+  );
+}
+
+/**
+ * Warn (once, to stderr) when the admin key is about to be sent somewhere other
+ * than the canonical registry or localhost. Helps an operator catch a typo'd or
+ * hostile --registry before the master key leaves the machine. Never prints the
+ * key. Suppressed in --json mode so it can't corrupt a parsed stream.
+ */
+function maybeWarnNonDefaultHost(registryUrl: string, isJson: boolean): void {
+  if (isJson || isTrustedAdminHost(registryUrl)) return;
+  process.stderr.write(
+    yellow('Warning: ') +
+      `sending the internal admin key to ${registryUrl} (not the default registry). ` +
+      'Make sure you trust this host.\n',
+  );
+}
+
+/**
+ * Resolve the internal admin key without ever surfacing its value. Precedence:
+ * explicit flag, namespaced env var, then the registry's own var name (which the
+ * documented `INTERNAL_API_KEY=... opena2a ...` operator pattern sets).
+ */
+export function resolveApiKey(explicit?: string): string | null {
+  const key =
+    explicit ||
+    process.env.OPENA2A_INTERNAL_API_KEY ||
+    process.env.INTERNAL_API_KEY ||
+    '';
+  return key.trim() ? key.trim() : null;
+}
+
+function emitJson(value: unknown): void {
+  process.stdout.write(JSON.stringify(value) + '\n');
+}
+
+function missingKeyMessage(isJson: boolean): number {
+  const msg =
+    'No internal admin key found. Set OPENA2A_INTERNAL_API_KEY (or INTERNAL_API_KEY), or pass --api-key.';
+  if (isJson) {
+    emitJson({ error: msg });
+  } else {
+    process.stderr.write(red('Error: ') + msg + '\n');
+    process.stderr.write(
+      dim('  Example: INTERNAL_API_KEY="$INTERNAL_API_KEY_registry_prod" opena2a admin sensors list-pending\n'),
+    );
+  }
+  return 1;
+}
+
+/** Map an HTTP failure to an actionable, key-safe message. */
+function httpErrorMessage(verb: string, res: ApiResult<unknown>): string {
+  switch (res.status) {
+    case 401:
+    case 403:
+      return `${verb} rejected (HTTP ${res.status}): the admin key is missing, invalid, or lacks internal:admin scope.`;
+    case 404:
+      return res.error
+        ? `${verb} failed (HTTP 404): ${res.error}`
+        : `${verb} failed (HTTP 404): no matching pending enrollment for that sensor id.`;
+    case 409:
+      return `${verb} conflict (HTTP 409): ${res.error ?? 'the enrollment is in a state that cannot be changed.'}`;
+    default:
+      return res.error
+        ? `${verb} failed (HTTP ${res.status}): ${res.error}`
+        : `${verb} failed (HTTP ${res.status}).`;
+  }
+}
+
+function renderPending(list: PendingEnrollment[]): void {
+  const out = process.stdout;
+  out.write('\n' + bold('Pending sensor enrollments') + '\n');
+  if (list.length === 0) {
+    out.write(green('  Inbox clear -- no enrollments awaiting approval.\n\n'));
+    return;
+  }
+  out.write(gray(`  ${list.length} awaiting approval (newest first)\n\n`));
+  for (const e of list) {
+    out.write('  ' + bold(e.sensorId) + '\n');
+    out.write('    ' + dim('key:     ') + e.publicKey + '\n');
+    out.write('    ' + dim('enrolled:') + ' ' + e.createdAt + '\n');
+    out.write('    ' + cyan(`approve: opena2a admin sensors approve ${e.sensorId}`) + '\n');
+    out.write('    ' + gray(`reject:  opena2a admin sensors reject ${e.sensorId}`) + '\n\n');
+  }
+  out.write(
+    yellow('  Approving mints a VERIFIED sensor (ingest weight 0.85). Vet before approving.\n\n'),
+  );
+}
+
+// --- Subcommand handlers ---
+
+async function handleListPending(
+  registryUrl: string,
+  apiKey: string,
+  isJson: boolean,
+): Promise<number> {
+  let res: ApiResult<{ pending: PendingEnrollment[]; count: number }>;
+  try {
+    res = await _internals.listPending(registryUrl, apiKey);
+  } catch (err) {
+    const msg = `Could not reach the registry at ${registryUrl}: ${(err as Error).message}`;
+    if (isJson) emitJson({ error: msg });
+    else process.stderr.write(red('Error: ') + msg + '\n');
+    return 1;
+  }
+
+  if (!res.ok) {
+    const msg = httpErrorMessage('List', res);
+    if (isJson) emitJson({ error: msg, status: res.status });
+    else process.stderr.write(red('Error: ') + msg + '\n');
+    return 1;
+  }
+
+  const pending = res.data?.pending ?? [];
+  if (isJson) {
+    emitJson({ pending, count: res.data?.count ?? pending.length });
+  } else {
+    renderPending(pending);
+  }
+  return 0;
+}
+
+async function handleApprove(
+  registryUrl: string,
+  apiKey: string,
+  sensorId: string | undefined,
+  opts: AdminOptions,
+  isJson: boolean,
+): Promise<number> {
+  const idErr = requireSensorId(sensorId, 'approve', isJson);
+  if (idErr !== null) return idErr;
+  const id = sensorId as string;
+
+  const consent = await confirmDestructive(
+    `Approve sensor ${id} -> VERIFIED (ingest weight 0.85)? [y/N] `,
+    opts,
+    isJson,
+    'approve',
+  );
+  if (consent !== 'consented') return abortFor(consent, isJson);
+
+  let res: ApiResult<{ sensorId: string; state: string }>;
+  try {
+    res = await _internals.approve(registryUrl, apiKey, id);
+  } catch (err) {
+    return networkError(registryUrl, err as Error, isJson);
+  }
+
+  if (!res.ok) {
+    const msg = httpErrorMessage('Approve', res);
+    if (isJson) emitJson({ error: msg, status: res.status });
+    else process.stderr.write(red('Error: ') + msg + '\n');
+    return 1;
+  }
+
+  const state = res.data?.state ?? 'verified';
+  if (isJson) {
+    emitJson({ sensorId: id, state });
+  } else {
+    process.stdout.write(green('Approved. ') + `Sensor ${bold(id)} is now ${bold(state)}.\n`);
+  }
+  return 0;
+}
+
+async function handleReject(
+  registryUrl: string,
+  apiKey: string,
+  sensorId: string | undefined,
+  opts: AdminOptions,
+  isJson: boolean,
+): Promise<number> {
+  const idErr = requireSensorId(sensorId, 'reject', isJson);
+  if (idErr !== null) return idErr;
+  const id = sensorId as string;
+
+  // Guard: `reject` wraps the generic DELETE /internal/service-accounts/:id,
+  // which revokes ANY service account -- including verified production sensors
+  // or unrelated internal accounts. The verb only promises to reject a *pending
+  // enrollment*, so refuse anything that is not currently in the inbox. This
+  // closes the footgun of revoking a live account by pasting the wrong UUID.
+  // NOTE: this is a best-effort client-side check with a small TOCTOU window
+  // (an id approved between this list and the DELETE would still be revoked); the
+  // authoritative fix is a pending-scoped reject endpoint, tracked server-side.
+  let inbox: ApiResult<{ pending: PendingEnrollment[]; count: number }>;
+  try {
+    inbox = await _internals.listPending(registryUrl, apiKey);
+  } catch (err) {
+    return networkError(registryUrl, err as Error, isJson);
+  }
+  if (!inbox.ok) {
+    const msg = httpErrorMessage('Reject', inbox);
+    if (isJson) emitJson({ error: msg, status: inbox.status });
+    else process.stderr.write(red('Error: ') + msg + '\n');
+    return 1;
+  }
+  const isPending = (inbox.data?.pending ?? []).some((e) => e.sensorId === id);
+  if (!isPending) {
+    const msg =
+      `${id} is not a pending enrollment; refusing to revoke. ` +
+      `Only enrollments currently in 'list-pending' can be rejected. ` +
+      `To revoke an active service account, use the registry admin API directly.`;
+    if (isJson) emitJson({ error: msg });
+    else process.stderr.write(red('Error: ') + msg + '\n');
+    return 1;
+  }
+
+  const consent = await confirmDestructive(
+    `Reject (revoke) pending enrollment ${id}? This deletes the service account. [y/N] `,
+    opts,
+    isJson,
+    'reject',
+  );
+  if (consent !== 'consented') return abortFor(consent, isJson);
+
+  let res: ApiResult<unknown>;
+  try {
+    res = await _internals.reject(registryUrl, apiKey, id);
+  } catch (err) {
+    return networkError(registryUrl, err as Error, isJson);
+  }
+
+  if (!res.ok) {
+    const msg = httpErrorMessage('Reject', res);
+    if (isJson) emitJson({ error: msg, status: res.status });
+    else process.stderr.write(red('Error: ') + msg + '\n');
+    return 1;
+  }
+
+  if (isJson) {
+    emitJson({ sensorId: id, state: 'rejected' });
+  } else {
+    process.stdout.write(green('Rejected. ') + `Enrollment ${bold(id)} revoked.\n`);
+  }
+  return 0;
+}
+
+// --- Shared subcommand helpers ---
+
+function requireSensorId(
+  sensorId: string | undefined,
+  verb: string,
+  isJson: boolean,
+): number | null {
+  if (!sensorId) {
+    const msg = `A sensor id is required: opena2a admin sensors ${verb} <sensorId>`;
+    if (isJson) emitJson({ error: msg });
+    else process.stderr.write(red('Error: ') + msg + '\n');
+    return 1;
+  }
+  if (!UUID_RE.test(sensorId)) {
+    const msg = `'${sensorId}' is not a valid sensor id (expected a UUID).`;
+    if (isJson) emitJson({ error: msg });
+    else process.stderr.write(red('Error: ') + msg + '\n');
+    return 1;
+  }
+  return null;
+}
+
+type Consent = 'consented' | 'declined' | 'refused';
+
+/**
+ * Gate a destructive/privileged action behind explicit confirmation. Only --yes
+ * consents -- a global --ci makes the run non-interactive but does NOT imply
+ * consent to mint/revoke a credential. In a non-interactive context without
+ * --yes we REFUSE rather than silently proceed. Returns a discriminated result
+ * so the caller emits exactly one message ('refused' already printed its own).
+ */
+async function confirmDestructive(
+  promptText: string,
+  opts: AdminOptions,
+  isJson: boolean,
+  verb: string,
+): Promise<Consent> {
+  if (opts.yes) return 'consented';
+  if (isJson || opts.ci || !process.stdin.isTTY) {
+    const msg = `Refusing to ${verb} non-interactively without confirmation. Re-run with --yes.`;
+    if (isJson) emitJson({ error: msg });
+    else process.stderr.write(red('Error: ') + msg + '\n');
+    return 'refused';
+  }
+  return (await _internals.confirm(promptText)) ? 'consented' : 'declined';
+}
+
+/** Resolve a non-consenting result to an exit code, printing once if needed. */
+function abortFor(consent: Consent, isJson: boolean): number {
+  // 'refused' already printed its own error; only 'declined' needs a message.
+  if (consent === 'declined' && !isJson) process.stdout.write(gray('Aborted.\n'));
+  return 1;
+}
+
+function networkError(registryUrl: string, err: Error, isJson: boolean): number {
+  const msg = `Could not reach the registry at ${registryUrl}: ${err.message}`;
+  if (isJson) emitJson({ error: msg });
+  else process.stderr.write(red('Error: ') + msg + '\n');
+  return 1;
+}
+
+function usage(isJson: boolean): number {
+  const lines = [
+    'Usage: opena2a admin sensors <subcommand>',
+    '',
+    '  list-pending            List enrollments awaiting approval (alias: pending, ls)',
+    '  approve <sensorId>      Promote a pending enrollment to a verified sensor',
+    '  reject  <sensorId>      Reject (revoke) a pending enrollment',
+    '',
+    'Options: --json  --yes  --api-key <key>  --registry <url>',
+  ];
+  if (isJson) emitJson({ error: 'unknown or missing subcommand', usage: lines });
+  else process.stdout.write(lines.join('\n') + '\n');
+  return isJson ? 1 : 0;
+}
+
+// --- Entry point ---
+
+export async function admin(options: AdminOptions): Promise<number> {
+  const isJson = options.json === true || options.format === 'json';
+  const args = options.args ?? [];
+
+  // The only group today is `sensors`. Accept `admin sensors <verb>` and, as a
+  // convenience, a bare `admin <verb>` that maps onto the sensors group.
+  let group = options.subcommand;
+  let rest = args;
+  if (group === 'sensors') {
+    group = args[0];
+    rest = args.slice(1);
+  }
+
+  // The privileged verbs share a prelude: resolve the key (never inheriting it
+  // into output) and the destination (host-pinned; warns on a non-default host).
+  if (group === 'list-pending' || group === 'pending' || group === 'ls' ||
+      group === 'approve' || group === 'reject') {
+    const apiKey = resolveApiKey(options.apiKey);
+    if (!apiKey) return missingKeyMessage(isJson);
+
+    let registryUrl: string;
+    try {
+      registryUrl = resolveRegistryUrl(options.registryUrl);
+    } catch (err) {
+      // validateRegistryUrl messages already name the problem (bad URL / non-HTTPS).
+      const msg = (err as Error).message;
+      if (isJson) emitJson({ error: msg });
+      else process.stderr.write(red('Error: ') + msg + '\n');
+      return 1;
+    }
+    maybeWarnNonDefaultHost(registryUrl, isJson);
+
+    switch (group) {
+      case 'list-pending':
+      case 'pending':
+      case 'ls':
+        return handleListPending(registryUrl, apiKey, isJson);
+      case 'approve':
+        return handleApprove(registryUrl, apiKey, rest[0], options, isJson);
+      case 'reject':
+        return handleReject(registryUrl, apiKey, rest[0], options, isJson);
+    }
+  }
+
+  return usage(isJson);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -960,6 +960,43 @@ Examples:
       printFooter({ ci: globalOpts.ci, json: opts.json || globalOpts.format === 'json' });
     });
 
+  // Admin command (registry operator tooling; requires the internal admin key)
+  program
+    .command('admin [subcommand] [args...]')
+    .description('Registry operator tooling (sensors list-pending|approve|reject)')
+    .allowUnknownOption(true)
+    .helpOption(false)
+    .option('--api-key <key>', 'Registry internal admin key (else OPENA2A_INTERNAL_API_KEY / INTERNAL_API_KEY)')
+    .option('--registry <url>', 'Registry base URL (default: https://api.oa2a.org)')
+    .option('--yes', 'Skip the confirmation prompt for approve/reject')
+    .option('--json', 'Output as JSON (alias for --format json)')
+    .addHelpText('after', `
+Examples:
+  $ opena2a admin sensors list-pending          Inbox of enrollments awaiting approval
+  $ opena2a admin sensors approve <sensorId>     Promote a pending enrollment to verified
+  $ opena2a admin sensors reject <sensorId>      Reject (revoke) a pending enrollment
+
+Auth: set OPENA2A_INTERNAL_API_KEY or INTERNAL_API_KEY (the key is never printed).`)
+    .action(async (subcommand: string | undefined, args: string[], opts, cmd) => {
+      if (subcommand === '--help' || subcommand === '-h' || (!subcommand && isHelpRequest())) {
+        process.stdout.write(cmd.helpInformation());
+        return;
+      }
+      const { admin } = await import('./commands/admin.js');
+      const globalOpts = program.opts();
+      process.exitCode = await admin({
+        subcommand,
+        args: args ?? [],
+        apiKey: opts.apiKey,
+        registryUrl: opts.registry,
+        yes: opts.yes,
+        ci: globalOpts.ci,
+        format: globalOpts.format,
+        json: opts.json,
+        verbose: globalOpts.verbose,
+      });
+    });
+
   // Baselines command
   program
     .command('baselines')

--- a/packages/cli/src/natural/known-commands.ts
+++ b/packages/cli/src/natural/known-commands.ts
@@ -17,7 +17,7 @@ export const CORE_COMMAND_NAMES: readonly string[] = [
   'init', 'protect', 'comply', 'guard', 'runtime', 'shield', 'review', 'identity',
   'config', 'self-register', 'verify', 'baselines', 'benchmark',
   'check', 'status', 'publish', 'detect', 'mcp', 'demo', 'setup', 'watch',
-  'trust', 'claim', 'create', 'login', 'logout', 'whoami',
+  'trust', 'claim', 'create', 'login', 'logout', 'whoami', 'admin',
 ];
 
 /** Every command name Commander will route directly: adapters + core. */

--- a/packages/cli/src/router.ts
+++ b/packages/cli/src/router.ts
@@ -57,7 +57,7 @@ export function classifyInput(argv: string[]): ClassifiedInput {
     'guard', 'broker', 'config', 'self-register',
     'verify', 'baselines', 'review',
     'scan-soul', 'harden-soul', 'harden-skill', 'detect', 'mcp', 'demo',
-    'trust', 'claim',
+    'trust', 'claim', 'admin',
   ];
 
   if (KNOWN_COMMANDS.includes(first)) {


### PR DESCRIPTION
## Summary

Adds `opena2a admin sensors {list-pending|approve|reject}` — a thin admin consumer over the Registry's internal telemetry sensor-vetting endpoints, so a human admin can operate the enrollment inbox without hand-rolling curl and the internal master key.

| Command | Endpoint |
|---|---|
| `list-pending` (aliases `pending`, `ls`) | `GET /internal/telemetry/sensors/pending` |
| `approve <sensorId>` | `POST /internal/telemetry/sensors/:id/approve` |
| `reject <sensorId>` | `DELETE /internal/service-accounts/:id` |

No registry-side changes — pure HTTP consumer over already-merged, deployed endpoints. This makes the merged enrollment inbox human-operable (the prerequisite for safely operating default-on telemetry later).

## Security

- Admin key read from `--api-key`, then `OPENA2A_INTERNAL_API_KEY`, then `INTERNAL_API_KEY`; **never printed** (Bearer header only).
- **Host-pinned key destination:** sent only to the default `api.oa2a.org` or a host the operator explicitly types via `--registry` — never inherited from an ambient `OPENA2A_REGISTRY_URL` / user-config `registry.url` (which an unrelated flow could set and silently exfiltrate the master key). A non-default `--registry` host prints a warning before the key is sent.
- `approve` mints the only verified sensor (ingest weight 0.85), so `approve`/`reject` confirm before acting and **refuse** to run non-interactively without `--yes`. A global `--ci` does not imply consent.
- `reject` wraps the generic service-account DELETE (which can revoke any account); guarded to only act on ids currently in the pending inbox, closing the wrong-UUID footgun (best-effort, small TOCTOU window noted in code; authoritative fix is a server-side pending-scoped endpoint).
- Sensor ids UUID-validated locally; HTTP failures map to actionable, key-safe messages (401/403, 404, 409).

## Testing

- 28 unit tests (`packages/cli/__tests__/commands/admin.test.ts`); full CLI suite 1299 pass; clean build/tsc.
- Proven end-to-end against prod: correct key → live inbox, wrong key → 401, reject of a non-pending id → refused before any DELETE, ambient `OPENA2A_REGISTRY_URL` ignored.
- Pre-push gate PASS. An independent adversarial reviewer flagged a key-exfiltration vector via ambient registry-URL inheritance; fixed (host-pinning) and re-verified PASS.

## Out of scope

- Registry-web admin page (follow-up).
- Pre-existing HMA HIGHs in `adapters/docker.ts` / `shield/llm-backend.ts` / `commands/shield.ts` (`process.env` passthrough; shield TOCTOU) — untouched by this diff, tracked separately.