### PR TITLE
fix(atx-verify): release-test findings — verify() null guard, mldsaPresent on reject, reason wording

### DIFF
--- a/packages/atx-verify/src/atx.ts
+++ b/packages/atx-verify/src/atx.ts
@@ -200,7 +200,7 @@ export class LocalAtxVerifier implements AtxVerifier {
    */
   verifyCredential(credentialJson: string | Uint8Array): AtxVerificationResult {
     if (credentialJson === null || credentialJson === undefined) {
-      return reject('MALFORMED', 'credential is null');
+      return reject('MALFORMED', 'credential is null or undefined');
     }
     // Out-of-contract argument types stay MALFORMED rejections, never escaping
     // throws — including a Proxy whose getPrototypeOf trap throws inside the
@@ -261,12 +261,19 @@ export class LocalAtxVerifier implements AtxVerifier {
   }
 
   verify(atx: Atx): AtxVerificationResult {
+    // The type forbids it, but a plain-JS caller doing verify(JSON.parse(body))
+    // reaches here with null (or a scalar) when the wire body is degenerate —
+    // reject structurally rather than throw on the first property read.
+    if (atx === null || typeof atx !== 'object') {
+      return reject('MALFORMED', 'credential is not an object');
+    }
     const now = (this.anchors.now ?? (() => new Date()))();
 
     // Step 1: schema version. Dispatch on atcVersion: "1.0" verifies the legacy
-    // pipe form, "1.1" verifies JCS(TBS) (atx-spec §1.3a).
+    // pipe form, "1.1" verifies JCS(TBS) (atx-spec §1.3a). The reason names
+    // atcVersion — the schema field a consumer greps their credential for.
     if (atx.atcVersion !== SUPPORTED_ATX_VERSION && atx.atcVersion !== SUPPORTED_ATX_VERSION_V11) {
-      return reject('UNSUPPORTED_VERSION', `unsupported atxVersion ${String(atx.atcVersion)}`);
+      return reject('UNSUPPORTED_VERSION', `unsupported atcVersion ${String(atx.atcVersion)}`);
     }
     const isV11 = atx.atcVersion === SUPPORTED_ATX_VERSION_V11;
 
@@ -351,7 +358,11 @@ export class LocalAtxVerifier implements AtxVerifier {
     }
 
     if (!edVerified) {
-      return reject('SIGNATURE_INVALID', 'no Ed25519 signature verified');
+      // Keep mldsaPresent on this rejection: an ML-DSA-only credential fails
+      // here precisely because its PQC half is delegated, and the flag is how
+      // a caller distinguishes "delegated, bring your own ML-DSA verifier"
+      // from "carried no usable signature at all".
+      return { ...reject('SIGNATURE_INVALID', 'no Ed25519 signature verified'), mldsaPresent };
     }
 
     return {

--- a/packages/atx-verify/src/strict-parse.test.ts
+++ b/packages/atx-verify/src/strict-parse.test.ts
@@ -223,3 +223,44 @@ describe('LocalAtxVerifier.verifyCredential', () => {
     expect(r.rejectCategory).toBe('MALFORMED');
   });
 });
+
+describe('LocalAtxVerifier.verify (object overload, plain-JS runtime inputs)', () => {
+  const verifier = new LocalAtxVerifier(emptyAnchors);
+
+  it('rejects null/scalar credentials as MALFORMED instead of throwing', () => {
+    // Release-test P2: verify(JSON.parse('null')) threw on the first property
+    // read. The type forbids these, plain-JS callers reach them anyway.
+    for (const bad of [null, undefined, 5, 'x', true]) {
+      const r = verifier.verify(bad as never);
+      expect(r.valid, String(bad)).toBe(false);
+      expect(r.rejectCategory, String(bad)).toBe('MALFORMED');
+    }
+  });
+
+  it('names the schema field atcVersion in the version rejection reason', () => {
+    const r = verifier.verify({ atcVersion: '2.0' } as never);
+    expect(r.rejectCategory).toBe('UNSUPPORTED_VERSION');
+    expect(r.reason).toContain('atcVersion');
+  });
+
+  it('mldsaPresent is set when an ML-DSA-only credential fails Ed25519 verification', () => {
+    const anchors: AtxTrustAnchors = { trustedIssuers: ['did:x:issuer'], publicKeys: [] };
+    const r = new LocalAtxVerifier(anchors).verify({
+      atcVersion: '1.0',
+      agentId: 'a',
+      agentDid: 'did:x:a',
+      version: '1',
+      contentHash: 'h',
+      issuerDid: 'did:x:issuer',
+      trustLevel: 1,
+      trustScore: 0.5,
+      issuedAt: '2026-01-01T00:00:00Z',
+      expiresAt: '2999-01-01T00:00:00Z',
+      signatures: [{ algorithm: 'ML-DSA-65', value: 'AA==' }],
+    } as never);
+    expect(r.valid).toBe(false);
+    expect(r.rejectCategory).toBe('SIGNATURE_INVALID');
+    expect(r.reason).toContain('no Ed25519 signature verified');
+    expect(r.mldsaPresent).toBe(true);
+  });
+});


### PR DESCRIPTION
Fresh-user release testing for 0.3.0 surfaced one P2 and several P3s; this fixes the P2 and the two trivial P3s before the `atx-verify-v0.3.0` tag is pushed, so the published 0.3.0 carries them.

- **P2:** `verify(JSON.parse(body))` with wire body `'null'` threw `TypeError` on the first property read (the object overload had no runtime guard — same defect class the Java SDK's adversarial round caught on its raw path). Non-object credentials now reject `MALFORMED` structurally; `verifyCredential` already guarded this.
- `mldsaPresent` is now kept on the `no Ed25519 signature verified` rejection — an ML-DSA-only credential fails there precisely because its PQC half is delegated, and the flag is how a caller distinguishes that from a credential with no usable signature.
- Version-rejection reason names `atcVersion` (the schema field consumers grep for; it said `atxVersion`), and the null-argument reason says `null or undefined`.

All changes are reject-side only; the 20-fixture conformance replay pins the accept-set unchanged. 72 package tests. Remaining P3s tracked for 0.4.0.