### PR TITLE
atx-verify: release-test P3 batch (anchor-fault diagnostics, exports map, type precision)

### DIFF
--- a/packages/atx-verify/README.md
+++ b/packages/atx-verify/README.md
@@ -58,6 +58,16 @@ Ed25519 is verified fully via Node's `crypto`. **ML-DSA-65** presence is recorde
 matching the Python reference verifier. Wire the PQC half via the `AtxVerifier`
 seam in production.
 
+## Runtime and packaging
+
+- **ESM-only** (`"type": "module"`). On Node >= 22, CommonJS consumers can
+  `require()` it natively; on Node 18/20 use `await import('@opena2a/atx-verify')`
+  (the pattern the secretless broker uses). The package exposes only the root
+  entry via its `exports` map.
+- **Node types**: the canonical-payload helpers return Node `Buffer`s, so a
+  TypeScript consumer compiling with `skipLibCheck: false` needs `@types/node`
+  (any recent version) in its own devDependencies.
+
 ## Usage
 
 ```ts
@@ -105,11 +115,12 @@ than one issuer.
 
 ## Conformance
 
-`src/conformance.test.ts` replays the FULL OpenA2A ATX conformance suite (20
+The package's test suite — in [the repository](https://github.com/opena2a-org/opena2a/tree/main/packages/atx-verify),
+not the published tarball — replays the FULL OpenA2A ATX conformance suite (20
 fixtures, pinned signatures, vendored verbatim from `atx-conformance` at
 `f4d40a4`) through the raw `verifyCredential` entry point; CI byte-compares the
-vendored copies against the pinned suite so they cannot drift. `src/atx.test.ts`
-pins the v1.1 JCS baseline canonical bytes from `atx-conformance/jcs-vectors`.
+vendored copies against the pinned suite so they cannot drift, and pins the
+v1.1 JCS baseline canonical bytes from `atx-conformance/jcs-vectors`.
 Where the reference verifiers report `PARSE_ERROR`, this SDK reports
 `MALFORMED` (the shared SDK `RejectCategory` union has no `PARSE_ERROR`).
 

--- a/packages/atx-verify/package.json
+++ b/packages/atx-verify/package.json
@@ -5,6 +5,13 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run --passWithNoTests",

--- a/packages/atx-verify/src/atx.keybinding.test.ts
+++ b/packages/atx-verify/src/atx.keybinding.test.ts
@@ -126,3 +126,53 @@ describe('key-to-issuer binding', () => {
     expect(result.valid).toBe(true);
   });
 });
+
+describe('anchor-fault diagnostics (empty eligible key set names the configuration fault)', () => {
+  it('no Ed25519 anchors configured', () => {
+    const { privateKey } = keypair();
+    const atx = signWith(atxBase(), privateKey, `${ISSUER_A}#key-1`);
+    const result = new LocalAtxVerifier(anchors({ publicKeys: [] })).verify(atx);
+    expect(result.valid).toBe(false);
+    expect(result.rejectCategory).toBe('SIGNATURE_INVALID');
+    expect(result.reason).toContain('no Ed25519 trust anchors configured');
+  });
+
+  it('all configured keys excluded by key-to-issuer binding', () => {
+    const a = keypair();
+    // Key bound to ISSUER_B; credential issued by ISSUER_A. The crypto WOULD
+    // verify (same key signed it) — the reason must say binding, not bad bytes.
+    const atx = signWith(atxBase({ issuerDid: ISSUER_A, issuerChain: [ISSUER_A] }), a.privateKey, `${ISSUER_B}#key-1`);
+    const result = new LocalAtxVerifier(
+      anchors({ publicKeys: [{ algorithm: 'Ed25519', publicKeyHex: a.pubHex, keyId: `${ISSUER_B}#key-1` }] }),
+    ).verify(atx);
+    expect(result.valid).toBe(false);
+    expect(result.rejectCategory).toBe('SIGNATURE_INVALID');
+    expect(result.reason).toContain('key-to-issuer binding');
+    expect(result.reason).toContain(ISSUER_A);
+  });
+
+  it('eligible key material fails to parse (bad hex)', () => {
+    const { privateKey } = keypair();
+    const atx = signWith(atxBase(), privateKey, `${ISSUER_A}#key-1`);
+    const result = new LocalAtxVerifier(
+      anchors({ publicKeys: [{ algorithm: 'Ed25519', publicKeyHex: 'zz-not-hex', keyId: `${ISSUER_A}#key-1` }] }),
+    ).verify(atx);
+    expect(result.valid).toBe(false);
+    expect(result.rejectCategory).toBe('SIGNATURE_INVALID');
+    expect(result.reason).toContain('failed to parse');
+  });
+
+  it('a genuine bad-signature rejection has no dangling space when keyId is absent', () => {
+    const a = keypair();
+    const atx = signWith(atxBase(), a.privateKey, `${ISSUER_A}#key-1`);
+    // Wrong-key anchor (unbound, so eligible): reaches the did-not-verify path.
+    const other = keypair();
+    const unsigned: Atx = { ...atx, signatures: [{ algorithm: 'Ed25519', value: atx.signatures[0].value }] };
+    const result = new LocalAtxVerifier(
+      anchors({ publicKeys: [{ algorithm: 'Ed25519', publicKeyHex: other.pubHex }] }),
+    ).verify(unsigned);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Ed25519 signature did not verify');
+    expect(result.reason).not.toContain('  ');
+  });
+});

