### PR TITLE
release: @opena2a/atx-verify 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4259,7 +4259,7 @@
     },
     "packages/atx-verify": {
       "name": "@opena2a/atx-verify",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "canonicalize": "2.1.0"

--- a/packages/atx-verify/package.json
+++ b/packages/atx-verify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/atx-verify",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Spec-compliant offline verifier for ATX (Agent Trust eXtension) credentials — Ed25519 signature verification over the canonical payload (v1.0 pipe / v1.1 JCS RFC 8785), expiry, revocation, issuer-trust, and issuer-chain checks. Byte-for-byte interoperable with the Go and Python reference verifiers.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump only. Ships #230 (strict-parse `verifyCredential` raw entry point + declaredPurpose v1.1 TBS coverage fix) as 0.3.0 — minor per semver for the new public API.

Publish is via the `atx-verify-v0.3.0` tag after merge (Trusted Publishing / OIDC; the shared release workflow's `publish_if_new` was audited pre-tag: all other workspace packages are version==npm, so only atx-verify publishes).