### PR TITLE
atx-verify: strict-parse raw credential entry point + declaredPurpose TBS coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,51 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run lint
+
+  atx-fixture-drift:
+    runs-on: ubuntu-latest
+    env:
+      # Pinned atx-conformance suite ref. Bump deliberately when the suite
+      # grows; the vendored copies under packages/atx-verify/src/__fixtures__
+      # must be refreshed in the same PR or the byte-compare below fails.
+      # Same gate pattern as agent-identity-management's Java SDK fixtures.
+      ATX_CONFORMANCE_REF: f4d40a4e33ac15946e90683ad1f1c59122559407
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone pinned atx-conformance suite
+        run: |
+          git clone --no-checkout https://github.com/opena2a-standards/atx-conformance.git /tmp/atx-conformance
+          git -C /tmp/atx-conformance checkout "$ATX_CONFORMANCE_REF"
+
+      - name: MANIFEST.sha256 integrity
+        working-directory: /tmp/atx-conformance
+        run: |
+          rc=0
+          while read -r sha file; do
+            [ -z "$sha" ] && continue
+            got=$(sha256sum "$file" | awk '{print $1}')
+            if [ "$got" != "$sha" ]; then
+              echo "::error::MANIFEST mismatch: $file"; rc=1
+            fi
+          done < MANIFEST.sha256
+          exit $rc
+
+      - name: Vendored fixtures byte-match the pinned suite
+        run: |
+          fail=0
+          for f in /tmp/atx-conformance/fixtures/*.json; do
+            b=$(basename "$f")
+            if ! cmp -s "$f" "packages/atx-verify/src/__fixtures__/$b"; then
+              echo "::error::vendored fixture $b is missing or drifted from the pinned suite"
+              fail=1
+            fi
+          done
+          for f in packages/atx-verify/src/__fixtures__/*.json; do
+            b=$(basename "$f")
+            if [ ! -f "/tmp/atx-conformance/fixtures/$b" ]; then
+              echo "::error::vendored fixture $b does not exist in the pinned suite"
+              fail=1
+            fi
+          done
+          exit $fail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
       - 'package.json'
       - 'turbo.json'
       - 'tsconfig.base.json'
+      # A lone ATX_CONFORMANCE_REF bump must still run the fixture drift gate.
+      - '.github/workflows/ci.yml'
 
 concurrency:
   group: ci-${{ github.event.pull_request.number }}

--- a/packages/atx-verify/README.md
+++ b/packages/atx-verify/README.md
@@ -44,8 +44,9 @@ post-quantum half) via the `AtxVerifier` seam.
   cover `capabilities`, `scanSummary`, `issuerChain`, `publisher`,
   `behavioralProfile`, and — when present — `declaredPurpose` (atx-spec §1.5;
   absent, `null`, and empty-object purposes are omitted from the TBS per
-  §1.3a.2 rule 5, so an attacker-appended purpose value breaks the signature
-  instead of riding it).
+  §1.3a.2 rule 5, so an appended purpose value carrying any data breaks the
+  signature instead of riding it — only the data-free `null`/`{}` forms
+  canonicalize away as absent).
 
 The verified context exposes `signedCapabilities` (true iff v1.1) so callers can
 gate capability-based authorization on whether those fields are signed.

--- a/packages/atx-verify/README.md
+++ b/packages/atx-verify/README.md
@@ -10,13 +10,24 @@ across Go == Python == TS is pinned by `atx-conformance/jcs-vectors`.
 
 ## What it does
 
-`LocalAtxVerifier.verify(atx)` runs the full local check with no network call:
+`LocalAtxVerifier.verifyCredential(json)` takes the raw credential (string or
+`Uint8Array`) and runs the full local check with no network call:
 
-1. schema version (`atcVersion` `1.0` or `1.1`)
-2. expiry
-3. revocation (the credential's `revoked` field + a cached/federated CRL)
-4. issuer trust (issuer DID against injected trust anchors)
-5. Ed25519 signature over the canonical payload
+1. **strict parse** — a duplicate object member at any depth, exact-name or
+   fold-colliding case variant, rejects as `MALFORMED` before any field is
+   interpreted (RFC 8259 §4 leaves duplicate handling parser-divergent; the
+   ATX credential is a signed body, so there is no layer with sanctioned
+   last-wins semantics)
+2. schema version (`atcVersion` `1.0` or `1.1`)
+3. expiry
+4. revocation (the credential's `revoked` field + a cached/federated CRL)
+5. issuer trust (issuer DID against injected trust anchors)
+6. Ed25519 signature over the canonical payload
+
+`verify(atx)` runs steps 2-6 on an already-parsed object. Prefer
+`verifyCredential` whenever you hold the wire form: `JSON.parse` is last-wins
+on duplicate members, so a parsed object cannot carry the evidence step 1
+rejects on.
 
 Trust anchors (trusted issuers, public keys, CRL, clock) are **injected** — the
 library does no I/O. A consumer wires the live anchors (and, in production, the
@@ -30,8 +41,11 @@ post-quantum half) via the `AtxVerifier` seam.
   `issuerChain`, or `publisher` — a holder can edit those without breaking the
   signature, so they MUST NOT be trusted for authorization.
 - **v1.1** (`canonicalPayloadV11`) signs `JCS(TBS)` (RFC 8785), which **does**
-  cover `capabilities`, `scanSummary`, `issuerChain`, `publisher`, and
-  `behavioralProfile`.
+  cover `capabilities`, `scanSummary`, `issuerChain`, `publisher`,
+  `behavioralProfile`, and — when present — `declaredPurpose` (atx-spec §1.5;
+  absent, `null`, and empty-object purposes are omitted from the TBS per
+  §1.3a.2 rule 5, so an attacker-appended purpose value breaks the signature
+  instead of riding it).
 
 The verified context exposes `signedCapabilities` (true iff v1.1) so callers can
 gate capability-based authorization on whether those fields are signed.
@@ -63,7 +77,8 @@ const anchors: AtxTrustAnchors = {
   crl: { entries: [] },
 };
 
-const result = new LocalAtxVerifier(anchors).verify(atx);
+// Raw wire form (string | Uint8Array): strict-parses, then verifies.
+const result = new LocalAtxVerifier(anchors).verifyCredential(credentialJson);
 if (result.valid) {
   // result.context — backend-free; only authorize on capabilities when
   // result.context.signedCapabilities is true (v1.1).
@@ -89,10 +104,13 @@ than one issuer.
 
 ## Conformance
 
-`src/conformance.test.ts` runs the verifier against the OpenA2A ATX conformance
-fixtures (with their pinned signatures), and `src/atx.test.ts` pins the v1.1
-JCS baseline canonical bytes from `atx-conformance/jcs-vectors`. Any drift from
-the cross-language contract fails the package's own CI.
+`src/conformance.test.ts` replays the FULL OpenA2A ATX conformance suite (20
+fixtures, pinned signatures, vendored verbatim from `atx-conformance` at
+`f4d40a4`) through the raw `verifyCredential` entry point; CI byte-compares the
+vendored copies against the pinned suite so they cannot drift. `src/atx.test.ts`
+pins the v1.1 JCS baseline canonical bytes from `atx-conformance/jcs-vectors`.
+Where the reference verifiers report `PARSE_ERROR`, this SDK reports
+`MALFORMED` (the shared SDK `RejectCategory` union has no `PARSE_ERROR`).
 
 ## License
 

--- a/packages/atx-verify/src/__fixtures__/baseline-valid-hybrid.json
+++ b/packages/atx-verify/src/__fixtures__/baseline-valid-hybrid.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/baseline-valid-hybrid",
+  "description": "An ATX v1.0 credential carrying both an Ed25519 signature and an ML-DSA-65 signature over the same canonical payload. This is the hybrid signing path the ATX v1.0 spec mandates. A spec-conformant verifier MUST verify BOTH signatures and ACCEPT only when both are valid. NOTE: the current opena2a-registry/pkg/atcverify verifier verifies Ed25519 only and silently ignores ML-DSA-65 signatures; the conformance Go verifier in ../verifiers/go DOES verify both, per spec.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    },
+    {
+      "role": "issuer-primary-pqc",
+      "path": "vectors/mldsa65-seed.json",
+      "algorithm": "ML-DSA-65",
+      "publicKeyHex": "48683d91978e31eb3dddb8b0473482d2b88a5f625949fd8f58a561e696bd4c27d05b38dbb2edf01e664efd81be1ea893688ce68aa2d51c5958f8bbc6eb4e89ee67d2c0320954d57212cac7229ff1d6eaf03928bd51511f8d88d847736c7de2730d5978e5410713160978867711bf5539a0bfc4c350c2be572baf0ee2e2fb16ccfea08028d99ac49aebb75937ddce111cdab62fff3cea8ba2233d1e56fbc5c5a1e726de63fadd2af016b119177fa3d971a2d9277173fce55b67745af0b7c21d597dbeb93e6a32f341c49a5a8be9e825088d1f2aa45155d6c8ae15367e4eb003b8fdf7851071949739f9fff09023eaf45104d2a84a45906eed4671a44dc28d27987bb55df69e9e8561f61a80a72699503865fed9b7ee72a8e17a19c408144f4b29afef7031c3a6d8571610b42c9f421245a88f197e16812b031159b65b9687e5b3e934c5225ae98a79ba73d2b399d73510effad19e53b8450f0ba8fce1012fd98d260a74aaaa13fae249a006b1c34f5ba0b882f26378222fb36f2283c243f0ffeb5f1bb414a0a70d55e3d40a56b6cbc88ae1f03b7b2882d98deea28e145c9dedfd8eaf1cef2ed94a8b050f8964f46d1ea0d0c2a43e0dda6182adbf4f6ed175b6742257859bf22f3a417ecf1f9d89317b5e539d587af16b9e1313e04514ffa64ba8b3ff2b8321f8811cb3fb022c8f644e70a4b80a2fbfee604abb7379091ea8e6c5c74dfc0283666b40c0793870028204a136bf5da9568eb798d349038bdb0c11e03445e7847cb5069c75cf28ac601c7799d958210ddbcb226e51afef9f1de47b073873d6d3f97456bede085082e74a298b2cd48f4b3093155f366c8fa601c6af858dfa32c08491b2a29887f90335949a5d6edaa679882a3a95d6bf6d970a221f4b9d3d8cbf384af81aac95e2b3294e04789ac83727a5dc04559f96af41d8a053516feeeebc52746eb6ab2819e09108710d835f011fa63065872ad334d5cdffb2b2310507e92fc993ae317da97f4f309cdaf0f67ed99d90215576083849f953b246d7fedb3fdb67679850a5ad404e64147fb7cf4f6aeddd05afb4b834968d1fe88014960dce5d942236526e12a478d69e5fbe6970310b308c06845018cfc7b2ab430a13a6b1ac7bb02cccbb3d911ac2f11068613fbe029bfdce02cf5cd38950ed72c83944edfbc75615af87f864c051f3c55456c5412863a40c06d1dab562bdff0571b8d3c3917bbd300880bba5e998239b95fa91b7d6416d4f398b3adbcd30983ed3592b4d9ef7d4236fd00f50d98aa53a235ac4172720f77d96172672980cfe8ff7a5a702783edc2ba31b2259015a112fc7f468a9c2f9464039002d30ef678b4cb798bc116216bf7a9a7c18ba03b7b58fd07515d3115049d3614be7a07e744300750df1d2c58753389059eafc3d785ccdd31c07648bedc03a5c3b8ad46d064d59c13d57374729fc4e295362e2a5191204530428bc1522afa28ff5fe1655e304ca5bc8c27ad0e0c6a39dd4df28956c14b38cc93682cefe402bbd5e82d29c464e44eb5d37b48fc568dfe0cc6e8e16baea05e5135590f19294e73e8367b0216dbb815030b9de55913f08039c42351c59e5515dd5af8e089a15e625e8f6dee639386c46497d7a263288774de581a7de9629b41b4424141f978fb8331208efdec3c6e0de39bc57063f3dcd6c470373c08891ea29cbc7cc6d6483b8889083ace86aa7b51b1c2cfe6e2ad18d97ce36fbc56ea42fae97e6a7ac114864478c366df1ebb1e7b11a9098504fd5975bdf1f49dc70002b63c1739a9d263fbad4073f6a9f6c2b8af4b4c332a103a0cffa5deeb2d062ca3c215fd360026be7c5164f4a4424ef74948804d66f46487732c8202c795478647b4ea71d627c086024cca354a41f0877b38f19b3774ad2095c8da53b069e21c76ae2d2007e16719ed40080d334f7da52e9f5a5990439caf083a95b833f02ad10a08c1a6d0f260c007285bd4a2f47703a5aef465287d253b18ac22514316210ff566814b10f87a293d6f199d3c3959990d0c1268b4f50d5f9fcefbbf237bd0c28b80182d6659741f14f10bfbb21bba12ab620aa2396f56c0686b4ea9017990224216b2fe8ad76c4a9148eef9a86a3635a6aa77bc1dcfb6fba59a77dfda9b7530dc0ca8648c8d973738e01bab8f08b4905e84aa4641bd602410cd97520265f2f231f2b35e15eb2fa04d2bd94d5a77abaf1e0e161010a990087f5b46ea988b2bc0512fda0fa923dadd6c45c5301d09483673265b5ab2e10f4ba520f6bbad564a5c3d5e27bdb080f7d20e13296a3181954c39c649c943ebe17df5c1f7aae0a8fe126c477585a5d4d648a0d008b6af5e8cd31be69a9296d4f3fd25ed86f221e4b93f65f5929967533624b9235750c30707550b58536d109a7131c5a5bbe4a5715567c12534aec7660761eebb9fae2891c774589b80e566ad557ddef7367196b7227ea9870ef09ddfec79d6b9319a6879b5205d76bf7aba5acf33afb59d17fc54e68383d6be5a08e9b66da53dcde008bb294b8582bd132cdcc49959fdbc21e52721880c8ad0352c79f03a43bbd84c4cdfdc6c529005e1e7cd9a349a7168a35569ba5dea818968d5a91466bd6e64e20bf62417198afc4e81c28dd77ed4028232398b52fbde86bc84f475b9016710ce2aabc11a06b4dbac901ec16cf365ca3f2d53813948a693a0f93e79c46ca5d5a6dca3d28ca50ad18bd13fca55059dd9b185f79f9c47196a4e81b2104bc460a051e02f2e8444f",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1-pqc"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      },
+      {
+        "role": "issuer-primary-pqc",
+        "path": "vectors/mldsa65-seed.json",
+        "algorithm": "ML-DSA-65",
+        "publicKeyHex": "48683d91978e31eb3dddb8b0473482d2b88a5f625949fd8f58a561e696bd4c27d05b38dbb2edf01e664efd81be1ea893688ce68aa2d51c5958f8bbc6eb4e89ee67d2c0320954d57212cac7229ff1d6eaf03928bd51511f8d88d847736c7de2730d5978e5410713160978867711bf5539a0bfc4c350c2be572baf0ee2e2fb16ccfea08028d99ac49aebb75937ddce111cdab62fff3cea8ba2233d1e56fbc5c5a1e726de63fadd2af016b119177fa3d971a2d9277173fce55b67745af0b7c21d597dbeb93e6a32f341c49a5a8be9e825088d1f2aa45155d6c8ae15367e4eb003b8fdf7851071949739f9fff09023eaf45104d2a84a45906eed4671a44dc28d27987bb55df69e9e8561f61a80a72699503865fed9b7ee72a8e17a19c408144f4b29afef7031c3a6d8571610b42c9f421245a88f197e16812b031159b65b9687e5b3e934c5225ae98a79ba73d2b399d73510effad19e53b8450f0ba8fce1012fd98d260a74aaaa13fae249a006b1c34f5ba0b882f26378222fb36f2283c243f0ffeb5f1bb414a0a70d55e3d40a56b6cbc88ae1f03b7b2882d98deea28e145c9dedfd8eaf1cef2ed94a8b050f8964f46d1ea0d0c2a43e0dda6182adbf4f6ed175b6742257859bf22f3a417ecf1f9d89317b5e539d587af16b9e1313e04514ffa64ba8b3ff2b8321f8811cb3fb022c8f644e70a4b80a2fbfee604abb7379091ea8e6c5c74dfc0283666b40c0793870028204a136bf5da9568eb798d349038bdb0c11e03445e7847cb5069c75cf28ac601c7799d958210ddbcb226e51afef9f1de47b073873d6d3f97456bede085082e74a298b2cd48f4b3093155f366c8fa601c6af858dfa32c08491b2a29887f90335949a5d6edaa679882a3a95d6bf6d970a221f4b9d3d8cbf384af81aac95e2b3294e04789ac83727a5dc04559f96af41d8a053516feeeebc52746eb6ab2819e09108710d835f011fa63065872ad334d5cdffb2b2310507e92fc993ae317da97f4f309cdaf0f67ed99d90215576083849f953b246d7fedb3fdb67679850a5ad404e64147fb7cf4f6aeddd05afb4b834968d1fe88014960dce5d942236526e12a478d69e5fbe6970310b308c06845018cfc7b2ab430a13a6b1ac7bb02cccbb3d911ac2f11068613fbe029bfdce02cf5cd38950ed72c83944edfbc75615af87f864c051f3c55456c5412863a40c06d1dab562bdff0571b8d3c3917bbd300880bba5e998239b95fa91b7d6416d4f398b3adbcd30983ed3592b4d9ef7d4236fd00f50d98aa53a235ac4172720f77d96172672980cfe8ff7a5a702783edc2ba31b2259015a112fc7f468a9c2f9464039002d30ef678b4cb798bc116216bf7a9a7c18ba03b7b58fd07515d3115049d3614be7a07e744300750df1d2c58753389059eafc3d785ccdd31c07648bedc03a5c3b8ad46d064d59c13d57374729fc4e295362e2a5191204530428bc1522afa28ff5fe1655e304ca5bc8c27ad0e0c6a39dd4df28956c14b38cc93682cefe402bbd5e82d29c464e44eb5d37b48fc568dfe0cc6e8e16baea05e5135590f19294e73e8367b0216dbb815030b9de55913f08039c42351c59e5515dd5af8e089a15e625e8f6dee639386c46497d7a263288774de581a7de9629b41b4424141f978fb8331208efdec3c6e0de39bc57063f3dcd6c470373c08891ea29cbc7cc6d6483b8889083ace86aa7b51b1c2cfe6e2ad18d97ce36fbc56ea42fae97e6a7ac114864478c366df1ebb1e7b11a9098504fd5975bdf1f49dc70002b63c1739a9d263fbad4073f6a9f6c2b8af4b4c332a103a0cffa5deeb2d062ca3c215fd360026be7c5164f4a4424ef74948804d66f46487732c8202c795478647b4ea71d627c086024cca354a41f0877b38f19b3774ad2095c8da53b069e21c76ae2d2007e16719ed40080d334f7da52e9f5a5990439caf083a95b833f02ad10a08c1a6d0f260c007285bd4a2f47703a5aef465287d253b18ac22514316210ff566814b10f87a293d6f199d3c3959990d0c1268b4f50d5f9fcefbbf237bd0c28b80182d6659741f14f10bfbb21bba12ab620aa2396f56c0686b4ea9017990224216b2fe8ad76c4a9148eef9a86a3635a6aa77bc1dcfb6fba59a77dfda9b7530dc0ca8648c8d973738e01bab8f08b4905e84aa4641bd602410cd97520265f2f231f2b35e15eb2fa04d2bd94d5a77abaf1e0e161010a990087f5b46ea988b2bc0512fda0fa923dadd6c45c5301d09483673265b5ab2e10f4ba520f6bbad564a5c3d5e27bdb080f7d20e13296a3181954c39c649c943ebe17df5c1f7aae0a8fe126c477585a5d4d648a0d008b6af5e8cd31be69a9296d4f3fd25ed86f221e4b93f65f5929967533624b9235750c30707550b58536d109a7131c5a5bbe4a5715567c12534aec7660761eebb9fae2891c774589b80e566ad557ddef7367196b7227ea9870ef09ddfec79d6b9319a6879b5205d76bf7aba5acf33afb59d17fc54e68383d6be5a08e9b66da53dcde008bb294b8582bd132cdcc49959fdbc21e52721880c8ad0352c79f03a43bbd84c4cdfdc6c529005e1e7cd9a349a7168a35569ba5dea818968d5a91466bd6e64e20bf62417198afc4e81c28dd77ed4028232398b52fbde86bc84f475b9016710ce2aabc11a06b4dbac901ec16cf365ca3f2d53813948a693a0f93e79c46ca5d5a6dca3d28ca50ad18bd13fca55059dd9b185f79f9c47196a4e81b2104bc460a051e02f2e8444f",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1-pqc"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "ACCEPT"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:opena2a.org-root"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "T+tCrEORj2ipWjPwZIEHxvJUw2qIEWILz6HITxrVEnw9kpnaGmp5a1YGAnKuQZC3Vp4LEmyq6RqkQCIh/C/pAg=="
+      },
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1-pqc",
+        "algorithm": "ML-DSA-65",
+        "value": "4UPrwKrcCr3RlEQ15mkbzrPv3BvSOwE/3nYf5FJyKFPgRqP8ji1Jk60/uMlkxta6ixWOn5SBuLrexF3tzhaF3wcyMXM4yUmZ8V3JuATpIDzsYDTbLIg1ibAVUV3uBaOk5hsgYkXqHnOv6q9gp+XiMvDMoLIrNnCjTvw9eu8Bl7VmirOmMozV8JpmKMEzn5H7zdMZqygMdQN0t85cMl63ft3TDpu9UZ2uQ7nNM8FYsjE8LCtbSPuaiW5KYDg188aGwTJLOi1NrWN9hCTEoMXW3xPfXYovXkZpPxqXQLbvKbYxRcL3ZYr2VvGxUDgRN9Aj7DCS0bu6aH9bP9o4o10TTldVj/miOHQHwFE0trYEPDyyjE9/+Z86HCFGK0P05QSYOIYljZFd/1ZnQLxmZIm5Y7JLkW/2Jc0Z+t4i21VCiqFpw1dfOlQSy1I0iwwb91PwsftSvFR2ZAbCytNmA1vzv+gTelGAb1UDnklkngSD53hdOdD/rCkByZ4oY4obH+/it6GMaGXY019NTXiwcqNVHxMGKfFTkhvNveKc2YBV6ELWVdHpYbWXuSzTrLSJtDhRjjumWPaa3Fd0/V/ozTYBodwC1fBaGBQdXDBzmK/JyAYxc9s+5Vb7jS1hlSvwx+xBvY8qDD9HGsn1PwVxuVGjlLOk88R5uykdBkOJ79+vU3ey9WXBBjm5cqvPIvIrlXtlKo6t9sCZGz2gyFxDqW8sKSlLQmGWuoXUg54JTwvdTG1jbpremDbrPz/xM8O312JsF+TCOD4fg6TiklQJ7tfED5EJ0Zm9nSJ+A+ke70u8QW3SgU116vNDS0dzpX0hoLJCupvGPqnqPLw7VuIPGyyBoqwDA3rx1kzn+hxfFc2glKZV5tO0tEK2NVY4zcR09ZY4LDPbCS5TsOwo22nU+3GSHCT0xdYU3piiwbNhCcR1fIruZTSYpEUzFY0Vbc/ng30w8C3g8WGYvzAzk7s9ud3IgR1vnfbQCL8S4cgpl9I4EfobWrLcr6PjHtAIDY96cY4OvwPickvc46GprRzaNiMQX/uHupBesRkZatBFsOkD2u0c7S1/HTCgsbySNqkoleWNZ1naPY+8LF5YUUXeQBq8v8mjSe2SCXAVrviIn1L78Ec3Q7t6KTf6kQRGDz8mIqBk+Zypf1DRMgEedt3Mf4vNzUgvMz5hhqZlnMEeP51TW96J7XFtPCCvUcOX7odJK/atGCk16N8hfGXO6FDItu/3J56olTtziG/yGJx86zjWZpTO5vrT99YqFq1vsoolg52X5Mb9oxHKSylBbEb20gTWIC/S6k4snG6UgaTmKk2kNqT8k/rJdPwRPjWv91FMOIoYXipeBnoMbgImMTQGa29gpadoeEpgKA+leBgybHCR+TdNPI9GaOlHhisAfEOs4mFgpTdZIjpkbjDXDed9lCaQA4M8nJx/oNPHZUTRVkAhvs8XBIH3ELRzdqJJ1i/mLdiNV0gtXTYMu8ofpZ9tbH4HVbplcq+k4sK+pS92VEhx1m3MAzZH9oTVtzMN9MD/DxeksG5yGWlWtnG8cvrJVzbAPnwpKPncUYaxDr51a2vOitRxUlxiVJM/HOLLnlj4Jl5xGNJNBHukRWpQTvVXEeYF5zNB7mXXCfMNKM69DeE73B1EqYnFDCn+sS5Npru8fW4B50DYbB5/HflgFll5IjPQ1Z4OM14HlPK7ww6/dfT77NA1QkXIdI2SsrFhtSXD1h+khNNA3WbXu0EFQcO66bDgkXme0ae4pElApRj3OSZh8Y+UhQvjYUxCszAn8G5+/fFDhH9wOYcf0ODyyaEtLwuDUo+dSudJcevDSRhn6aC1QO+OFetua0MO/so5rFwV3dqOImncL0V1wqIwR9kAQpFE78t52FYWitMuSKFH3hKJKWfp/Ml85WO2pMe0E7pdRBtt7cwxX3fOnyVeWhxEmceD5xponvaAmrIgJN5hhUvS1ArnmvxsMFUlXXYAsx04RARjxrziyeHDENRmz1YqWcpyvUjbHDUiA39LX+D9vjj8DcVLSflgdDE9Mt6lgpkRkKkMrcQzLUqpXkzzKEA4pUZoJqaoSaE4ekEApkyH2Vs6f8LyvQlU2tFY1A5lWcDeCmvdTSyu8D6PSOL+YZkRc002bLKryNSY5V9uKfxdG5LPfa558VJLyNPVzYl8MPcB9FzDs6nZe8fNM2zM46sHrPl/yHct+QKW3wPJt/aiHfzQyNUp7uC5j1pAgSZ9+vUHA7gyqofRy6rQSUnHJBWxqxLRKqYKb/doXovDLxSLRry0C5vsAyiekimzchT/rSzNq2D6mjnhHccaqNri85YItJZM8PwKZJytkYBp/5alR62kT6XdelvqX5HTybJS7HqcK3OAf8sa1aHpB4Wl1YEELg3qbW40uTw47D+1y7NfhZJvGmAfOXpVng8a/ra7ku57W2hIE3Prsd9jbhYdm62XylS09F5X9OmX9jfDks/zA/bcCZtaPq7RO9VVJ0N5TtMk33U0QQpkPrvPs0m65zpaAJLN7qiirA1nBDV4oiSprY3ciebjbHvB/R5fYFhY+xOrgmvZttJ66lnPPGvs5xohfF9h7qEXwVO7pizehJSW8E3TbERebuFhf1lxpSjZbo0+/Epkk2LVFuCrSn/GBu2lQXwDFq0s5SBlQTOZC5TgArNOblvIik31N6Fr1omc8AMvzZsjHVtDxmP3CXOGH7S6hPw7J+LF1gVDTzry/wzkGGGzimEZbY0J14znXxdQn0z31N9dDNGQS2mG7s1aLfjeEbH2PS72wFIb/J20f/DRqG0Zztv0mSD4M3CP0p2WxldYSoACHcpI6qH8XHaMCVv1VAXR5lNla/l+ytKi+WvWvvlgEffjXhXAXRX6Oj+AizGJ4J8fTjjQ9+ZLlrh1CPxRRPjH2f3Z/JvgkmKJY7BTtBYnS233YWTJVQAxTV7i03SCIrsahvxZErxR0rtq7FccPA28I0VctmWsXD6uiaO2w9MxERuP8tKvIkVYuyzk4Lnt8/5J6cJf+TFTtqcaTnjq/KaTwy1KoAs7bo9QiyX1EHoXRJO8zzLZWMUZoI9KQYouDBxB0PUTZ3H15n3Z98aZQa6gqAASEiEE5G5KWw/dUhblz57qNPqaXQ4N8TiZtOh6c/VWu0jYXk9888q+cv953reqNwasD32nS73qMafspajAbrbpQ7hikYeNlTPXtMZ1qYTuM2ZNMM3xxSstOt2XCOaCbWjjWUsYIRvmdRZaDc88CwAPyJGQTWyr4Mwm4u8E2hu5zklmm+gvQI3ykGEx4HsYJVpLPhMCXSxP/BnvL5QesWkcvTA1hHcGNFYbpwmJUUzYf1Ffcj/awB2thuv3m2IzRo1GZYgQ+4bfCWIKAXrTSN1MCQjJzPbA4fcWWrxIQsgNw0M6jj7hD82AfShwVFyjWgIhCT+uf4Nxe9aWMJFQlC8ehJUiD1Itx1OjYqwzlqOjElIh9wXEtYYbdVxZ2eiqV5uq+YO7m/rMWetghe7hpHiYnWp3+d+Em0ROBSoD/JmFxNV3ysh4bYDndTWdx339hjMlDBYCRJuQui9ApycHXUhz83VzRq3NtqWRTd+MW9qTlkQOIG+JqKwxqezhRQQ8Y9fW3+iSNdJY+g+vBS2bZxV3+ik+yGQj1D8uZLq5ZrY1oi8Dz6jIOkAHzK3UqFpq50p2PHIlzXDtBmpNK1D3UCvleJXp7hgcGGu6OWGTsHrqZ8gHA1cLl7F0rRmf+Uc0UVrPyIt2SBJ2FJAVhWnzDEVHKpuSv21EpBLY4JAnXYtibkYJfkR2LKPZCW0BzoXzQDI3taUTmwFtojTj6RK7xO+nIqM+g/sG8hCQBa04d64+EahsSD01Mf5pzlRRmo7coqOuM1Ow3O0qxHOaxF88jgBcNsJpqOwAlqOCDDnIQue3JK8AP2KCn0SfNzS1pJsW7lu92sO6qC2ZdtFbhxBZEeke2Ltli5e/HY2gMPnffHEHbIRttjcqHb51l1vThnsi+a5S4mbUTOkc/Qqaq65LYiWmqpbhgCvQnhDRW62z2cgUfQ/c5LO5z1zbABjcFQ/UIIlayk3KqLKu8eoCPxp7k191tT2myKLJdwc8PooyYqDv57rabmSGErHCTm3ZyE6KbH96pyv84EYztFLzS+R8iV/hJzo5GXrEnUwa4AUFZ20wQrn/GGity5iJ34zGC87vwfxVGZM7JaKFxqyqxhPTxulNXGAf63fC9oWX4hi4wdmvfQo0eeBDqBaNzI/Bhkr+5qJ6wpX08mqm4uTeQXlGv1+H/6jFHrwBykwYgtZ1VAoYMOn+bP4RPb519AQFzKnZ3CGVsugHAVC6gBYXJY/8s+wLD5+95ejw8vb7ITBYxBk+ZqK5MT2Mn6+5y0BYvdoVNj4/dHh6mMAAAAAAAAAAAAAAAAAAAAAACg4TGh4n"
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/malformed-schema.json
+++ b/packages/atx-verify/src/__fixtures__/malformed-schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/malformed-schema",
+  "description": "An ATX whose atcVersion claims a version (2.0) that is not the v1.0 supported by this conformance suite. Verifier MUST REJECT at step 1 (schema-version check) with an unsupported-version reason. NOTE: the signature is computed using ATCVersion=\"1.0\" canonical bytes because the production canonicalPayload function hardcodes \"1.0\" in the canonical string regardless of the credential's atcVersion field. This is itself a discrepancy worth noting in the reconciliation log; the conformance fixture intentionally still produces a syntactically reasonable file so verifiers can demonstrate they reject on schema-version alone.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "UNSUPPORTED_VERSION",
+    "reasonContains": "version"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "2.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:opena2a.org-root"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "T+tCrEORj2ipWjPwZIEHxvJUw2qIEWILz6HITxrVEnw9kpnaGmp5a1YGAnKuQZC3Vp4LEmyq6RqkQCIh/C/pAg=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/threshold-2of3-cosignature.json
+++ b/packages/atx-verify/src/__fixtures__/threshold-2of3-cosignature.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/threshold-2of3-cosignature",
+  "description": "An ATX cosigned by all three keys of a 2-of-3 threshold issuer (primary plus two cosigners). All three signatures are Ed25519 and cover the same canonical payload. Verifier MUST ACCEPT. A spec-conformant verifier additionally MUST validate at least two of the three signatures for trust level 4.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    },
+    {
+      "role": "issuer-cosigner-1",
+      "path": "vectors/issuer-cosigner-1.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+      "keyId": "did:opena2a:authority:opena2a.org#key-2"
+    },
+    {
+      "role": "issuer-cosigner-2",
+      "path": "vectors/issuer-cosigner-2.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+      "keyId": "did:opena2a:authority:opena2a.org#key-3"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "ACCEPT"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:opena2a.org-root"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "T+tCrEORj2ipWjPwZIEHxvJUw2qIEWILz6HITxrVEnw9kpnaGmp5a1YGAnKuQZC3Vp4LEmyq6RqkQCIh/C/pAg=="
+      },
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-2",
+        "algorithm": "Ed25519",
+        "value": "VgJM86Nfztvtt4zTMNT+wqI/fhF9bpZ5G5t8Aiq3EzLPhZ1SY0Tc9OgwjPxN7I7nB17gS7xHb7GqYP6vpHQUAw=="
+      },
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-3",
+        "algorithm": "Ed25519",
+        "value": "E/bK1NmDzFnaETj56KTTGkMB8d16JkdhhT0KxKaB61Mur7c4BSk87Pe+KWeaxm+J49mhvLkAPf3/WaQDdltVCg=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/v1_1-baseline-valid-hybrid.json
+++ b/packages/atx-verify/src/__fixtures__/v1_1-baseline-valid-hybrid.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/baseline-valid-hybrid",
+  "description": "An ATX v1.1 credential carrying both an Ed25519 signature and an ML-DSA-65 signature over the SAME JCS(TBS) bytes. A spec-conformant verifier MUST verify both and ACCEPT.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    },
+    {
+      "role": "issuer-primary-pqc",
+      "path": "vectors/mldsa65-seed.json",
+      "algorithm": "ML-DSA-65",
+      "publicKeyHex": "48683d91978e31eb3dddb8b0473482d2b88a5f625949fd8f58a561e696bd4c27d05b38dbb2edf01e664efd81be1ea893688ce68aa2d51c5958f8bbc6eb4e89ee67d2c0320954d57212cac7229ff1d6eaf03928bd51511f8d88d847736c7de2730d5978e5410713160978867711bf5539a0bfc4c350c2be572baf0ee2e2fb16ccfea08028d99ac49aebb75937ddce111cdab62fff3cea8ba2233d1e56fbc5c5a1e726de63fadd2af016b119177fa3d971a2d9277173fce55b67745af0b7c21d597dbeb93e6a32f341c49a5a8be9e825088d1f2aa45155d6c8ae15367e4eb003b8fdf7851071949739f9fff09023eaf45104d2a84a45906eed4671a44dc28d27987bb55df69e9e8561f61a80a72699503865fed9b7ee72a8e17a19c408144f4b29afef7031c3a6d8571610b42c9f421245a88f197e16812b031159b65b9687e5b3e934c5225ae98a79ba73d2b399d73510effad19e53b8450f0ba8fce1012fd98d260a74aaaa13fae249a006b1c34f5ba0b882f26378222fb36f2283c243f0ffeb5f1bb414a0a70d55e3d40a56b6cbc88ae1f03b7b2882d98deea28e145c9dedfd8eaf1cef2ed94a8b050f8964f46d1ea0d0c2a43e0dda6182adbf4f6ed175b6742257859bf22f3a417ecf1f9d89317b5e539d587af16b9e1313e04514ffa64ba8b3ff2b8321f8811cb3fb022c8f644e70a4b80a2fbfee604abb7379091ea8e6c5c74dfc0283666b40c0793870028204a136bf5da9568eb798d349038bdb0c11e03445e7847cb5069c75cf28ac601c7799d958210ddbcb226e51afef9f1de47b073873d6d3f97456bede085082e74a298b2cd48f4b3093155f366c8fa601c6af858dfa32c08491b2a29887f90335949a5d6edaa679882a3a95d6bf6d970a221f4b9d3d8cbf384af81aac95e2b3294e04789ac83727a5dc04559f96af41d8a053516feeeebc52746eb6ab2819e09108710d835f011fa63065872ad334d5cdffb2b2310507e92fc993ae317da97f4f309cdaf0f67ed99d90215576083849f953b246d7fedb3fdb67679850a5ad404e64147fb7cf4f6aeddd05afb4b834968d1fe88014960dce5d942236526e12a478d69e5fbe6970310b308c06845018cfc7b2ab430a13a6b1ac7bb02cccbb3d911ac2f11068613fbe029bfdce02cf5cd38950ed72c83944edfbc75615af87f864c051f3c55456c5412863a40c06d1dab562bdff0571b8d3c3917bbd300880bba5e998239b95fa91b7d6416d4f398b3adbcd30983ed3592b4d9ef7d4236fd00f50d98aa53a235ac4172720f77d96172672980cfe8ff7a5a702783edc2ba31b2259015a112fc7f468a9c2f9464039002d30ef678b4cb798bc116216bf7a9a7c18ba03b7b58fd07515d3115049d3614be7a07e744300750df1d2c58753389059eafc3d785ccdd31c07648bedc03a5c3b8ad46d064d59c13d57374729fc4e295362e2a5191204530428bc1522afa28ff5fe1655e304ca5bc8c27ad0e0c6a39dd4df28956c14b38cc93682cefe402bbd5e82d29c464e44eb5d37b48fc568dfe0cc6e8e16baea05e5135590f19294e73e8367b0216dbb815030b9de55913f08039c42351c59e5515dd5af8e089a15e625e8f6dee639386c46497d7a263288774de581a7de9629b41b4424141f978fb8331208efdec3c6e0de39bc57063f3dcd6c470373c08891ea29cbc7cc6d6483b8889083ace86aa7b51b1c2cfe6e2ad18d97ce36fbc56ea42fae97e6a7ac114864478c366df1ebb1e7b11a9098504fd5975bdf1f49dc70002b63c1739a9d263fbad4073f6a9f6c2b8af4b4c332a103a0cffa5deeb2d062ca3c215fd360026be7c5164f4a4424ef74948804d66f46487732c8202c795478647b4ea71d627c086024cca354a41f0877b38f19b3774ad2095c8da53b069e21c76ae2d2007e16719ed40080d334f7da52e9f5a5990439caf083a95b833f02ad10a08c1a6d0f260c007285bd4a2f47703a5aef465287d253b18ac22514316210ff566814b10f87a293d6f199d3c3959990d0c1268b4f50d5f9fcefbbf237bd0c28b80182d6659741f14f10bfbb21bba12ab620aa2396f56c0686b4ea9017990224216b2fe8ad76c4a9148eef9a86a3635a6aa77bc1dcfb6fba59a77dfda9b7530dc0ca8648c8d973738e01bab8f08b4905e84aa4641bd602410cd97520265f2f231f2b35e15eb2fa04d2bd94d5a77abaf1e0e161010a990087f5b46ea988b2bc0512fda0fa923dadd6c45c5301d09483673265b5ab2e10f4ba520f6bbad564a5c3d5e27bdb080f7d20e13296a3181954c39c649c943ebe17df5c1f7aae0a8fe126c477585a5d4d648a0d008b6af5e8cd31be69a9296d4f3fd25ed86f221e4b93f65f5929967533624b9235750c30707550b58536d109a7131c5a5bbe4a5715567c12534aec7660761eebb9fae2891c774589b80e566ad557ddef7367196b7227ea9870ef09ddfec79d6b9319a6879b5205d76bf7aba5acf33afb59d17fc54e68383d6be5a08e9b66da53dcde008bb294b8582bd132cdcc49959fdbc21e52721880c8ad0352c79f03a43bbd84c4cdfdc6c529005e1e7cd9a349a7168a35569ba5dea818968d5a91466bd6e64e20bf62417198afc4e81c28dd77ed4028232398b52fbde86bc84f475b9016710ce2aabc11a06b4dbac901ec16cf365ca3f2d53813948a693a0f93e79c46ca5d5a6dca3d28ca50ad18bd13fca55059dd9b185f79f9c47196a4e81b2104bc460a051e02f2e8444f",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1-pqc"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      },
+      {
+        "role": "issuer-primary-pqc",
+        "path": "vectors/mldsa65-seed.json",
+        "algorithm": "ML-DSA-65",
+        "publicKeyHex": "48683d91978e31eb3dddb8b0473482d2b88a5f625949fd8f58a561e696bd4c27d05b38dbb2edf01e664efd81be1ea893688ce68aa2d51c5958f8bbc6eb4e89ee67d2c0320954d57212cac7229ff1d6eaf03928bd51511f8d88d847736c7de2730d5978e5410713160978867711bf5539a0bfc4c350c2be572baf0ee2e2fb16ccfea08028d99ac49aebb75937ddce111cdab62fff3cea8ba2233d1e56fbc5c5a1e726de63fadd2af016b119177fa3d971a2d9277173fce55b67745af0b7c21d597dbeb93e6a32f341c49a5a8be9e825088d1f2aa45155d6c8ae15367e4eb003b8fdf7851071949739f9fff09023eaf45104d2a84a45906eed4671a44dc28d27987bb55df69e9e8561f61a80a72699503865fed9b7ee72a8e17a19c408144f4b29afef7031c3a6d8571610b42c9f421245a88f197e16812b031159b65b9687e5b3e934c5225ae98a79ba73d2b399d73510effad19e53b8450f0ba8fce1012fd98d260a74aaaa13fae249a006b1c34f5ba0b882f26378222fb36f2283c243f0ffeb5f1bb414a0a70d55e3d40a56b6cbc88ae1f03b7b2882d98deea28e145c9dedfd8eaf1cef2ed94a8b050f8964f46d1ea0d0c2a43e0dda6182adbf4f6ed175b6742257859bf22f3a417ecf1f9d89317b5e539d587af16b9e1313e04514ffa64ba8b3ff2b8321f8811cb3fb022c8f644e70a4b80a2fbfee604abb7379091ea8e6c5c74dfc0283666b40c0793870028204a136bf5da9568eb798d349038bdb0c11e03445e7847cb5069c75cf28ac601c7799d958210ddbcb226e51afef9f1de47b073873d6d3f97456bede085082e74a298b2cd48f4b3093155f366c8fa601c6af858dfa32c08491b2a29887f90335949a5d6edaa679882a3a95d6bf6d970a221f4b9d3d8cbf384af81aac95e2b3294e04789ac83727a5dc04559f96af41d8a053516feeeebc52746eb6ab2819e09108710d835f011fa63065872ad334d5cdffb2b2310507e92fc993ae317da97f4f309cdaf0f67ed99d90215576083849f953b246d7fedb3fdb67679850a5ad404e64147fb7cf4f6aeddd05afb4b834968d1fe88014960dce5d942236526e12a478d69e5fbe6970310b308c06845018cfc7b2ab430a13a6b1ac7bb02cccbb3d911ac2f11068613fbe029bfdce02cf5cd38950ed72c83944edfbc75615af87f864c051f3c55456c5412863a40c06d1dab562bdff0571b8d3c3917bbd300880bba5e998239b95fa91b7d6416d4f398b3adbcd30983ed3592b4d9ef7d4236fd00f50d98aa53a235ac4172720f77d96172672980cfe8ff7a5a702783edc2ba31b2259015a112fc7f468a9c2f9464039002d30ef678b4cb798bc116216bf7a9a7c18ba03b7b58fd07515d3115049d3614be7a07e744300750df1d2c58753389059eafc3d785ccdd31c07648bedc03a5c3b8ad46d064d59c13d57374729fc4e295362e2a5191204530428bc1522afa28ff5fe1655e304ca5bc8c27ad0e0c6a39dd4df28956c14b38cc93682cefe402bbd5e82d29c464e44eb5d37b48fc568dfe0cc6e8e16baea05e5135590f19294e73e8367b0216dbb815030b9de55913f08039c42351c59e5515dd5af8e089a15e625e8f6dee639386c46497d7a263288774de581a7de9629b41b4424141f978fb8331208efdec3c6e0de39bc57063f3dcd6c470373c08891ea29cbc7cc6d6483b8889083ace86aa7b51b1c2cfe6e2ad18d97ce36fbc56ea42fae97e6a7ac114864478c366df1ebb1e7b11a9098504fd5975bdf1f49dc70002b63c1739a9d263fbad4073f6a9f6c2b8af4b4c332a103a0cffa5deeb2d062ca3c215fd360026be7c5164f4a4424ef74948804d66f46487732c8202c795478647b4ea71d627c086024cca354a41f0877b38f19b3774ad2095c8da53b069e21c76ae2d2007e16719ed40080d334f7da52e9f5a5990439caf083a95b833f02ad10a08c1a6d0f260c007285bd4a2f47703a5aef465287d253b18ac22514316210ff566814b10f87a293d6f199d3c3959990d0c1268b4f50d5f9fcefbbf237bd0c28b80182d6659741f14f10bfbb21bba12ab620aa2396f56c0686b4ea9017990224216b2fe8ad76c4a9148eef9a86a3635a6aa77bc1dcfb6fba59a77dfda9b7530dc0ca8648c8d973738e01bab8f08b4905e84aa4641bd602410cd97520265f2f231f2b35e15eb2fa04d2bd94d5a77abaf1e0e161010a990087f5b46ea988b2bc0512fda0fa923dadd6c45c5301d09483673265b5ab2e10f4ba520f6bbad564a5c3d5e27bdb080f7d20e13296a3181954c39c649c943ebe17df5c1f7aae0a8fe126c477585a5d4d648a0d008b6af5e8cd31be69a9296d4f3fd25ed86f221e4b93f65f5929967533624b9235750c30707550b58536d109a7131c5a5bbe4a5715567c12534aec7660761eebb9fae2891c774589b80e566ad557ddef7367196b7227ea9870ef09ddfec79d6b9319a6879b5205d76bf7aba5acf33afb59d17fc54e68383d6be5a08e9b66da53dcde008bb294b8582bd132cdcc49959fdbc21e52721880c8ad0352c79f03a43bbd84c4cdfdc6c529005e1e7cd9a349a7168a35569ba5dea818968d5a91466bd6e64e20bf62417198afc4e81c28dd77ed4028232398b52fbde86bc84f475b9016710ce2aabc11a06b4dbac901ec16cf365ca3f2d53813948a693a0f93e79c46ca5d5a6dca3d28ca50ad18bd13fca55059dd9b185f79f9c47196a4e81b2104bc460a051e02f2e8444f",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1-pqc"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "ACCEPT"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "yzWTRo2drtwsfSdx0RkabNQsRMXFR/KaJPA6lN95CcKbRuNVUN4QEmb/k/A3MGDn7IcSptJJv28KNHaMoL9wBw=="
+      },
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1-pqc",
+        "algorithm": "ML-DSA-65",
+        "value": "dKmrzf4H9tQfiRpzsa7fYef0vbkEUs5eYTc/y5iVlaUU5YHl4/ADb0oO0DxPsx8ZZGjSbnC2Bv2gJR4vG5/H8GhUOqQTi9+o2t5e9RUgDEiON5C/e82LRAjDAJ5RjPXYRq3hB6v2Qf0+huNAKaypD1vNChc2juYpOl0zuwo5A5DUfLwmJ2E6REj9CozFyNhYoNVBvd4kKtt/53OICdBxYRDwHuA6AgJd2wF3adfN9Z4kaYnQ3EHdtm/fPcuqMbBd0Zj/rOiUsqHe7g5B5W4PCWCS4oECmAKBIghhmBBKGed5SGcKv6Btvnsh6t3A/uAxW4ctMNzyRa35Ptr4eaUIQ4DlaqKTHT6ErBxh4J4pmZw8/QREeHg6bMaJn+SeJHPLNnsDHbrtLIZXCw7kvcgBMfLRN+2DBCy3Cdh71ZaD3E/4lsI80TU6PyJ33Fxh1cDsphNg3OEBKY3pXXh58ZMlaHTPk9GxjLZxhaC3d0QYDAYUyL0PQ9HFYIVb07w4OfuweVcfkIBmzGK9Qo7yLWj7DAj1lvpkxboiAOjS5/jQI8aPWJPiIdLHFo/kYlyHZtENmucVE2Ew0HGAP4ZfVp8DnKdscBADlrdUJEoZNLoxX0se/z8DqVdVJjXV+M9ud6ns6H6V7wNZ85nwwf8+9ebRM5+ZsbCfRQHQiCLyr4kzZ8sFhKksEOT3dfWmKviJlUjEK7Er22hEfpYJo89FbNWIN/GZI//wyEnUkx4QogvewiWpXiNSwR39fbBRVvz3WjP7Bkkr9OO+Fq7cVDKHj3WTgzS3X+Dxr8m1klIhaueLVeoMKkYAsvsoPqL/T13+/W8GvYrhEPdkoGunxoh0AuhAfIS5wW6SdAxs6h4tRTko8Vq+LdUlm28ymCxN8VquBUA7nDUzv9fGnlQdBbN7Bj40vFwNtRbCLH0eJY8I4MtcrlWIKg4GT0fjjc3sjc1McjB+aneSl2JQfQhiBvEkuWQjJBuNAiDdpX3NMxDJ0s05WtNFJKIfvCPahYSaUyWwKIi/89ce1apyC8wvyrKLuIbGgNA96WgG85T/jh6Jy9iWjd2NdILYM9Blj8TV7lBhrpCf7vE9CCq8aubfWGxjRsdxM7TZWchEE2VCMPgg1TTdwVWHTSFScMpmVGFVwGuHDXstxUNZ8/PfMXSPugN4mjOC6Zm4W/zTuXk53Gy0U2E0VX1epT/Xbeb/f91V6sTdCavRb4QEiShP/UrW46/8RntjANei96ncC1odA8IGRlLU+MUXtFc2ZtFoU/7B9n9oquMEzRysbDbP0ZtEiqQGrgvGp4L/kqff0S7HrOQgkQBpKLowRWDaoB0+V1N0/jgxKFTRB7tzoR6MQKM0BDoLSb0eEvdoLNprfmh2AtZTgPc6ogBuVU0dj2phwcKhaGr1wc1o9k322fOj+55g5Y0/Oqp8HaGMpVpeSIMf8ttpGvrUnkwOECIloWdemU3D3S1/iqCyzStUmv1TquXv03qKLsb5QZQ9CX6lYDVWabagGs7/BF0z3wzUd1E0vTFzOsbHhwDfLFb02A4GWTufyiD9qTCR8bo23KVhtcDZqvW4sLYIj8yVp/adAU8Twnv1O1KM7T6vvw9rrSbd3RvjoagLlOTWoxD3ts27L1uG235YNte+8FGcoCrfTfr9udDfB3fc9HKChg1iqbMKkSH5X2UBzt8d3ZQHVlFHNpYXrH//jly7Vad8cXg0yj9zgcEELgvyIarI/THAOAibACNjfPe4kOJtXiVIuRLxfPyYkA1nyYX1hELfwRqSAoVCBDHocsilSp303qAI1ajDwarVRGvHyUnJ95SjP4uc/++nPLAe+5nF6tiuMaT4aKZQ8ZpnZbBu3huQBn2JqTAOfoU+5EsV0TCHJnpZYHEhVsxuVxZ0dxnNaf7P6QBeRBiNN0ySZznx2lUb6gve4tP0t0hlixgEJGWRb6PAE5gh2L8T7ymQIRZfZ5SaLhBW6NJEyzJ6hMeuEuHvX8eb1ZXatfry56y2UGOx+Z2WyOXQnCNQVG199F6RbJUuEEdUHJakVYePUXtJo1qgFOF66Bh12QKefvQn2Tpv62DqZrdCAo5AnBSCea0AnkpnP7sxi2iu3Nq8LKttY0zLUIWb2Snr9gCZwZ7ggz/aLLYww5EU61MCo/41A7gixdj6Y78pL3M8exEHwRauEo9F49xLrZNoWo+a5HfN6VEqW682osFDOBSvfk48ay8KoPYyaHCSazUgam/CfSiJ0GcjR4La8ILau8YWA+ahkFr2EgDSU+7tFVugYLw8/McELqRNhu7eyhwdQ9F9l69wROxHFTpLe44JzVBA5gpcFTU9DnNXEC2ao5k+w1Q2uWvl0SW5eNNxJQGxKHfOB6l9qFGHXJuuqy4KO1eyNGCecCqLAlBU+xlsBo5eqqy0iUIlMt2MB0AwFS/y+FHYtHIQsfLR3mp9gEz0jJDNhlmxtScYpIGINNNlVdyvbIycOy30QYdsrtd3bROVVCacWhfYWEslA5W7zTDXwKmsb2ll8uVmSSv0CIbcpRNWwRPTP1oAhHF/rOIVw/x3z1rh2BSzw0KBJn81q8uBJIrS1oXa0cs3T6yquZVKRDCm+5r2n8bahcz+CkWY5BJlEcHpKXPWDZLmR59jIs0xZYXqTwgM2TWxxpY9ffNkOQ2rFqX6G8uaL9GkM987kKmJ8X0DrSX+x2U3ZLKL4ey2xSvvdEBWFEsIHI9IkbQMKfGrDq0v0RQRzLS/GPMCjIvLm6NuUKBkyt5FP6i6PyT5HWTsddTc44fKcNCyT5SCp+rDgpe5nrm4Dnra3EIev+7u4l4NQ7MNHE8X9styIvmPPdjmG5sVHXahlin/siij++Gri0dw1nODX0hWeKS2yjn+rn9CaH7dnR5t0jMV/l2M6w0yGuXjp+q2bCGJfnmq6DJ2SgUwEFszI6RU0Irg12CX1uioeJ/S1+RkAn8I4K8Eh8TMuLdnY9qycmnPe0tUlzMCZ4HYia7NGVT6zPRtP8RwyWjWfAYaj6I/ljxnBFrdGhIi58AqOFl7ewLrnbPas/0IIPK2gupoAY9/f3NTQfMj13r4bLLgSwI1SsY8FnxA+6GjNW5VGdeb/oAjXDvkeG5yT0MLeT/OfcwlO7+1K9mKA50DN2iVLgbOgPW3PT8xAuVz4W3Ku+qcISkzulZ0R5UE6RbLCPSzzLPSmyloPnFRifcjFgy8UMrLn4vr3eJRTOCvPCu+pzrl/+lWxZnYLQ5PXENSQv2LlnryKAG1eL2+D/JvYJwUZ680dHCZGSbxxoAfdFwPxIOVvoBPLk4MlmwPaXfysfU8X39INGuKxvVyWKrdQNps909fBVLveQi152rHkOBYqFQKqLb2XvlKDiMQzUsWB32T2CLCbapT5DnomuVCPGPGkU/Ohay13v99BJgWengrpX7573cnUAvdGRD+7LK6NNQc0SurxMYj55SwsfjOC4cbZd62PYFK/iPJZYzDvcc+4UI0uPUMZTRaGTYLelRnvvtCijWqnd4dbUjGqe32LPlKV6CFHnLMbvz3VIfDIEWJyn2hS7L9FCCqBXMguGO2qLMTo0wRYo2VBPnu+DotyUDUMlbZelunF38nI3LJ13sYhL3NtrI1qnsbA91nH71gslZp5/lV+5+l7zrxcyzQxmpWZ1Eelg+w1ssmT6zIXbOOpCibp1GxAOF6Dx23YfDVdY35C/g6939T9zcjVrKBN9MDGRo7gngQbd+IT37O1aBa6Z+fH9/zFaPgAGjVXIQQb8uDwy8hDai2tst6KCcRLVZMPQSD4h/krw6iCgUUx5jk6MfJp1zoH73/OTZKixYEAW62y6E1g/yvdvxRoA5CxJTbJiySdZPEnQVL9L8gh8Sjp3HsjEy5vSb+0HiOdVniOlfPU5b05lJMEFy5taMgXKll5MZGliNawA031w8+1R4L2WUjeNrlzdQWc+Gez4Eh4TqnXbPrid5tsymbievRogXfw+SY5szjbqIvmhfSMh7tH+mzILrQ7gWboZrUt6usFI2XxtzDiueMqcTA+cR5GS3kwuY/qIW7lsdhEHULCEZTTgorX1WMRkY6N7Cv0dsvf7uuYEKflOcxQdZSaZO+6pMYRw5dynJAhsDG7uxv8/FKaGQAxttD49vN7trgsDNR1wNkwljV9hz6HcobiQJKO4EfYiQoAcGQlZxBTSjxyM7QIjUN2gcUVmlrB7MeHqr7eWLdqMSSwX0Jgjdkt4mb78SyaF1kRxJF+ICwUP3Igi1kuslQVX0tfOgGOFed0GXnO0BqHn5YG/7PmTY7Iu0qTtr8QXYbT8f7zsrsHlICmhhFzpjT1OcwfyzKvxckrjutFQwIFF8BP1ujvc3g7fUYGmmEvO2FrLXu9v8CKUxfcpPxISIlQk1tqOIJMLb7AAAAAAAAAAAAAAAAAAAACQ8VHCQo"
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/v1_1-baseline-valid.json
+++ b/packages/atx-verify/src/__fixtures__/v1_1-baseline-valid.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/baseline-valid",
+  "description": "A baseline ATX v1.1 credential. The single Ed25519 signature covers JCS(TBS) per atx-spec core.md §1.3a.2, so capabilities, scanSummary, issuerChain, publisher, and behavioralProfile are integrity-protected. Verifier MUST ACCEPT. The canonical bytes equal the jcs-vectors baseline vector.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "ACCEPT"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "yzWTRo2drtwsfSdx0RkabNQsRMXFR/KaJPA6lN95CcKbRuNVUN4QEmb/k/A3MGDn7IcSptJJv28KNHaMoL9wBw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/v1_1-case-variant-member.json
+++ b/packages/atx-verify/src/__fixtures__/v1_1-case-variant-member.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/case-variant-member",
+  "description": "An ATX v1.1 credential carrying a decoy top-level TRUSTLEVEL member (value 9) injected before the signed trustLevel member (value 4) — two names that fold to the same field. Go's encoding/json resolves struct fields case-insensitively last-wins, so it collapses the pair to the signed trustLevel=4: a lenient Go verifier ACCEPTs, silently carrying a stray fold-colliding TRUSTLEVEL member. The same bytes read differently under other conforming parsers: a case-insensitive first-wins parser reads 9, and a case-sensitive parser (this suite's Python json.loads) keeps both as distinct members, reading trustLevel=4 alongside a separate TRUSTLEVEL=9. A case-SENSITIVE duplicate check flags neither. Because encoding/json's field folding makes the credential mean different things to different conforming parsers — the RFC 8259 §4 first-wins/last-wins parser divergence the strict parse exists to close — verifiers MUST fold member names and REJECT fold-colliding members with PARSE_ERROR before interpreting any field. Reference: foldKey in verifiers/go and verifiers/python (atx-conformance#16).",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "PARSE_ERROR",
+    "reasonContains": "duplicate"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "TRUSTLEVEL": 9,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "yzWTRo2drtwsfSdx0RkabNQsRMXFR/KaJPA6lN95CcKbRuNVUN4QEmb/k/A3MGDn7IcSptJJv28KNHaMoL9wBw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/v1_1-cross-issuer-key.json
+++ b/packages/atx-verify/src/__fixtures__/v1_1-cross-issuer-key.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/cross-issuer-key",
+  "description": "An ATX v1.1 credential issued by the primary authority but signed by a different trusted authority's key (partner.example). The secondary authority is trusted and its key is configured, and the signature is valid over JCS(TBS), but the secondary is neither the issuer nor present in the signed issuerChain. A spec-conformant verifier binds each signature to a key controlled by the issuer (or a signed issuerChain authority) and MUST REJECT with a signature-validation reason.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    },
+    {
+      "role": "issuer-secondary",
+      "path": "vectors/issuer-secondary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "2043fa51c3d9e4a21a535ccb38bdc4fb56083737d22059d69475e7e43c47f582",
+      "keyId": "did:opena2a:authority:partner.example#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:partner.example"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      },
+      {
+        "role": "issuer-secondary",
+        "path": "vectors/issuer-secondary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "2043fa51c3d9e4a21a535ccb38bdc4fb56083737d22059d69475e7e43c47f582",
+        "keyId": "did:opena2a:authority:partner.example#key-1"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "SIGNATURE_INVALID",
+    "reasonContains": "signature"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:partner.example#key-1",
+        "algorithm": "Ed25519",
+        "value": "VIoRLMLXWSQJosyTSMpnORfH1oMv9pfWYoehAwyASHRJ03cL7MuErJ/0vu7jziGur8meBaleSNP3D3ETLTXmBw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/v1_1-declared-purpose-array-injected.json
+++ b/packages/atx-verify/src/__fixtures__/v1_1-declared-purpose-array-injected.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/declared-purpose-array-injected",
+  "description": "An ATX v1.1 credential signed with no declaredPurpose, carrying an attacker-appended ARRAY declaredPurpose value. Non-object values are included in the TBS verbatim (atx-spec §1.3a.2 rule 5), so the recomputed canonical bytes no longer match the signature and the verifier MUST REJECT with a signature-validation reason. A verifier that normalizes non-object values away would accept unsigned purpose content riding a valid signature.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "SIGNATURE_INVALID",
+    "reasonContains": "signature"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "declaredPurpose": [
+      "billing:inquiry",
+      "act-autonomously"
+    ],
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "yzWTRo2drtwsfSdx0RkabNQsRMXFR/KaJPA6lN95CcKbRuNVUN4QEmb/k/A3MGDn7IcSptJJv28KNHaMoL9wBw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/v1_1-declared-purpose-empty-whitespace.json
+++ b/packages/atx-verify/src/__fixtures__/v1_1-declared-purpose-empty-whitespace.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/declared-purpose-empty-whitespace",
+  "description": "An ATX v1.1 credential signed with no declaredPurpose, carrying a whitespace-empty declaredPurpose object ({ }) appended after signing. Emptiness is a JSON-parse-level property (atx-spec §1.3a.2 rule 5): any serialization of the empty object is the empty object, treated as absent and omitted from the TBS, so the signature still verifies. Verifier MUST ACCEPT. A verifier that compares the raw byte string against \"{}\" instead of parsing wrongly includes the value and REJECTs.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "ACCEPT"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "declaredPurpose": { },
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "yzWTRo2drtwsfSdx0RkabNQsRMXFR/KaJPA6lN95CcKbRuNVUN4QEmb/k/A3MGDn7IcSptJJv28KNHaMoL9wBw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/v1_1-declared-purpose-string-injected.json
+++ b/packages/atx-verify/src/__fixtures__/v1_1-declared-purpose-string-injected.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/declared-purpose-string-injected",
+  "description": "An ATX v1.1 credential signed with no declaredPurpose, carrying an attacker-appended STRING declaredPurpose value. Non-object values are included in the TBS verbatim (atx-spec §1.3a.2 rule 5), so the recomputed canonical bytes no longer match the signature and the verifier MUST REJECT with a signature-validation reason.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "SIGNATURE_INVALID",
+    "reasonContains": "signature"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "declaredPurpose": "customer-support",
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "yzWTRo2drtwsfSdx0RkabNQsRMXFR/KaJPA6lN95CcKbRuNVUN4QEmb/k/A3MGDn7IcSptJJv28KNHaMoL9wBw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/v1_1-declared-purpose-valid.json
+++ b/packages/atx-verify/src/__fixtures__/v1_1-declared-purpose-valid.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/declared-purpose-valid",
+  "description": "A baseline ATX v1.1 credential carrying a populated declaredPurpose (atx-spec §1.5): vocabVersion, statement, category, taskScopes, capabilityJustification, autonomy, dataScopes, egressScopes. declaredPurpose is the one presence-based TBS member (§1.3a.2 rule 5); when present it is signed as part of JCS(TBS). Verifier MUST ACCEPT. Canonical bytes equal the jcs-vectors 08-declared-purpose vector.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "ACCEPT"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "declaredPurpose": {
+      "vocabVersion": "1",
+      "statement": "Processes customer billing inquiries and issues refunds up to a supervisor-set limit. 北京",
+      "category": "financial-operations",
+      "taskScopes": [
+        "billing:inquiry",
+        "billing:refund"
+      ],
+      "capabilityJustification": {
+        "read:public": [
+          "billing:inquiry"
+        ],
+        "write:owned": [
+          "billing:refund"
+        ]
+      },
+      "autonomy": "supervised",
+      "dataScopes": [
+        "customer.billing",
+        "customer.contact"
+      ],
+      "egressScopes": [
+        "api.stripe.com",
+        "hooks.internal.acme.com"
+      ]
+    },
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "sfxSAtxm3TwrzodrXyjph5dEBGePWAot8lz96WdlCrCDYGlHvuAYhgWF/GCzwsFDxjWXUFYTUX0DN+0ofCvRAw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/v1_1-duplicate-purpose-member.json
+++ b/packages/atx-verify/src/__fixtures__/v1_1-duplicate-purpose-member.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/duplicate-purpose-member",
+  "description": "An ATX v1.1 credential whose declaredPurpose bytes contain the category member twice: a decoy (customer-support) followed by the signed value (financial-operations). The Ed25519 signature is REAL and covers the last-wins interpretation, so a lenient last-wins parser sees a verifying credential while a first-wins parser sees different content — the classic RFC 8259 §4 duplicate-member smuggling split. Because the entire ATX credential feeds the signed canonical form (JCS(TBS), §1.3a.2), verifiers MUST strict-parse the credential object and REJECT duplicate members at any depth with PARSE_ERROR, before interpreting any field. A verifier that parses last-wins without a duplicate check wrongly ACCEPTs; a first-wins verifier rejects with the wrong category (SIGNATURE_INVALID).",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "PARSE_ERROR",
+    "reasonContains": "duplicate"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "declaredPurpose": {
+      "vocabVersion": "1",
+      "statement": "Processes customer billing inquiries and issues refunds up to a supervisor-set limit. 北京",
+      "category": "customer-support",
+      "category": "financial-operations",
+      "taskScopes": [
+        "billing:inquiry",
+        "billing:refund"
+      ],
+      "capabilityJustification": {
+        "read:public": [
+          "billing:inquiry"
+        ],
+        "write:owned": [
+          "billing:refund"
+        ]
+      },
+      "autonomy": "supervised",
+      "dataScopes": [
+        "customer.billing",
+        "customer.contact"
+      ],
+      "egressScopes": [
+        "api.stripe.com",
+        "hooks.internal.acme.com"
+      ]
+    },
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "sfxSAtxm3TwrzodrXyjph5dEBGePWAot8lz96WdlCrCDYGlHvuAYhgWF/GCzwsFDxjWXUFYTUX0DN+0ofCvRAw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/v1_1-tampered-capabilities.json
+++ b/packages/atx-verify/src/__fixtures__/v1_1-tampered-capabilities.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/tampered-capabilities",
+  "description": "An ATX v1.1 credential whose capabilities were escalated to include admin:all AFTER signing. Because v1.1 signs JCS(TBS), capabilities are covered by the signature; the verifier recomputes the canonical bytes, finds they no longer match, and MUST REJECT with a signature-validation reason. This is the integrity property v1.0 lacked.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "SIGNATURE_INVALID",
+    "reasonContains": "signature"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned",
+      "admin:all"
+    ],
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "yzWTRo2drtwsfSdx0RkabNQsRMXFR/KaJPA6lN95CcKbRuNVUN4QEmb/k/A3MGDn7IcSptJJv28KNHaMoL9wBw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/__fixtures__/v1_1-tampered-declared-purpose.json
+++ b/packages/atx-verify/src/__fixtures__/v1_1-tampered-declared-purpose.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/tampered-declared-purpose",
+  "description": "An ATX v1.1 credential whose declaredPurpose.category was rewritten from financial-operations to agent-orchestration AFTER signing. Because v1.1 signs JCS(TBS) and declaredPurpose is part of it, the verifier recomputes the canonical bytes, finds they no longer match the signature, and MUST REJECT. This is the integrity property that makes a declared purpose binding and non-repudiable (§1.5).",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "SIGNATURE_INVALID",
+    "reasonContains": "signature"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "declaredPurpose": {
+      "vocabVersion": "1",
+      "statement": "Processes customer billing inquiries and issues refunds up to a supervisor-set limit. 北京",
+      "category": "agent-orchestration",
+      "taskScopes": [
+        "billing:inquiry",
+        "billing:refund"
+      ],
+      "capabilityJustification": {
+        "read:public": [
+          "billing:inquiry"
+        ],
+        "write:owned": [
+          "billing:refund"
+        ]
+      },
+      "autonomy": "supervised",
+      "dataScopes": [
+        "customer.billing",
+        "customer.contact"
+      ],
+      "egressScopes": [
+        "api.stripe.com",
+        "hooks.internal.acme.com"
+      ]
+    },
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "sfxSAtxm3TwrzodrXyjph5dEBGePWAot8lz96WdlCrCDYGlHvuAYhgWF/GCzwsFDxjWXUFYTUX0DN+0ofCvRAw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/packages/atx-verify/src/atx.ts
+++ b/packages/atx-verify/src/atx.ts
@@ -202,10 +202,19 @@ export class LocalAtxVerifier implements AtxVerifier {
     if (credentialJson === null || credentialJson === undefined) {
       return reject('MALFORMED', 'credential is null');
     }
+    // Out-of-contract argument types stay MALFORMED rejections, never escaping
+    // throws — including a Proxy whose getPrototypeOf trap throws inside the
+    // instanceof check.
+    let isBytes = false;
+    try {
+      isBytes = credentialJson instanceof Uint8Array;
+    } catch {
+      return reject('MALFORMED', 'credential must be a string or Uint8Array');
+    }
     let text: string;
     if (typeof credentialJson === 'string') {
       text = credentialJson;
-    } else if (credentialJson instanceof Uint8Array) {
+    } else if (isBytes) {
       try {
         text = new TextDecoder('utf-8', { fatal: true }).decode(credentialJson);
       } catch {

--- a/packages/atx-verify/src/atx.ts
+++ b/packages/atx-verify/src/atx.ts
@@ -24,8 +24,16 @@
  *    can edit those without invalidating the signature, so they MUST NOT be
  *    trusted for authorization.
  *  - v1.1 (canonicalPayloadV11): the signature covers JCS(TBS), which includes
- *    `capabilities`, `scanSummary`, `issuerChain`, and `publisher`. Those fields
- *    are integrity-protected and safe to authorize on.
+ *    `capabilities`, `scanSummary`, `issuerChain`, `publisher`, and (when
+ *    present) `declaredPurpose`. Those fields are integrity-protected and safe
+ *    to authorize on.
+ *
+ * SECURITY — parse before trust: `verify(atx)` takes an already-parsed object,
+ * and `JSON.parse` is last-wins on duplicate members, so a duplicate-member
+ * smuggle is collapsed before that overload can see it. Wire consumers holding
+ * credential text/bytes should call {@link LocalAtxVerifier.verifyCredential},
+ * which strict-parses first (fold-aware duplicate rejection at any depth, see
+ * `strict-parse.ts`) and then delegates.
  *
  * The verified context exposes `signedCapabilities` (true iff v1.1) so callers
  * can tell the two apart and gate capability-based authorization accordingly.
@@ -33,6 +41,7 @@
 
 import * as crypto from 'node:crypto';
 import { createRequire } from 'node:module';
+import { firstDuplicateMember } from './strict-parse.js';
 
 // `canonicalize` (RFC 8785) is a CommonJS module whose .d.ts declares an ESM
 // default export; under Node16 ESM resolution that default is not callable at
@@ -81,6 +90,12 @@ export interface Atx {
   issuedAt: string;
   expiresAt: string;
   capabilities?: string[];
+  /**
+   * Declared purpose (atx-spec §1.5); absent/null when not declared. Kept
+   * untyped: the v1.1 TBS passes a present, non-empty value through verbatim
+   * for JCS to re-canonicalize (§1.3a.2 rule 5).
+   */
+  declaredPurpose?: unknown;
   /** Observed-behavior summary. Covered by the v1.1 signature. */
   behavioralProfile?: { checksum?: string; generatedAt?: string; observationDays?: number } | null;
   scanSummary?: { oasbLevel?: string; [k: string]: unknown };
