### PR TITLE
chore: point published contact email to info@opena2a.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ git clone https://github.com/opena2a-org/opena2a.git
 cd opena2a && npm install && npm run build && npm test
 ```
 
-Security issues: `security@opena2a.org` (coordinated disclosure, response within 24 hours).
+Security issues: `info@opena2a.org` (coordinated disclosure, response within 24 hours).
 
 ## Links
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 If you discover a security vulnerability in any OpenA2A project, please report it responsibly.
 
-**Email:** security@opena2a.org
+**Email:** info@opena2a.org
 
 Please include:
 - Description of the vulnerability


### PR DESCRIPTION
Points the published contact/security email to `info@opena2a.org`, the real monitored business inbox.

Upstream 5005df5 already fixed `SECURITY.md` but missed the README occurrence at README.md:238 (`security@opena2a.org`). This completes that: net change is the one README line. `SECURITY.md` is already identical to `main`, so it will merge as a no-op.

Part of an org-wide contact-email sweep. Only the email string changed; no logic.