--- a/packages/atx-verify/src/atx.ts
+++ b/packages/atx-verify/src/atx.ts
@@ -74,7 +74,14 @@ export interface AtxSignature {
 
 /** The ATX credential (subset used for verification + context derivation). */
 export interface Atx {
-  atcVersion?: string;
+  /**
+   * Schema version, "1.0" or "1.1". Required: there is no default — a
+   * credential without it always rejects UNSUPPORTED_VERSION, so the optional
+   * typing this field used to carry only misled constructors. (ATX is the
+   * current name for the credential formerly called ATC; the wire field keeps
+   * the historical spelling.)
+   */
+  atcVersion: string;
   agentId: string;
   agentDid: string;
   /** Publisher identity. Unsigned under v1.0; covered by the v1.1 signature. */
@@ -323,9 +330,13 @@ export class LocalAtxVerifier implements AtxVerifier {
     if (isV11) {
       for (const did of atx.issuerChain ?? []) authoritySet.add(did);
     }
-    const edKeys = this.anchors.publicKeys
-      .filter((k) => k.algorithm === 'Ed25519')
-      .filter((k) => keyEligible(k.keyId, authoritySet))
+    // Staged so an empty final key set can be diagnosed precisely: nothing
+    // configured vs binding-excluded vs unparseable key material. All three
+    // used to collapse into "signature did not verify", which reads as bad
+    // signature bytes when the actual fault is anchor configuration.
+    const configuredEd = this.anchors.publicKeys.filter((k) => k.algorithm === 'Ed25519');
+    const eligibleEd = configuredEd.filter((k) => keyEligible(k.keyId, authoritySet));
+    const edKeys = eligibleEd
       .map((k) => ed25519FromRawHex(k.publicKeyHex))
       .filter((k): k is crypto.KeyObject => k !== null);
 
@@ -334,11 +345,29 @@ export class LocalAtxVerifier implements AtxVerifier {
 
     for (const sig of atx.signatures ?? []) {
       if (sig.algorithm === 'Ed25519') {
+        // An empty eligible-key set can never verify — name the configuration
+        // fault instead of letting it read as bad signature bytes.
+        if (edKeys.length === 0) {
+          if (configuredEd.length === 0) {
+            return reject('SIGNATURE_INVALID', 'no Ed25519 trust anchors configured');
+          }
+          if (eligibleEd.length === 0) {
+            return reject(
+              'SIGNATURE_INVALID',
+              `key-to-issuer binding: none of the ${configuredEd.length} configured Ed25519 key(s) ` +
+                `is controlled by an authority of this credential (issuer ${atx.issuerDid})`,
+            );
+          }
+          return reject(
+            'SIGNATURE_INVALID',
+            'configured Ed25519 key(s) for this issuer failed to parse (expected 32-byte raw public key hex)',
+          );
+        }
         let sigBytes: Buffer;
         try {
           sigBytes = Buffer.from(sig.value, 'base64');
         } catch {
-          return reject('SIGNATURE_INVALID', `signature ${sig.keyId ?? ''} has invalid base64`);
+          return reject('SIGNATURE_INVALID', `${sigLabel(sig.keyId)} has invalid base64`);
         }
         const ok = edKeys.some((key) => {
           try {
@@ -348,7 +377,7 @@ export class LocalAtxVerifier implements AtxVerifier {
           }
         });
         if (!ok) {
-          return reject('SIGNATURE_INVALID', `Ed25519 signature ${sig.keyId ?? ''} did not verify`);
+          return reject('SIGNATURE_INVALID', `Ed25519 ${sigLabel(sig.keyId)} did not verify`);
         }
         edVerified = true;
       } else if (sig.algorithm === 'ML-DSA-65') {
@@ -386,6 +415,11 @@ export class LocalAtxVerifier implements AtxVerifier {
 
 function reject(rejectCategory: RejectCategory, reason: string): AtxVerificationResult {
   return { valid: false, rejectCategory, reason };
+}
+
+/** "signature <keyId>" or plain "signature" — no dangling space when keyId is absent. */
+function sigLabel(keyId: string | undefined): string {
+  return keyId ? `signature ${keyId}` : 'signature';
 }
 
 /**

--- a/packages/atx-verify/src/index.ts
+++ b/packages/atx-verify/src/index.ts
@@ -20,4 +20,11 @@ export {
   type ResolutionContext,
   type RejectCategory,
 } from './atx.js';
-export { firstDuplicateMember, foldKey, StrictParseError, MAX_SCAN_DEPTH } from './strict-parse.js';
+export {
+  firstDuplicateMember,
+  foldKey,
+  topLevelMemberSpan,
+  StrictParseError,
+  MAX_SCAN_DEPTH,
+  type ValueSpan,
+} from './strict-parse.js';


### PR DESCRIPTION
Lands the six deferred P3s from the 0.3.0 fresh-user release test (tracker: todo 2026-07-06-atx-verify-release-test-p3s) plus one enabling export, so 0.4.0 is tag-ready at the next publish window. **No tag with this PR** — today's publish budget is used.

- **Anchor-fault diagnostics:** an empty eligible-key set previously fell through to `Ed25519 signature ... did not verify`, which reads as bad signature bytes when the fault is configuration. Three staged reasons now distinguish: no Ed25519 anchors configured / all keys excluded by key-to-issuer binding (the cross-issuer case where the crypto WOULD verify) / eligible key hex failed to parse. Same rejectCategory (SIGNATURE_INVALID) everywhere — reject-side reason refinement only; the 20-fixture conformance replay pins the accept-set unchanged.
- **Packaging:** `exports` map (root + package.json — deep `dist/*` imports were never documented); README states ESM-only consumption patterns and the `@types/node` requirement for `skipLibCheck: false` consumers; the conformance section points at the repository instead of files absent from the tarball.
- **Types:** `Atx.atcVersion` is now required — absence always rejects `UNSUPPORTED_VERSION`, so the optional marker only misled constructors. Type-level change for object-literal constructors (both known in-org consumers already set it); flagging for the 0.4.0 release notes.
- **New export:** `topLevelMemberSpan`/`ValueSpan` — the tokenizer-offset raw-member extractor the conformance tests use, needed by consumers that want credential-only strict-parse scoping of a larger envelope (e.g. the secretless grant body).

76 package tests (4 new), monorepo 22/22 test + 16/16 lint.