@@ -169,6 +184,68 @@ export interface AtxVerifier {
  */
 export class LocalAtxVerifier implements AtxVerifier {
   constructor(private readonly anchors: AtxTrustAnchors) {}
+
+  /**
+   * Verifies a credential from its raw JSON text or bytes, applying the strict
+   * parse (reject a duplicate object member at any depth, folded — see
+   * `strict-parse.ts`) before interpreting any field, then delegating to
+   * {@link verify}. This is the entry point wire consumers should use: the
+   * object-taking {@link verify} cannot see duplicate members `JSON.parse`'s
+   * last-wins semantics have already collapsed. A duplicate or otherwise
+   * unparseable credential rejects as MALFORMED (the SDK's structural-parse
+   * category; the reference verifiers call it PARSE_ERROR), with a reason
+   * naming the duplicate member. Degenerate inputs (JSON `null`, scalars, a
+   * top-level array, empty/invalid text, non-UTF-8 bytes) reject MALFORMED —
+   * this method never throws on bad input.
+   */
+  verifyCredential(credentialJson: string | Uint8Array): AtxVerificationResult {
+    if (credentialJson === null || credentialJson === undefined) {
+      return reject('MALFORMED', 'credential is null');
+    }
+    let text: string;
+    if (typeof credentialJson === 'string') {
+      text = credentialJson;
+    } else if (credentialJson instanceof Uint8Array) {
+      try {
+        text = new TextDecoder('utf-8', { fatal: true }).decode(credentialJson);
+      } catch {
+        return reject('MALFORMED', 'credential is not valid UTF-8');
+      }
+    } else {
+      return reject('MALFORMED', 'credential must be a string or Uint8Array');
+    }
+
+    let dup: string | null;
+    try {
+      dup = firstDuplicateMember(text);
+    } catch (err) {
+      return reject('MALFORMED', `credential is not valid ATX JSON: ${(err as Error).message}`);
+    }
+    if (dup !== null) {
+      return reject(
+        'MALFORMED',
+        `credential contains duplicate member "${dup}" (strict parse: the ATX credential is a ` +
+          'signed body; RFC 8259 §4 duplicate names are parser-divergent)',
+      );
+    }
+
+    // The scan above already vouches for well-formedness and bounds nesting,
+    // but stay defensive: catch everything (including a hypothetical engine
+    // RangeError on deep input) rather than let a throw escape.
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch (err) {
+      return reject('MALFORMED', `credential is not valid ATX JSON: ${(err as Error).message}`);
+    }
+    // A bare JSON `null`, scalar, or array is not a credential — reject rather
+    // than misread it as an Atx (the Java SDK's adversarial round caught an
+    // NPE-on-JSON-null here; this is the equivalent guard).
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return reject('MALFORMED', 'credential is not a JSON object');
+    }
+    return this.verify(parsed as Atx);
+  }
 
   verify(atx: Atx): AtxVerificationResult {
     const now = (this.anchors.now ?? (() => new Date()))();
@@ -332,7 +409,7 @@ export function canonicalPayload(atx: Atx): Buffer {
 /**
  * Project an ATX into the v1.1 TBS and return JCS(TBS) (RFC 8785). Unlike
  * canonicalPayload, this covers capabilities, scanSummary, issuerChain,
- * publisher, and behavioralProfile. The projection (canonical empties,
+ * publisher, declaredPurpose, and behavioralProfile. The projection (canonical empties,
  * always-full scanSummary, %.6f string trustScore, root-first issuerChain) and
  * the canonicalizer match opena2a-registry/pkg/atcverify and the conformance
  * verifiers exactly; byte agreement is pinned by atx-conformance/jcs-vectors.
@@ -350,6 +427,7 @@ export function canonicalPayloadV11(atx: Atx): Buffer {
     buildAttestation: atx.buildAttestation ?? '',
     capabilities: atx.capabilities ?? [],
     behavioralProfile: projectBehavioralProfile(atx.behavioralProfile),
+    ...declaredPurposeTbsMember(atx.declaredPurpose),
     scanSummary: {
       hma: asString(scan.hma),
       criticalFindings: asInt(scan.criticalFindings),
@@ -371,6 +449,26 @@ export function canonicalPayloadV11(atx: Atx): Buffer {
     throw new Error('canonicalize returned non-string');
   }
   return Buffer.from(canonical, 'utf-8');
+}
+
+/**
+ * Presence-based rule for the optional declaredPurpose member (atx-spec
+ * §1.3a.2 rule 5): an absent purpose — missing, JSON null, or an empty object
+ * (emptiness is a parse-level property, so `{ }` counts) — is OMITTED from the
+ * TBS, keeping a no-purpose credential byte-identical to one issued before the
+ * field existed. Any other present value (a populated object, or a non-object
+ * an attacker appends) passes through verbatim for JCS to re-canonicalize, so
+ * unsigned purpose content breaks the signature instead of riding it. Matches
+ * the Go/Python reference verifiers and the Java SDK's projectDeclaredPurpose.
+ */
+function declaredPurposeTbsMember(dp: unknown): { declaredPurpose?: unknown } {
+  if (dp === null || dp === undefined) {
+    return {};
+  }
+  if (typeof dp === 'object' && !Array.isArray(dp) && Object.keys(dp).length === 0) {
+    return {};
+  }
+  return { declaredPurpose: dp };
 }
 
 /** behavioralProfile -> null when absent, else the canonical three-field object. */

--- a/packages/atx-verify/src/atx.ts
+++ b/packages/atx-verify/src/atx.ts
@@ -216,7 +216,11 @@ export class LocalAtxVerifier implements AtxVerifier {
       text = credentialJson;
     } else if (isBytes) {
       try {
-        text = new TextDecoder('utf-8', { fatal: true }).decode(credentialJson);
+        // ignoreBOM keeps a leading U+FEFF in the decoded text so the strict
+        // parse rejects it — same verdict as the string entry form and the
+        // Go/Python reference verifiers. The default would silently strip it,
+        // giving identical wire bytes two different verdicts by entry form.
+        text = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(credentialJson);
       } catch {
         return reject('MALFORMED', 'credential is not valid UTF-8');
       }

--- a/packages/atx-verify/src/conformance.test.ts
+++ b/packages/atx-verify/src/conformance.test.ts
@@ -93,6 +93,12 @@ describe('conformance fixtures (atx-conformance @ f4d40a4, pinned signatures)', 
         if (f.expected.rejectCategory) {
           expect(result.rejectCategory).toBe(expectedCategory(f.expected.rejectCategory));
         }
+        // For the strict-parse fixtures, pin that the rejection is BECAUSE of
+        // the duplicate member — not an incidental MALFORMED — so the gate
+        // stays structurally non-vacuous.
+        if (f.expected.rejectCategory === 'PARSE_ERROR') {
+          expect(result.reason).toContain('duplicate');
+        }
       }
     });
   }

--- a/packages/atx-verify/src/conformance.test.ts
+++ b/packages/atx-verify/src/conformance.test.ts
@@ -1,23 +1,36 @@
 /**
- * Conformance gate: run LocalAtxVerifier against the OpenA2A ATX conformance
- * fixtures (verbatim copies from `atx-conformance/fixtures/`, including their
- * PINNED Ed25519 signatures and issuer public keys). This proves the verifier
- * accepts/rejects exactly the credentials the cross-language suite does — the
- * same fixtures the Go and Python reference verifiers are gated against.
+ * Conformance gate: run LocalAtxVerifier against the FULL OpenA2A ATX
+ * conformance suite (verbatim copies from `atx-conformance/fixtures/` pinned at
+ * f4d40a4, including their PINNED Ed25519 signatures and issuer public keys —
+ * CI byte-compares the vendored copies against the pinned suite). This proves
+ * the verifier accepts/rejects exactly the credentials the Go and Python
+ * reference verifiers do.
+ *
+ * Every fixture is replayed through the RAW entry point (`verifyCredential`)
+ * so the strict parse — duplicate / fold-colliding members at any depth — runs
+ * before any field is interpreted: the object-taking `verify(atx)` cannot see
+ * members `JSON.parse`'s last-wins semantics have already collapsed. The
+ * credential bytes are extracted from each fixture by tokenizer offsets
+ * (`topLevelMemberSpan`), duplicates preserved; the fixture wrapper itself is
+ * harness metadata and parses leniently.
  *
  * We assert the machine contract (verifyResult + rejectCategory). We do NOT
  * assert the fixtures' `reasonContains` — that is the reference verifiers'
- * specific human wording; this verifier's reason strings are its own and the
- * structured rejectCategory is the interoperable contract.
+ * specific human wording. Where the reference verifiers report PARSE_ERROR
+ * (strict-parse rejections), this SDK reports MALFORMED — the SDK
+ * RejectCategory union (shared with the AIM Java SDK) has no PARSE_ERROR, and
+ * MALFORMED is its structural-parse category — so those fixtures map to
+ * MALFORMED here.
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import {
   LocalAtxVerifier,
-  type Atx,
   type AtxPublicKey,
   type AtxTrustAnchors,
+  type RejectCategory,
 } from './atx.js';
+import { topLevelMemberSpan } from './strict-parse.js';
 
 interface Fixture {
   name: string;
@@ -28,23 +41,15 @@ interface Fixture {
     crl?: { entries: Array<{ agentId: string; reason?: string }> };
   };
   expected: { verifyResult: 'ACCEPT' | 'REJECT'; rejectCategory?: string };
-  atx: Atx;
 }
 
-/** Representative v1.0 fixtures lifted from atx-conformance/fixtures/. */
-const FIXTURE_FILES = [
-  'baseline-valid.json',
-  'tampered-signature.json',
-  'expired.json',
-  'revoked.json',
-  'wrong-issuer.json',
-  'cross-issuer-key.json',
-] as const;
+/** The suite pinned at atx-conformance f4d40a4 has exactly 20 fixtures. */
+const PINNED_SUITE_SIZE = 20;
 
-function loadFixture(file: string): Fixture {
-  const url = new URL(`./__fixtures__/${file}`, import.meta.url);
-  return JSON.parse(readFileSync(url, 'utf-8')) as Fixture;
-}
+const FIXTURES_DIR = new URL('./__fixtures__/', import.meta.url);
+const fixtureFiles = readdirSync(FIXTURES_DIR)
+  .filter((f) => f.endsWith('.json'))
+  .sort();
 
 function anchorsFromFixture(f: Fixture): AtxTrustAnchors {
   const clock = new Date(f.verifierState.clockRfc3339);
@@ -58,14 +63,36 @@ function anchorsFromFixture(f: Fixture): AtxTrustAnchors {
   };
 }
 
-describe('conformance fixtures (atx-conformance/fixtures, pinned signatures)', () => {
-  for (const file of FIXTURE_FILES) {
-    const f = loadFixture(file);
+/** The reference suite's PARSE_ERROR is this SDK's MALFORMED (see header). */
+function expectedCategory(suiteCategory: string): RejectCategory {
+  return (suiteCategory === 'PARSE_ERROR' ? 'MALFORMED' : suiteCategory) as RejectCategory;
+}
+
+describe('conformance fixtures (atx-conformance @ f4d40a4, pinned signatures)', () => {
+  it(`covers the full pinned suite (${PINNED_SUITE_SIZE} fixtures)`, () => {
+    expect(fixtureFiles.length).toBe(PINNED_SUITE_SIZE);
+  });
+
+  for (const file of fixtureFiles) {
+    const rawText = readFileSync(new URL(file, FIXTURES_DIR), 'utf-8');
+    // Wrapper parse is lenient (harness metadata); the credential bytes are
+    // sliced raw below so strict-parse fixtures keep their duplicate members.
+    const f = JSON.parse(rawText) as Fixture;
+    const span = topLevelMemberSpan(rawText, 'atx');
+    if (span === null) {
+      throw new Error(`fixture ${file} has no top-level atx member`);
+    }
+    const rawAtx = rawText.slice(span.start, span.end);
+
     it(`${f.name} -> ${f.expected.verifyResult}${f.expected.rejectCategory ? ` (${f.expected.rejectCategory})` : ''}`, () => {
-      const result = new LocalAtxVerifier(anchorsFromFixture(f)).verify(f.atx);
-      expect(result.valid).toBe(f.expected.verifyResult === 'ACCEPT');
-      if (f.expected.verifyResult === 'REJECT' && f.expected.rejectCategory) {
-        expect(result.rejectCategory).toBe(f.expected.rejectCategory);
+      const result = new LocalAtxVerifier(anchorsFromFixture(f)).verifyCredential(rawAtx);
+      if (f.expected.verifyResult === 'ACCEPT') {
+        expect(result.valid, `expected ACCEPT, got: ${result.reason}`).toBe(true);
+      } else {
+        expect(result.valid, 'expected REJECT but verifier accepted').toBe(false);
+        if (f.expected.rejectCategory) {
+          expect(result.rejectCategory).toBe(expectedCategory(f.expected.rejectCategory));
+        }
       }
     });
   }

--- a/packages/atx-verify/src/index.ts
+++ b/packages/atx-verify/src/index.ts
@@ -20,3 +20,4 @@ export {
   type ResolutionContext,
   type RejectCategory,
 } from './atx.js';
+export { firstDuplicateMember, foldKey, StrictParseError, MAX_SCAN_DEPTH } from './strict-parse.js';

--- a/packages/atx-verify/src/strict-parse.test.ts
+++ b/packages/atx-verify/src/strict-parse.test.ts
@@ -99,7 +99,7 @@ describe('firstDuplicateMember', () => {
       '{"a":"\\u12g4"}',
       '{"a":"unterminated}',
       '{"a\u0001b":1}',
-      '﻿{}',
+      '\uFEFF{}',
     ]) {
       expect(() => firstDuplicateMember(bad), JSON.stringify(bad)).toThrow(StrictParseError);
     }
@@ -204,7 +204,7 @@ describe('LocalAtxVerifier.verifyCredential', () => {
     const r = verifier.verifyCredential(bomJson);
     expect(r.valid).toBe(false);
     expect(r.rejectCategory).toBe('MALFORMED');
-    expect(verifier.verifyCredential('﻿{}')).toEqual(r);
+    expect(verifier.verifyCredential('\uFEFF{}')).toEqual(r);
   });
 
   it('accepts Uint8Array input equivalently to string input', () => {

--- a/packages/atx-verify/src/strict-parse.test.ts
+++ b/packages/atx-verify/src/strict-parse.test.ts
@@ -196,6 +196,17 @@ describe('LocalAtxVerifier.verifyCredential', () => {
     expect(r.rejectCategory).toBe('MALFORMED');
   });
 
+  it('rejects BOM-prefixed bytes as MALFORMED, matching the string entry form', () => {
+    // Adversarial round 2: the default TextDecoder strips a leading BOM, which
+    // gave identical wire bytes two different verdicts by entry form (and
+    // diverged from the Go/Python reference verifiers, which reject a BOM).
+    const bomJson = new Uint8Array([0xef, 0xbb, 0xbf, 0x7b, 0x7d]); // BOM + "{}"
+    const r = verifier.verifyCredential(bomJson);
+    expect(r.valid).toBe(false);
+    expect(r.rejectCategory).toBe('MALFORMED');
+    expect(verifier.verifyCredential('﻿{}')).toEqual(r);
+  });
+
   it('accepts Uint8Array input equivalently to string input', () => {
     const json = '{"atcVersion":"0.9"}';
     const fromString = verifier.verifyCredential(json);

--- a/packages/atx-verify/src/strict-parse.test.ts
+++ b/packages/atx-verify/src/strict-parse.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import {
+  firstDuplicateMember,
+  foldKey,
+  topLevelMemberSpan,
+  StrictParseError,
+  MAX_SCAN_DEPTH,
+} from './strict-parse.js';
+import { LocalAtxVerifier, type AtxTrustAnchors } from './atx.js';
+
+const emptyAnchors: AtxTrustAnchors = { trustedIssuers: [], publicKeys: [] };
+
+describe('foldKey', () => {
+  it('lowercases ASCII', () => {
+    expect(foldKey('TrustLevel')).toBe('trustlevel');
+    expect(foldKey('TRUSTLEVEL')).toBe('trustlevel');
+    expect(foldKey('agent_id-9')).toBe('agent_id-9');
+  });
+
+  it('folds the two non-ASCII code points that land on ASCII', () => {
+    expect(foldKey('K')).toBe('k'); // Kelvin sign
+    expect(foldKey('ſ')).toBe('s'); // long s
+    expect(foldKey('taſk')).toBe(foldKey('task'));
+  });
+
+  it('uses the simple lowercase for U+0130 (matching Go/Java, not JS full mapping)', () => {
+    expect(foldKey('İ')).toBe('i');
+    expect('İ'.toLowerCase()).not.toBe('i'); // the divergence this guards
+  });
+
+  it('lowercases other non-ASCII 1:1 and passes non-letters through', () => {
+    expect(foldKey('Ä')).toBe('ä');
+    expect(foldKey('ΣΩ')).toBe('σω');
+    expect(foldKey('名前')).toBe('名前');
+  });
+});
+
+describe('firstDuplicateMember', () => {
+  it('returns null for clean credentials', () => {
+    expect(firstDuplicateMember('{"a":1,"b":{"a":2},"c":[{"a":3},{"a":4}]}')).toBeNull();
+    expect(firstDuplicateMember('{}')).toBeNull();
+    expect(firstDuplicateMember('  {"x":[1,2,{"y":"z"}]}  ')).toBeNull();
+    expect(firstDuplicateMember('"scalar"')).toBeNull();
+    expect(firstDuplicateMember('null')).toBeNull();
+  });
+
+  it('reports an exact duplicate at the top level', () => {
+    expect(firstDuplicateMember('{"trustLevel":4,"trustLevel":9}')).toBe('trustLevel');
+  });
+
+  it('reports a case-variant (fold-colliding) duplicate', () => {
+    expect(firstDuplicateMember('{"TRUSTLEVEL":9,"trustLevel":4}')).toBe('trustLevel');
+  });
+
+  it('reports Kelvin-sign and long-s fold collisions', () => {
+    expect(firstDuplicateMember('{"k":1,"K":2}')).toBe('K');
+    expect(firstDuplicateMember('{"task":1,"taſk":2}')).toBe('taſk');
+  });
+
+  it('reports duplicates at any depth', () => {
+    expect(firstDuplicateMember('{"a":{"b":{"c":1,"c":2}}}')).toBe('c');
+    expect(firstDuplicateMember('{"a":[{"x":1},{"y":1,"Y":2}]}')).toBe('Y');
+  });
+
+  it('decodes escapes in member names before folding (escape smuggle)', () => {
+    // "trustLevel" decodes to "trustLevel": JSON.parse collapses the
+    // pair, so the scan must collide it too.
+    expect(firstDuplicateMember('{"trustLevel":4,"trust\\u004Cevel":9}')).toBe('trustLevel');
+    expect(firstDuplicateMember('{"a\\u0062":1,"ab":2}')).toBe('ab');
+  });
+
+  it('treats escaped and case-variant names together', () => {
+    expect(firstDuplicateMember('{"aa":1,"a\\u0041":2}')).toBe('aA');
+  });
+
+  it('does not collide distinct names, including __proto__/constructor', () => {
+    expect(firstDuplicateMember('{"__proto__":1,"constructor":2,"toString":3}')).toBeNull();
+    expect(firstDuplicateMember('{"__proto__":1,"__proto__":2}')).toBe('__proto__');
+  });
+
+  it('same names in sibling objects are not duplicates', () => {
+    expect(firstDuplicateMember('[{"a":1},{"a":2}]')).toBeNull();
+  });
+
+  it('throws StrictParseError on malformed input', () => {
+    for (const bad of [
+      '',
+      '   ',
+      '{',
+      '[1,2',
+      '{"a":}',
+      '{"a"1}',
+      "{'a':1}",
+      '{"a":1,}',
+      '[1,]',
+      '{"a":1} {}',
+      '{"a":1}x',
+      '{"a":"\\q"}',
+      '{"a":"\\u12g4"}',
+      '{"a":"unterminated}',
+      '{"a\u0001b":1}',
+      '﻿{}',
+    ]) {
+      expect(() => firstDuplicateMember(bad), JSON.stringify(bad)).toThrow(StrictParseError);
+    }
+  });
+
+  it('accepts nesting up to MAX_SCAN_DEPTH open containers and rejects beyond', () => {
+    const nested = (n: number): string => '['.repeat(n) + ']'.repeat(n);
+    expect(firstDuplicateMember(nested(MAX_SCAN_DEPTH))).toBeNull();
+    expect(() => firstDuplicateMember(nested(MAX_SCAN_DEPTH + 1))).toThrow(StrictParseError);
+  });
+
+  it('scans a duplicate hidden at depth just inside the bound', () => {
+    // A scan that silently abandoned deep subtrees (Go-style abort without
+    // reject) would miss this duplicate while JSON.parse still collapses it.
+    const openers = '{"a":'.repeat(MAX_SCAN_DEPTH - 1);
+    const closers = '}'.repeat(MAX_SCAN_DEPTH - 1);
+    const deepDup = `${openers}{"x":1,"X":2}${closers}`;
+    expect(firstDuplicateMember(deepDup)).toBe('X');
+  });
+});
+
+describe('topLevelMemberSpan', () => {
+  it('returns the raw span of a top-level member value, duplicates preserved', () => {
+    const text = '{"name":"f","atx":{"a":1,"A":2},"expected":{}}';
+    const span = topLevelMemberSpan(text, 'atx');
+    expect(span).not.toBeNull();
+    expect(text.slice(span!.start, span!.end)).toBe('{"a":1,"A":2}');
+  });
+
+  it('captures scalar, string, and array member values', () => {
+    const text = '{"s":"x{y","n":-1.5e3,"arr":[{"k":[1]},2]}';
+    expect(text.slice(topLevelMemberSpan(text, 's')!.start, topLevelMemberSpan(text, 's')!.end)).toBe('"x{y"');
+    expect(text.slice(topLevelMemberSpan(text, 'n')!.start, topLevelMemberSpan(text, 'n')!.end)).toBe('-1.5e3');
+    expect(text.slice(topLevelMemberSpan(text, 'arr')!.start, topLevelMemberSpan(text, 'arr')!.end)).toBe(
+      '[{"k":[1]},2]',
+    );
+  });
+
+  it('is null for absent members and non-object roots', () => {
+    expect(topLevelMemberSpan('{"a":1}', 'atx')).toBeNull();
+    expect(topLevelMemberSpan('[1,2]', 'atx')).toBeNull();
+    // nested "atx" members do not count as top-level
+    expect(topLevelMemberSpan('{"wrap":{"atx":1}}', 'atx')).toBeNull();
+  });
+});
+
+describe('LocalAtxVerifier.verifyCredential', () => {
+  const verifier = new LocalAtxVerifier(emptyAnchors);
+
+  it('rejects a duplicate member as MALFORMED naming the member, before any field is read', () => {
+    const r = verifier.verifyCredential('{"atcVersion":"1.1","trustLevel":4,"TRUSTLEVEL":9}');
+    expect(r.valid).toBe(false);
+    expect(r.rejectCategory).toBe('MALFORMED');
+    expect(r.reason).toContain('TRUSTLEVEL');
+  });
+
+  it('rejects every degenerate credential as MALFORMED and never throws', () => {
+    // Ports the Java LocalAtxVerifierConformanceTest degenerate matrix (the
+    // Java adversarial round caught an NPE on the JSON literal `null`).
+    for (const bad of ['null', '5', '"x"', 'true', '[]', '', '   ', '[{"a":1}]']) {
+      const r = verifier.verifyCredential(bad);
+      expect(r.valid, JSON.stringify(bad)).toBe(false);
+      expect(r.rejectCategory, JSON.stringify(bad)).toBe('MALFORMED');
+    }
+  });
+
+  it('rejects null/undefined/non-string arguments as MALFORMED', () => {
+    for (const bad of [null, undefined, 42, {}, [], Symbol('x')]) {
+      const r = verifier.verifyCredential(bad as never);
+      expect(r.valid).toBe(false);
+      expect(r.rejectCategory).toBe('MALFORMED');
+    }
+  });
+
+  it('rejects invalid UTF-8 bytes as MALFORMED', () => {
+    const r = verifier.verifyCredential(new Uint8Array([0x7b, 0xff, 0xfe, 0x7d]));
+    expect(r.valid).toBe(false);
+    expect(r.rejectCategory).toBe('MALFORMED');
+  });
+
+  it('accepts Uint8Array input equivalently to string input', () => {
+    const json = '{"atcVersion":"0.9"}';
+    const fromString = verifier.verifyCredential(json);
+    const fromBytes = verifier.verifyCredential(new TextEncoder().encode(json));
+    expect(fromBytes).toEqual(fromString);
+    // and proves delegation reached verify(atx): version gate, not MALFORMED
+    expect(fromString.rejectCategory).toBe('UNSUPPORTED_VERSION');
+  });
+
+  it('rejects pathologically deep input cleanly (no RangeError escapes)', () => {
+    const deep = '['.repeat(300_000) + ']'.repeat(300_000);
+    const r = verifier.verifyCredential(deep);
+    expect(r.valid).toBe(false);
+    expect(r.rejectCategory).toBe('MALFORMED');
+  });
+});

--- a/packages/atx-verify/src/strict-parse.test.ts
+++ b/packages/atx-verify/src/strict-parse.test.ts
@@ -174,6 +174,22 @@ describe('LocalAtxVerifier.verifyCredential', () => {
     }
   });
 
+  it('rejects a Proxy with a throwing getPrototypeOf trap as MALFORMED (no escape)', () => {
+    // Adversarial round 1: `instanceof Uint8Array` invokes the trap; the throw
+    // must not escape verifyCredential.
+    const hostile = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error('boom');
+        },
+      },
+    );
+    const r = verifier.verifyCredential(hostile as never);
+    expect(r.valid).toBe(false);
+    expect(r.rejectCategory).toBe('MALFORMED');
+  });
+
   it('rejects invalid UTF-8 bytes as MALFORMED', () => {
     const r = verifier.verifyCredential(new Uint8Array([0x7b, 0xff, 0xfe, 0x7d]));
     expect(r.valid).toBe(false);

--- a/packages/atx-verify/src/strict-parse.ts
+++ b/packages/atx-verify/src/strict-parse.ts
@@ -1,0 +1,428 @@
+/**
+ * Strict pre-parse for ATX credentials: rejects a credential that carries a
+ * duplicate object member at ANY depth, where "duplicate" is judged under the
+ * field folding a lenient consumer's JSON parser would apply.
+ *
+ * Every ATX field feeds a signed canonical form (the v1.1 JCS(TBS) projection,
+ * the v1.0 pipe fields), so there is no layer with sanctioned RFC 7519
+ * last-wins semantics — a duplicate member anywhere in the credential is the
+ * RFC 8259 §4 first-wins/last-wins parser-divergence smuggling split and MUST
+ * be rejected before any field is interpreted. This mirrors the strict parse
+ * in the reference verifiers (atx-conformance `verifiers/go`,
+ * `verifiers/python`), `opena2a-registry/pkg/atcverify`, and the Java SDK's
+ * `AtxStrictParse` (agent-identity-management).
+ *
+ * Folding matters because a lenient struct-mapping parser (Go's encoding/json)
+ * collapses a case-variant pair like `{"trustLevel":9,"TRUSTLEVEL":1}` to one
+ * field last-wins. `JSON.parse` itself is case-sensitive but last-wins on
+ * exact duplicates, so the two smuggle shapes land on different parsers; the
+ * fold-scan catches both in a single pass.
+ *
+ * The scan runs on the RAW TEXT with a hand-rolled tokenizer: a reviver (or
+ * any post-`JSON.parse` inspection) sees objects whose duplicates are already
+ * collapsed. The tokenizer decodes string escapes in member names before
+ * folding — `"trustLevel"` and `"trustLevel"` are the same member to
+ * `JSON.parse`, so they must collide here too. It is iterative (explicit
+ * frame stack, no recursion), so deep input cannot overflow the JS call stack;
+ * nesting is additionally bounded at {@link MAX_SCAN_DEPTH} open containers.
+ *
+ * Unlike the Go reference verifier — whose scan silently abandons over-deep
+ * input because `encoding/json.Unmarshal` enforces the same 10000-depth cap
+ * right behind it — this scan REJECTS over-deep input itself: `JSON.parse`
+ * has no fixed nesting cap, so an abandoned scan would leave members below
+ * the abandonment depth unscanned while `JSON.parse` still reads them. The
+ * resulting accept-set matches Go's scan+Unmarshal combination exactly.
+ */
+
+/**
+ * Maximum number of simultaneously open containers (objects/arrays) the scan
+ * accepts. Matches Go `encoding/json`'s maxNestingDepth (10000), which is what
+ * the reference verifier's accept-set is bounded by; deeper input rejects as
+ * malformed. (The Java SDK sits at Jackson's default of 1000 — stricter, on
+ * inputs no honest credential produces.)
+ */
+export const MAX_SCAN_DEPTH = 10000;
+
+/**
+ * Controlled failure of the strict parse: the input is not JSON this scan can
+ * vouch for (malformed, truncated, trailing content, or nested beyond
+ * {@link MAX_SCAN_DEPTH}). `LocalAtxVerifier.verifyCredential` maps it to a
+ * MALFORMED rejection; callers using {@link firstDuplicateMember} directly
+ * must catch it.
+ */
+export class StrictParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StrictParseError';
+  }
+}
+
+/**
+ * Folds a JSON member name the way a lenient JSON-to-struct parser folds field
+ * names: ASCII letters lowercased, plus the only two non-ASCII code points
+ * that fold onto ASCII (Kelvin sign U+212A -> k, long s U+017F -> s); any
+ * other code point via its simple (1:1) lowercase mapping, matching Go's
+ * `unicode.ToLower` in the reference verifier's `foldKey` and Java's
+ * `Character.toLowerCase`. Two names with the same fold key are the same field
+ * to such a parser, so treating them as a duplicate here catches the
+ * case-variant collapse. Real ATX member names are ASCII, so the fold is exact
+ * on every honest credential.
+ */
+export function foldKey(name: string): string {
+  let out = '';
+  for (const ch of name) {
+    const cp = ch.codePointAt(0)!;
+    if (cp >= 0x41 && cp <= 0x5a) {
+      out += String.fromCharCode(cp + 0x20);
+    } else if (cp === 0x212a) {
+      out += 'k'; // Kelvin sign
+    } else if (cp === 0x017f) {
+      out += 's'; // Latin small letter long s
+    } else if (cp === 0x0130) {
+      // Latin capital I with dot above: its SIMPLE lowercase is "i" (what Go
+      // unicode.ToLower and Java Character.toLowerCase produce). JS
+      // toLowerCase applies the FULL mapping "i̇" — the one unconditional
+      // multi-code-point lowercase in Unicode — which would diverge from the
+      // reference fold.
+      out += 'i';
+    } else if (cp < 0x80) {
+      out += ch;
+    } else {
+      out += ch.toLowerCase();
+    }
+  }
+  return out;
+}
+
+/** Raw-text span of a JSON value: `text.slice(start, end)` is the value. */
+export interface ValueSpan {
+  start: number;
+  end: number;
+}
+
+interface ScanOptions {
+  /** Detect fold-colliding duplicate members and abort with the second name. */
+  checkDuplicates: boolean;
+  /**
+   * When the scanned value is an object, capture the raw span of this
+   * top-level member's value (used by the conformance tests to extract
+   * credential bytes verbatim, duplicates preserved).
+   */
+  spanMember?: string;
+}
+
+interface ScanResult {
+  dup: string | null;
+  span: ValueSpan | null;
+}
+
+/**
+ * Scans raw ATX credential JSON for a member name that collides — under field
+ * folding — with an earlier member of the same object, at any depth, and
+ * returns the first such name. Returns `null` when the credential has no
+ * duplicate members.
+ *
+ * @throws StrictParseError if the text is not a single well-formed JSON value
+ *     (or exceeds {@link MAX_SCAN_DEPTH}); the caller surfaces that as a
+ *     MALFORMED rejection.
+ */
+export function firstDuplicateMember(credentialJson: string): string | null {
+  return new Scanner(credentialJson).scan({ checkDuplicates: true }).dup;
+}
+
+/**
+ * Returns the raw-text span of a top-level object member's value, scanned with
+ * the same tokenizer as {@link firstDuplicateMember} (duplicates tolerated, so
+ * the strict-parse fixtures' credential bytes survive extraction verbatim).
+ * Test helper — mirrors the Java conformance test's `rawAtxBytes`. Returns
+ * `null` when the member is absent or the top-level value is not an object.
+ *
+ * @throws StrictParseError if the text is not a single well-formed JSON value.
+ */
+export function topLevelMemberSpan(text: string, member: string): ValueSpan | null {
+  return new Scanner(text).scan({ checkDuplicates: false, spanMember: member }).span;
+}
+
+/** One open container on the scan stack. */
+interface Frame {
+  isObject: boolean;
+  /** foldKey -> first raw (decoded) member name; null when not dup-checking or an array. */
+  seen: Map<string, string> | null;
+  /** Close of this frame ends the span capture. */
+  captureEnd: boolean;
+}
+
+class Scanner {
+  private i = 0;
+
+  constructor(private readonly text: string) {}
+
+  scan(opts: ScanOptions): ScanResult {
+    this.skipWs();
+    if (this.atEnd()) {
+      throw new StrictParseError('empty credential');
+    }
+    const result = this.scanValue(opts);
+    if (result.dup !== null) {
+      return result; // abort-unwind: report immediately, mirror Go/Java
+    }
+    this.skipWs();
+    if (!this.atEnd()) {
+      this.fail('unexpected trailing content');
+    }
+    return result;
+  }
+
+  /**
+   * Consumes exactly one JSON value iteratively. Two-phase loop: the outer
+   * `value` phase consumes a value's first token (pushing a frame for
+   * containers), the inner `unwind` phase consumes `,`-continuations and
+   * container closes until another value is expected or the whole value ends.
+   */
+  private scanValue(opts: ScanOptions): ScanResult {
+    const frames: Frame[] = [];
+    let span: ValueSpan | null = null;
+    let spanStart = -1;
+    // Set when the just-consumed member name is the span target: the next
+    // value scanned is the one to capture.
+    let capturePending = false;
+
+    const popFrame = (): void => {
+      const f = frames.pop()!;
+      if (f.captureEnd) {
+        span = { start: spanStart, end: this.i };
+      }
+    };
+
+    // Scans `"name" <ws> :` (cursor on the opening quote), dup-checks the
+    // decoded name against the enclosing object frame, and arms span capture
+    // when it matches the target. Returns the colliding name, or null.
+    const memberName = (): string | null => {
+      if (this.atEnd() || this.text[this.i] !== '"') {
+        this.fail('expected member name');
+      }
+      const name = this.scanString(true);
+      const top = frames[frames.length - 1];
+      if (top.seen !== null) {
+        const fk = foldKey(name);
+        if (top.seen.has(fk)) {
+          return name;
+        }
+        top.seen.set(fk, name);
+      }
+      this.skipWs();
+      if (this.atEnd() || this.text[this.i] !== ':') {
+        this.fail("expected ':' after member name");
+      }
+      this.i++;
+      capturePending = opts.spanMember !== undefined && frames.length === 1 && name === opts.spanMember;
+      return null;
+    };
+
+    value: for (;;) {
+      this.skipWs();
+      if (this.atEnd()) {
+        this.fail('unexpected end of input');
+      }
+      const c = this.text[this.i];
+      const valueStart = this.i;
+      const capture = capturePending;
+      capturePending = false;
+
+      if (c === '{' || c === '[') {
+        if (frames.length >= MAX_SCAN_DEPTH) {
+          this.fail(`nesting exceeds ${MAX_SCAN_DEPTH} levels`);
+        }
+        this.i++;
+        const isObject = c === '{';
+        frames.push({
+          isObject,
+          seen: isObject && opts.checkDuplicates ? new Map() : null,
+          captureEnd: capture,
+        });
+        if (capture) {
+          spanStart = valueStart;
+        }
+        this.skipWs();
+        if (!this.atEnd() && this.text[this.i] === (isObject ? '}' : ']')) {
+          this.i++;
+          popFrame();
+          // fall through to unwind
+        } else if (isObject) {
+          const dup = memberName();
+          if (dup !== null) {
+            return { dup, span };
+          }
+          continue value;
+        } else {
+          continue value;
+        }
+      } else if (c === '"') {
+        this.scanString(false);
+        if (capture) {
+          span = { start: valueStart, end: this.i };
+        }
+      } else {
+        this.scanScalarToken();
+        if (capture) {
+          span = { start: valueStart, end: this.i };
+        }
+      }
+
+      // unwind: a value just completed.
+      for (;;) {
+        if (frames.length === 0) {
+          return { dup: null, span };
+        }
+        this.skipWs();
+        if (this.atEnd()) {
+          this.fail('unexpected end of input');
+        }
+        const top = frames[frames.length - 1];
+        const ch = this.text[this.i];
+        if (ch === ',') {
+          this.i++;
+          if (top.isObject) {
+            this.skipWs();
+            const dup = memberName();
+            if (dup !== null) {
+              return { dup, span };
+            }
+          }
+          continue value;
+        }
+        if (ch === (top.isObject ? '}' : ']')) {
+          this.i++;
+          popFrame();
+          continue;
+        }
+        this.fail(`unexpected character '${ch}'`);
+      }
+    }
+  }
+
+  /**
+   * Scans a JSON string (cursor on the opening quote; on return, past the
+   * closing quote). Escape sequences are validated always and DECODED when
+   * `decode` is set — member-name comparison must happen on decoded names,
+   * exactly as `JSON.parse` (and Go's Decoder.Token, Jackson's currentName)
+   * produce them: `"trustLevel"` IS `"trustLevel"`. `\uXXXX` appends the
+   * raw UTF-16 code unit, so surrogate pairs (and lone surrogates) combine the
+   * same way `JSON.parse` combines them.
+   */
+  private scanString(decode: boolean): string {
+    const t = this.text;
+    this.i++; // opening quote
+    let out = '';
+    for (;;) {
+      if (this.i >= t.length) {
+        this.fail('unterminated string');
+      }
+      const c = t.charCodeAt(this.i);
+      if (c === 0x22) {
+        this.i++;
+        return out;
+      }
+      if (c === 0x5c) {
+        this.i++;
+        if (this.i >= t.length) {
+          this.fail('unterminated string escape');
+        }
+        const e = t[this.i];
+        this.i++;
+        switch (e) {
+          case '"':
+          case '\\':
+          case '/':
+            if (decode) out += e;
+            break;
+          case 'b':
+            if (decode) out += '\b';
+            break;
+          case 'f':
+            if (decode) out += '\f';
+            break;
+          case 'n':
+            if (decode) out += '\n';
+            break;
+          case 'r':
+            if (decode) out += '\r';
+            break;
+          case 't':
+            if (decode) out += '\t';
+            break;
+          case 'u': {
+            if (this.i + 4 > t.length) {
+              this.fail('truncated \\u escape');
+            }
+            const hex = t.slice(this.i, this.i + 4);
+            if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
+              this.fail('invalid \\u escape');
+            }
+            if (decode) out += String.fromCharCode(parseInt(hex, 16));
+            this.i += 4;
+            break;
+          }
+          default:
+            this.fail(`invalid escape '\\${e}'`);
+        }
+      } else if (c < 0x20) {
+        this.fail('unescaped control character in string');
+      } else {
+        if (decode) out += t[this.i];
+        this.i++;
+      }
+    }
+  }
+
+  /**
+   * Consumes a scalar token (number / true / false / null) lazily: the exact
+   * grammar is `JSON.parse`'s to enforce afterwards; here it only matters that
+   * the token's SPAN is right. The accepted character set contains no
+   * structural characters, so a lax scalar can never swallow a brace, bracket,
+   * quote, comma, or colon — and junk like `truex` still fails, either at the
+   * unwind phase or at `JSON.parse`.
+   */
+  private scanScalarToken(): void {
+    const t = this.text;
+    const start = this.i;
+    while (this.i < t.length) {
+      const c = t[this.i];
+      if (
+        (c >= '0' && c <= '9') ||
+        (c >= 'a' && c <= 'z') ||
+        (c >= 'A' && c <= 'Z') ||
+        c === '+' ||
+        c === '-' ||
+        c === '.'
+      ) {
+        this.i++;
+      } else {
+        break;
+      }
+    }
+    if (this.i === start) {
+      this.fail(`unexpected character '${t[start]}'`);
+    }
+  }
+
+  private skipWs(): void {
+    const t = this.text;
+    while (this.i < t.length) {
+      const c = t.charCodeAt(this.i);
+      if (c === 0x20 || c === 0x09 || c === 0x0a || c === 0x0d) {
+        this.i++;
+      } else {
+        return;
+      }
+    }
+  }
+
+  private atEnd(): boolean {
+    return this.i >= this.text.length;
+  }
+
+  private fail(message: string): never {
+    throw new StrictParseError(`${message} (offset ${this.i})`);
+  }
+}

--- a/packages/atx-verify/src/strict-parse.ts
+++ b/packages/atx-verify/src/strict-parse.ts
@@ -63,10 +63,12 @@ export class StrictParseError extends Error {
  * that fold onto ASCII (Kelvin sign U+212A -> k, long s U+017F -> s); any
  * other code point via its simple (1:1) lowercase mapping, matching Go's
  * `unicode.ToLower` in the reference verifier's `foldKey` and Java's
- * `Character.toLowerCase`. Two names with the same fold key are the same field
- * to such a parser, so treating them as a duplicate here catches the
- * case-variant collapse. Real ATX member names are ASCII, so the fold is exact
- * on every honest credential.
+ * `Character.toLowerCase`. (The Python reference's `str.lower()` diverges from
+ * all three on exotic code points like U+0130 — an acknowledged upstream
+ * outlier on names no honest credential produces.) Two names with the same
+ * fold key are the same field to such a parser, so treating them as a
+ * duplicate here catches the case-variant collapse. Real ATX member names are
+ * ASCII, so the fold is exact on every honest credential.
  */
 export function foldKey(name: string): string {
   let out = '';
@@ -122,8 +124,15 @@ interface ScanResult {
  * returns the first such name. Returns `null` when the credential has no
  * duplicate members.
  *
- * @throws StrictParseError if the text is not a single well-formed JSON value
- *     (or exceeds {@link MAX_SCAN_DEPTH}); the caller surfaces that as a
+ * A `null` return does NOT certify well-formedness: the scan is lax on scalar
+ * tokens (`{"a":truex}` scans clean), so callers using this directly must
+ * still `JSON.parse` — exactly what `verifyCredential` does. The laxness
+ * cannot hide a duplicate, because the scalar character set contains no
+ * structural characters.
+ *
+ * @throws StrictParseError if the text is structurally malformed (bad
+ *     strings/escapes, mismatched or misplaced punctuation, trailing content)
+ *     or exceeds {@link MAX_SCAN_DEPTH}; the caller surfaces that as a
  *     MALFORMED rejection.
  */
 export function firstDuplicateMember(credentialJson: string): string | null {


### PR DESCRIPTION
Closes #226.

## What

`LocalAtxVerifier.verifyCredential(credentialJson: string | Uint8Array)` — a raw-bytes strict-parse entry point, mirroring the Java SDK (agent-identity-management#337). The exported `AtxVerifier` interface is unchanged (consumers implement it); the raw entry point is a separate class method so wire-consumer migration is greppable.

- **Strict parse before any field is interpreted**: a dependency-free iterative JSON tokenizer scans the raw text and rejects a duplicate object member at any depth as `MALFORMED`, where duplicate means fold-colliding (ASCII case + U+212A Kelvin + U+017F long s, matching the Go reference `foldKey`; `PARSE_ERROR` maps to `MALFORMED` — the SDK RejectCategory union has no PARSE_ERROR). Escapes in member names are decoded before folding, so `"trust\u004Cevel"` collides with `"trustLevel"` exactly as `JSON.parse` collapses them.
- **Nesting bounded at 10000 open containers** (matches Go `encoding/json` maxNestingDepth, so the TS accept-set equals the reference scan+Unmarshal accept-set). Unlike Go's abort-and-delegate, the scan hard-rejects over-deep input — `JSON.parse` has no fixed cap to backstop an abandoned scan.
- **Degenerate inputs** (JSON `null`, scalars, arrays, empty, invalid UTF-8, out-of-contract argument types incl. hostile Proxies) reject `MALFORMED`; `verifyCredential` never throws.
- **declaredPurpose TBS coverage (security fix)**: 0.2.0's v1.1 TBS projection omitted `declaredPurpose` entirely, so unsigned purpose content appended to a signed credential rode the valid signature undetected (`v1_1-declared-purpose-string-injected` falsely ACCEPTed). The projection now implements atx-spec §1.3a.2 rule 5 (absent/null/empty-object omitted; anything else verbatim into JCS(TBS)).

## Conformance

Replays the FULL 20-fixture suite (pinned atx-conformance `f4d40a4`, vendored byte-verbatim) through the raw entry point, extracting each credential's bytes by tokenizer offsets so duplicates survive extraction. New CI job `atx-fixture-drift` byte-compares the vendored copies bidirectionally against the pinned suite (same pattern as the Java SDK gate).

## Review

Two independent adversarial rounds (combined ~500k differential fuzz trials against `JSON.parse` plus frame-scoping and span-attribution oracles) could not construct an input two conforming parsers read differently that the scan passes. Round findings — a Proxy-trap throw escape, a BOM entry-form divergence (bytes accepted / string rejected for identical wire bytes), doc overstatements — are all fixed with regression tests. Mutation checks: removing the depth guard, the dup scan, or the declaredPurpose projection each fails the suite.

## Compatibility

New optional `Atx.declaredPurpose` field (non-breaking). `verify(atx)` behavior is unchanged except v1.1 credentials carrying `declaredPurpose`, which previously computed a wrong TBS (falsely rejecting honestly-signed purposes and falsely accepting appended ones). Version bump to 0.3.0 deferred to the next release window per publish batching.