### PR TITLE
fix(telemetry): point SDK default endpoint at the canonical ingest path

### DIFF
--- a/packages/telemetry/CHANGELOG.md
+++ b/packages/telemetry/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **`DEFAULT_ENDPOINT` now points at the canonical ingest path** —
+  `https://api.oa2a.org/api/v1/telemetry/v1/event` (was
+  `.../api/v1/registry/telemetry/v1/event`). Registry PR #283 (2026-06-26) moved
+  the ingest mount off the `/registry/`-prefixed path, which every published SDK
+  (0.1.2 + 0.3.0) still posted to — so first-party telemetry silently 404'd for
+  ~7 days until registry PR #299 added a back-compat alias mounting the old path
+  to the same handler. All **deployed** installs recover via that alias with no
+  client release; this fix ensures **future** installs post to the canonical path
+  directly and lets the alias eventually be retired. Ships whenever the package is
+  next published — no consumer action required (the alias covers the gap).
+
 ## 0.3.0 — 2026-05-24
 
 ### Added

--- a/packages/telemetry/src/config.test.ts
+++ b/packages/telemetry/src/config.test.ts
@@ -90,14 +90,19 @@ describe("setEnabled", () => {
 });
 
 describe("endpointURL", () => {
-  it("defaults to api.oa2a.org Registry route", () => {
+  it("defaults to api.oa2a.org canonical ingest route", () => {
     expect(endpointURL()).toBe(DEFAULT_ENDPOINT);
-    expect(DEFAULT_ENDPOINT).toContain("/api/v1/registry/telemetry/v1/event");
+    expect(DEFAULT_ENDPOINT).toContain("/api/v1/telemetry/v1/event");
+    // Regression guard: the default MUST NOT carry the `/registry/` prefix.
+    // Registry #283 moved ingest off `/api/v1/registry/telemetry/v1/event`;
+    // shipping that path again silently 404s all first-party telemetry until
+    // the back-compat alias (#299) is retired.
+    expect(DEFAULT_ENDPOINT).not.toContain("/registry/");
   });
 
   it("env OPENA2A_TELEMETRY_URL overrides", () => {
-    process.env.OPENA2A_TELEMETRY_URL = "http://localhost:8088/api/v1/registry/telemetry/v1/event";
-    expect(endpointURL()).toBe("http://localhost:8088/api/v1/registry/telemetry/v1/event");
+    process.env.OPENA2A_TELEMETRY_URL = "http://localhost:8088/api/v1/telemetry/v1/event";
+    expect(endpointURL()).toBe("http://localhost:8088/api/v1/telemetry/v1/event");
   });
 });
 

--- a/packages/telemetry/src/config.ts
+++ b/packages/telemetry/src/config.ts
@@ -5,7 +5,7 @@ import { randomUUID, createHash } from "node:crypto";
 import { execSync } from "node:child_process";
 
 export const POLICY_URL = "https://opena2a.org/telemetry";
-export const DEFAULT_ENDPOINT = "https://api.oa2a.org/api/v1/registry/telemetry/v1/event";
+export const DEFAULT_ENDPOINT = "https://api.oa2a.org/api/v1/telemetry/v1/event";
 const ENV_OPT_OUT = "OPENA2A_TELEMETRY";
 const ENV_ENDPOINT = "OPENA2A_TELEMETRY_URL";
 const ENV_DEBUG = "OPENA2A_TELEMETRY_DEBUG";

--- a/packages/telemetry/src/types.ts
+++ b/packages/telemetry/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Wire-format event sent to POST /api/v1/registry/telemetry/v1/event.
+ * Wire-format event sent to POST /api/v1/telemetry/v1/event.
  *
  * Field names match the Registry handler's JSON binding (snake_case for
  * install_id, node_major, duration_ms — locked by the spec).


### PR DESCRIPTION
## What

`@opena2a/telemetry` `DEFAULT_ENDPOINT` dropped the `/registry/` prefix — it now posts to `https://api.oa2a.org/api/v1/telemetry/v1/event` (the live canonical ingest mount).

## Why

Tier-1 usage ingest was moved off the `/registry/`-prefixed path, but every published SDK (0.1.2 + 0.3.0) hardcoded that path — so first-party telemetry silently 404'd for ~7 days until a back-compat alias was restored server-side (registry `/api/v1/registry/telemetry/v1/event` now routes to the same handler). The alias recovers all **already-deployed** installs with no client release; this change makes **future** installs post to the canonical path directly so the alias can eventually be retired.

## Changes

- `config.ts` — `DEFAULT_ENDPOINT` → canonical path.
- `config.test.ts` — updated assertion + a regression guard asserting the default never carries the `/registry/` prefix again + reconciled the env-override fixture.
- `types.ts` — doc-comment path reconciled.
- `CHANGELOG.md` — recorded under `## Unreleased`.

## Not in this PR

- **No `package.json` bump / no publish.** Consumers pin exact `0.3.0` and the server alias covers the gap, so a standalone `0.3.1` buys nothing right now — the corrected default rides the next natural telemetry release. Version bumps at publish time (avoids monorepo lockfile desync).

## Verification

Build + typecheck + lint pass; 58/58 telemetry tests pass. Live probe: both the canonical path and the `/registry/` alias return 400 (reach handler); the corrected default resolves to the live mount.