### PR TITLE
release: @opena2a/atx-verify 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4259,7 +4259,7 @@
     },
     "packages/atx-verify": {
       "name": "@opena2a/atx-verify",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "canonicalize": "2.1.0"

--- a/packages/atx-verify/README.md
+++ b/packages/atx-verify/README.md
@@ -4,8 +4,10 @@ Spec-compliant **offline** verifier for ATX (Agent Trust eXtension) credentials 
 the signed, portable credential that states what an agent *is*.
 
 This is the single shared TypeScript verifier for the OpenA2A ecosystem. It is
-**byte-for-byte interoperable** with the Go (`opena2a-registry/pkg/atcverify`)
-and Python (`atx-conformance`) reference verifiers; canonicalization agreement
+**byte-for-byte interoperable** with the Go
+([`opena2a-registry/pkg/atcverify`](https://github.com/opena2a-org/opena2a-registry/tree/main/pkg/atcverify))
+and Python ([`atx-conformance`](https://github.com/opena2a-standards/atx-conformance))
+reference verifiers; canonicalization agreement
 across Go == Python == TS is pinned by `atx-conformance/jcs-vectors`.
 
 ## What it does
@@ -99,6 +101,68 @@ if (result.valid) {
 }
 ```
 
+## Building a test credential
+
+There is no signing API here (issuance lives in the Registry), but the exported
+canonical-payload helpers plus `node:crypto` are enough to build a valid signed
+credential for tests:
+
+```ts
+import crypto from "node:crypto";
+import {
+  LocalAtxVerifier,
+  canonicalPayloadV11,
+  type Atx,
+  type AtxTrustAnchors,
+} from "@opena2a/atx-verify";
+
+// 1. Issuer keypair (in production this is the issuing authority's key).
+const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+const jwk = publicKey.export({ format: "jwk" }) as { x: string };
+const publicKeyHex = Buffer.from(jwk.x, "base64url").toString("hex");
+
+// 2. The credential body. "1.1" signs JCS(TBS) — capabilities are covered.
+const atx: Atx = {
+  atcVersion: "1.1",
+  agentId: "example-agent",
+  agentDid: "did:opena2a:agent:example-agent",
+  version: "1.0.0",
+  contentHash:
+    "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  issuerDid: "did:opena2a:authority:example.org",
+  trustLevel: 2,
+  trustScore: 80,
+  issuedAt: new Date().toISOString(),
+  expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+  capabilities: ["registry:read"],
+  signatures: [],
+};
+
+// 3. Sign the canonical payload (v1.0 credentials use canonicalPayload) and attach.
+atx.signatures = [
+  {
+    algorithm: "Ed25519",
+    value: crypto.sign(null, canonicalPayloadV11(atx), privateKey).toString("base64"),
+    keyId: "did:opena2a:authority:example.org#key-1",
+  },
+];
+
+// 4. Verify the wire form.
+const anchors: AtxTrustAnchors = {
+  trustedIssuers: ["did:opena2a:authority:example.org"],
+  publicKeys: [
+    {
+      algorithm: "Ed25519",
+      publicKeyHex,
+      keyId: "did:opena2a:authority:example.org#key-1",
+    },
+  ],
+  crl: { entries: [] },
+};
+const result = new LocalAtxVerifier(anchors).verifyCredential(JSON.stringify(atx));
+// result.valid === true
+```
+
 ## Key-to-issuer binding
 
 A signature is only accepted from a key controlled by the credential's issuer.
@@ -113,14 +177,28 @@ A key with no `keyId`, or a `keyId` without a `#` fragment, is treated as
 set, but supply DID-URL `keyId`s whenever the anchor set holds keys for more
 than one issuer.
 
+## Additional exports
+
+Beyond the verifier itself, the package exports the primitives its strict parse
+and canonicalization are built from, for consumers that need to scope or
+reproduce them: `canonicalPayload` / `canonicalPayloadV11` (canonical signing
+bytes for v1.0 / v1.1), `firstDuplicateMember` (fold-aware duplicate scan over
+a raw JSON body), `topLevelMemberSpan` + `ValueSpan` (byte-offset extraction of
+one top-level member, for strict-parsing a credential embedded in a larger
+envelope), `foldKey`, `normalizeRfc3339`, `StrictParseError`, `MAX_SCAN_DEPTH`,
+and `SUPPORTED_ATX_VERSION` / `SUPPORTED_ATX_VERSION_V11`. Each carries doc
+comments in the published `.d.ts`.
+
 ## Conformance
 
 The package's test suite — in [the repository](https://github.com/opena2a-org/opena2a/tree/main/packages/atx-verify),
 not the published tarball — replays the FULL OpenA2A ATX conformance suite (20
-fixtures, pinned signatures, vendored verbatim from `atx-conformance` at
+fixtures, pinned signatures, vendored verbatim from
+[`atx-conformance`](https://github.com/opena2a-standards/atx-conformance) at
 `f4d40a4`) through the raw `verifyCredential` entry point; CI byte-compares the
 vendored copies against the pinned suite so they cannot drift, and pins the
-v1.1 JCS baseline canonical bytes from `atx-conformance/jcs-vectors`.
+v1.1 JCS baseline canonical bytes from
+[`atx-conformance/jcs-vectors`](https://github.com/opena2a-standards/atx-conformance/tree/main/jcs-vectors).
 Where the reference verifiers report `PARSE_ERROR`, this SDK reports
 `MALFORMED` (the shared SDK `RejectCategory` union has no `PARSE_ERROR`).
 

--- a/packages/atx-verify/package.json
+++ b/packages/atx-verify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/atx-verify",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Spec-compliant offline verifier for ATX (Agent Trust eXtension) credentials — Ed25519 signature verification over the canonical payload (v1.0 pipe / v1.1 JCS RFC 8785), expiry, revocation, issuer-trust, and issuer-chain checks. Byte-for-byte interoperable with the Go and Python reference verifiers.",
   "type": "module",
   "main": "dist/index.js",
@@ -17,7 +17,7 @@
     "test": "vitest run --passWithNoTests",
     "lint": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {
     "canonicalize": "2.1.0"

--- a/packages/atx-verify/src/atx.test.ts
+++ b/packages/atx-verify/src/atx.test.ts
@@ -87,6 +87,17 @@ describe('LocalAtxVerifier', () => {
     const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
     expect(r.valid).toBe(false);
     expect(r.rejectCategory).toBe('UNSUPPORTED_VERSION');
+    expect(r.reason).toContain('unsupported atcVersion 2.0');
+  });
+
+  it('names the absence, not "undefined", when atcVersion is missing', () => {
+    const { atx, pubHex } = makeSignedAtx({});
+    delete (atx as Record<string, unknown>).atcVersion;
+    const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+    expect(r.valid).toBe(false);
+    expect(r.rejectCategory).toBe('UNSUPPORTED_VERSION');
+    expect(r.reason).toContain('atcVersion is missing');
+    expect(r.reason).not.toContain('undefined');
   });
 
   it('rejects an expired ATX', () => {

--- a/packages/atx-verify/src/atx.ts
+++ b/packages/atx-verify/src/atx.ts
@@ -280,7 +280,12 @@ export class LocalAtxVerifier implements AtxVerifier {
     // pipe form, "1.1" verifies JCS(TBS) (atx-spec §1.3a). The reason names
     // atcVersion — the schema field a consumer greps their credential for.
     if (atx.atcVersion !== SUPPORTED_ATX_VERSION && atx.atcVersion !== SUPPORTED_ATX_VERSION_V11) {
-      return reject('UNSUPPORTED_VERSION', `unsupported atcVersion ${String(atx.atcVersion)}`);
+      return reject(
+        'UNSUPPORTED_VERSION',
+        atx.atcVersion === undefined || atx.atcVersion === null
+          ? 'atcVersion is missing (supported: "1.0", "1.1")'
+          : `unsupported atcVersion ${String(atx.atcVersion)}`,
+      );
     }
     const isV11 = atx.atcVersion === SUPPORTED_ATX_VERSION_V11;
 


### PR DESCRIPTION
Releases the #234 P3 batch as 0.4.0 (npm currently 0.3.0). Tag `atx-verify-v0.4.0` follows the merge; publish is via Trusted Publishing on the tag push.

**Version bump (minor):** new exports (`topLevelMemberSpan`/`ValueSpan`), `exports` map, and `Atx.atcVersion` became required — a type-level change for object-literal constructors (both known in-org consumers already set it; flagged for the release notes).

**Fresh-user release test on the packed 0.4.0 tarball:** P1 0 / P2 1 / P3 3, all fixed here:
- README gained a `Building a test credential` walkthrough (sign with `node:crypto` + `canonicalPayloadV11`, then `verifyCredential`) — the example is extracted and executed verbatim against the packed tarball, verifying `valid: true`
- Missing `atcVersion` now rejects with `atcVersion is missing (supported: "1.0", "1.1")` instead of interpolating `unsupported atcVersion undefined` (reason text only; category and verdict paths unchanged) + regression test
- Strict-parse/span primitives documented under `Additional exports`; conformance references link to the actual repos

**Also:** `clean` now removes `tsconfig.tsbuildinfo` — composite tsc emitted nothing after `clean` left a stale buildinfo, so a local `npm pack` produced a dist-less tarball. CI builds fresh, so published artifacts were never affected.

**Pre-tag audit:** all 10 other workspace packages verified `version == npm`, so the tag publishes only atx-verify.

Monorepo: build 11/11, test 22/22 (77 in-package), lint 16/16.