### PR TITLE
chore(deps): bump hackmyagent to 0.24.0 (exact)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1041,6 +1041,34 @@
       "resolved": "packages/aim-core",
       "link": true
     },
+    "node_modules/@opena2a/aim-sdk": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@opena2a/aim-sdk/-/aim-sdk-1.0.1.tgz",
+      "integrity": "sha512-KdwPxF7//ZLv+Thxt/SGJfSNUIaA9mfGLqqSY13xhb1f/r403vgHrnsm8CZHIJ637xqqhPv8ILqkdOinEXcfmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/ed25519": "^2.1.0",
+        "@noble/post-quantum": "^0.2.1",
+        "@opena2a/atx-verify": "0.2.0",
+        "fastify-plugin": "^6.0.0",
+        "js-yaml": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0 || ^5.0.0",
+        "fastify": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        },
+        "fastify": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@opena2a/atx-verify": {
       "resolved": "packages/atx-verify",
       "link": true
@@ -2349,6 +2377,22 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2526,15 +2570,16 @@
       }
     },
     "node_modules/hackmyagent": {
-      "version": "0.23.11",
-      "resolved": "https://registry.npmjs.org/hackmyagent/-/hackmyagent-0.23.11.tgz",
-      "integrity": "sha512-WS4Q1LrlPICGnTtRYZjCXeShQE8P7RcKPA6VbxbPz5FgB0C1WzOKH+835ZVd/SY/MTlodDxIEB09e+Xv4UO9fg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/hackmyagent/-/hackmyagent-0.24.0.tgz",
+      "integrity": "sha512-sgsR2/HLFdK20/BCWimBA8ohouJJtJ65vpSNJDBbzj2CCyijR8aYeDad6ZMTnqPcWTwXdkYuIFCzy8WoNCplKw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@noble/ed25519": "^2.3.0",
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/aim-core": "^0.1.2",
+        "@opena2a/aim-sdk": "1.0.1",
         "@opena2a/check-core": "0.3.0",
         "@opena2a/cli-ui": "0.5.2",
         "@opena2a/contribute": "^0.1.0",
@@ -4288,7 +4333,7 @@
         "@opena2a/telemetry": "0.3.0",
         "ai-trust": "^0.2.23",
         "commander": "^13.1.0",
-        "hackmyagent": "0.23.11",
+        "hackmyagent": "0.24.0",
         "secretless-ai": "^0.14.1"
       },
       "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "@opena2a/telemetry": "0.3.0",
     "ai-trust": "^0.2.23",
     "commander": "^13.1.0",
-    "hackmyagent": "0.23.11",
+    "hackmyagent": "0.24.0",
     "secretless-ai": "^0.14.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Propagation of hackmyagent 0.24.0 (published today, OIDC trusted publishing, SLSA v1 attested).

## What changes

- `packages/cli` hackmyagent exact pin `0.23.11` → `0.24.0`
- Lockfile: hackmyagent 0.24.0 + `@opena2a/aim-sdk` 1.0.1 (new transitive — the arp module now lives there and `hackmyagent/arp` re-exports it) + `fastify-plugin` 6.0.0 (aim-sdk dependency)

hackmyagent 0.24.0 scanner behavior is unchanged from 0.23.11 (the release is the arp shim + aim-sdk 1.0.1 pin + hono/js-yaml security bumps), so no score or band shifts are expected — and none were observed.

## Validation

- `packages/cli` tests: 1271/1271
- `release-smoke:corpus` (parity vs `hackmyagent secure` on every applicable fixture — same score, finding IDs, severity histogram): 12 passed, 0 failed
- `release-smoke:comply`: green
- Spot-check through the new delegation: `review ~/.opena2a/corpus/repo/malicious/kitchen-sink --ci` → 0/100, "Not safe to ship"

## Known pre-existing (verified NOT caused by this bump)

- `release-smoke:init` is RED on main today: buggy tier scores 93, equal to benign — reproduced identically on unmodified main with 0.23.11. Tracked in #227.
- hackmyagent self-scan pre-existing findings (docker adapter env passthrough et al.) tracked in #228.

No opena2a-cli publish rides this PR; the pin merges now and ships with the next batched release.