### PR TITLE
fix(telemetry): suppress telemetry in CI and under DO_NOT_TRACK

### DIFF
--- a/packages/cli-ui/CHANGELOG.md
+++ b/packages/cli-ui/CHANGELOG.md
@@ -23,6 +23,15 @@
   reports that the preference was saved but telemetry stays off here.
 - `TelemetryStatusLike.suppressedBy` is optional, so this stays structurally
   compatible with older `@opena2a/telemetry` versions that never set it.
+- The off-state toggle hint no longer offers `OPENA2A_TELEMETRY=on`. The two
+  directions are not symmetric: `OPENA2A_TELEMETRY=off` disables from any
+  state, but `OPENA2A_TELEMETRY=on` cannot re-enable a persisted opt-out
+  (precedence rule 2 — the config file wins), and this hint only ever prints
+  for an off-state that came from that file. Following it produced an
+  identical, unexplained "off". `<tool> telemetry on` alone is the remedy that
+  works there, and the on-state hint keeps `OPENA2A_TELEMETRY=off` unchanged.
+  The 0.5.1 papercut guard (#170, hint *direction*) is preserved; only the
+  incidental env-var assertion changed.
 
 ## 0.5.2
 

--- a/packages/cli-ui/CHANGELOG.md
+++ b/packages/cli-ui/CHANGELOG.md
@@ -5,12 +5,19 @@
 ### Fixed
 - `runTelemetryCommand` no longer prints a toggle hint that cannot work. When
   `@opena2a/telemetry` reports the new optional
-  `TelemetryStatusLike.suppressedBy` (`"ci"` / `"do-not-track"`), the status
-  block names the cause (`state: off (CI environment detected)`), states
-  plainly that the user did not turn it off, and offers the override that does
-  work (`OPENA2A_TELEMETRY=on <tool> <cmd>`). Previously it suggested
-  `<tool> telemetry on`, which persists `enabled: true`, changes nothing
-  observable, and leaves the next `status` still reporting off.
+  `TelemetryStatusLike.suppressedBy` (`"ci"` / `"do-not-track"` /
+  `"env-opt-out"`), the status block names the cause (e.g.
+  `state: off (CI environment detected)`) and offers a remedy that actually
+  works for that cause. Previously it suggested `<tool> telemetry on`, which
+  persists `enabled: true`, changes nothing observable, and leaves the next
+  `status` still reporting off.
+
+  Each reason gets its own remedy, because a shared one is wrong for two of
+  the three: `OPENA2A_TELEMETRY=on` overrides CI detection but deliberately
+  does **not** override `DO_NOT_TRACK`, and nothing re-enables telemetry while
+  `OPENA2A_TELEMETRY=off` is set. Only the CI copy says "you did not turn it
+  off" — for the other two the user did. A persisted `telemetry off` carries
+  no reason code and keeps the ordinary toggle hint, which works there.
 - `<tool> telemetry on` under automatic suppression no longer prints
   "Telemetry enabled for <tool>." directly above a `state: off` line. It now
   reports that the preference was saved but telemetry stays off here.

--- a/packages/cli-ui/CHANGELOG.md
+++ b/packages/cli-ui/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog — @opena2a/cli-ui
 
+## Unreleased
+
+### Fixed
+- `runTelemetryCommand` no longer prints a toggle hint that cannot work. When
+  `@opena2a/telemetry` reports the new optional
+  `TelemetryStatusLike.suppressedBy` (`"ci"` / `"do-not-track"`), the status
+  block names the cause (`state: off (CI environment detected)`), states
+  plainly that the user did not turn it off, and offers the override that does
+  work (`OPENA2A_TELEMETRY=on <tool> <cmd>`). Previously it suggested
+  `<tool> telemetry on`, which persists `enabled: true`, changes nothing
+  observable, and leaves the next `status` still reporting off.
+- `<tool> telemetry on` under automatic suppression no longer prints
+  "Telemetry enabled for <tool>." directly above a `state: off` line. It now
+  reports that the preference was saved but telemetry stays off here.
+- `TelemetryStatusLike.suppressedBy` is optional, so this stays structurally
+  compatible with older `@opena2a/telemetry` versions that never set it.
+
 ## 0.5.2
 
 ### Added

--- a/packages/cli-ui/src/telemetry-command.test.ts
+++ b/packages/cli-ui/src/telemetry-command.test.ts
@@ -40,13 +40,19 @@ describe("automatic suppression rendering", () => {
     expect(out).not.toContain("dvaa telemetry on'");
   });
 
-  it("explains DO_NOT_TRACK suppression", () => {
+  it("explains DO_NOT_TRACK suppression and offers a remedy that works", () => {
     const out = runTelemetryCommand(
       "status",
       makeInput({ enabled: false, suppressedBy: "do-not-track" }),
     );
     expect(out).toContain("DO_NOT_TRACK is set");
+    expect(out).toContain("unset DO_NOT_TRACK");
     expect(out).not.toContain("dvaa telemetry on'");
+    // OPENA2A_TELEMETRY=on does not override DO_NOT_TRACK, so suggesting it
+    // here would be a second dead end.
+    expect(out).not.toContain("OPENA2A_TELEMETRY=on");
+    // DO_NOT_TRACK is the user's own choice — don't tell them they didn't.
+    expect(out).not.toContain("you did not turn it off");
   });
 
   it("does not contradict itself when 'on' is run under suppression", () => {

--- a/packages/cli-ui/src/telemetry-command.test.ts
+++ b/packages/cli-ui/src/telemetry-command.test.ts
@@ -71,6 +71,21 @@ describe("automatic suppression rendering", () => {
     expect(out).not.toContain("did not turn it off");
   });
 
+  it("a persisted off state does NOT offer OPENA2A_TELEMETRY=on", () => {
+    // Precedence rule 2: a config-file opt-out is re-enabled by nothing,
+    // including OPENA2A_TELEMETRY=on. This hint only ever prints for an
+    // off-state that came from that file, so offering the env var sent the
+    // user round a loop landing on an identical, unexplained "off".
+    const out = runTelemetryCommand("status", makeInput({ enabled: false }));
+    expect(out).not.toContain("OPENA2A_TELEMETRY=on");
+  });
+
+  it("an on state still offers OPENA2A_TELEMETRY=off (that direction works)", () => {
+    const out = runTelemetryCommand("status", makeInput({ enabled: true }));
+    expect(out).toContain("dvaa telemetry off");
+    expect(out).toContain("OPENA2A_TELEMETRY=off");
+  });
+
   it("explains OPENA2A_TELEMETRY=off instead of suggesting a toggle it overrides", () => {
     // `telemetry on` cannot survive an env opt-out — env-off always wins —
     // so the old hint sent the user round a loop that always landed on off.
@@ -96,7 +111,13 @@ describe("automatic suppression rendering", () => {
   });
 
   it("every suppression reason renders a remedy", () => {
-    // Fails by construction if a reason is added without a remedy.
+    // NOT a fail-by-construction guard, despite appearances: the reason list
+    // below is a hardcoded literal, so a new union member does not extend it.
+    // The actual guard is the compiler — `SUPPRESSION_LABEL` /
+    // `SUPPRESSION_EXPLANATION` are Record<SuppressionReason, string> and
+    // `suppressionRemedy` is a switch with no default, so a fourth reason
+    // fails tsc at all three sites. This is a characterization test: it pins
+    // the rendered shape of the three reasons that exist today.
     for (const reason of ["ci", "do-not-track", "env-opt-out"] as const) {
       const out = runTelemetryCommand("status", makeInput({ enabled: false, suppressedBy: reason }));
       expect(out, `reason=${reason}`).toMatch(/override:|to re-enable:/);
@@ -129,9 +150,19 @@ describe("runTelemetryCommand", () => {
   });
 
   it("status hint suggests 'on' when telemetry is off (papercut from DVAA 0.9.0 release-test)", () => {
+    // The original papercut (#170) was hint DIRECTION: status suggested
+    // turning telemetry *off* when it was already off. That guard is intact —
+    // `dvaa telemetry on` is still suggested, and no "off" affordance appears.
+    //
+    // The `OPENA2A_TELEMETRY=on` assertion that used to live here was
+    // incidental to that fix (the env hint merely mirrored the flip) and was
+    // wrong: this hint only prints for an off-state that came from the config
+    // file, and precedence rule 2 says nothing re-enables that — including
+    // OPENA2A_TELEMETRY=on. Following it landed on an identical, unexplained
+    // "off". Asserting its absence now.
     const out = runTelemetryCommand("status", makeInput({ enabled: false }));
     expect(out).toContain("dvaa telemetry on");
-    expect(out).toContain("OPENA2A_TELEMETRY=on");
+    expect(out).not.toContain("OPENA2A_TELEMETRY=on");
     expect(out).not.toContain("dvaa telemetry off'");
     expect(out).not.toContain("OPENA2A_TELEMETRY=off");
   });

--- a/packages/cli-ui/src/telemetry-command.test.ts
+++ b/packages/cli-ui/src/telemetry-command.test.ts
@@ -6,21 +6,65 @@ beforeEach(() => {
   chalk.level = 0;
 });
 
-function makeInput(overrides: { enabled?: boolean } = {}) {
+function makeInput(
+  overrides: { enabled?: boolean; suppressedBy?: "ci" | "do-not-track" } = {},
+) {
   let enabled = overrides.enabled ?? true;
   return {
     tool: "dvaa",
     setOptOut: vi.fn((v: boolean) => {
-      enabled = v;
+      // Mirrors the real SDK: under automatic suppression the preference is
+      // persisted but the effective state stays off.
+      enabled = overrides.suppressedBy ? false : v;
     }),
     getStatus: () => ({
       enabled,
       policyURL: "https://opena2a.org/telemetry",
       configPath: "/home/user/.config/opena2a/telemetry.json",
       installId: "abc-123",
+      ...(overrides.suppressedBy ? { suppressedBy: overrides.suppressedBy } : {}),
     }),
   };
 }
+
+describe("automatic suppression rendering", () => {
+  // The dead end this guards: under CI suppression the old renderer printed
+  // `state: off` with a `dvaa telemetry on` hint. That hint writes
+  // enabled=true, changes nothing, and the next status still says off.
+  it("explains CI suppression instead of suggesting a toggle that cannot work", () => {
+    const out = runTelemetryCommand("status", makeInput({ enabled: false, suppressedBy: "ci" }));
+    expect(out).toContain("CI environment detected");
+    expect(out).toContain("you did not turn it off");
+    expect(out).toContain("OPENA2A_TELEMETRY=on dvaa <cmd>");
+    // The broken hint must not appear.
+    expect(out).not.toContain("dvaa telemetry on'");
+  });
+
+  it("explains DO_NOT_TRACK suppression", () => {
+    const out = runTelemetryCommand(
+      "status",
+      makeInput({ enabled: false, suppressedBy: "do-not-track" }),
+    );
+    expect(out).toContain("DO_NOT_TRACK is set");
+    expect(out).not.toContain("dvaa telemetry on'");
+  });
+
+  it("does not contradict itself when 'on' is run under suppression", () => {
+    const out = runTelemetryCommand("on", makeInput({ enabled: false, suppressedBy: "ci" }));
+    expect(out).toContain("Preference saved");
+    expect(out).toContain("stays off");
+    expect(out).toContain("state:       off");
+    // The old header claimed "Telemetry enabled" directly above `state: off`.
+    expect(out).not.toContain("Telemetry enabled for dvaa.");
+  });
+
+  it("a plain off state (user's own choice) keeps the normal toggle hint", () => {
+    const out = runTelemetryCommand("status", makeInput({ enabled: false }));
+    expect(out).toContain("dvaa telemetry on");
+    expect(out).not.toContain("CI environment detected");
+    expect(out).not.toContain("did not turn it off");
+  });
+});
 
 describe("runTelemetryCommand", () => {
   it("status (no action) prints current state and toggle hint", () => {

--- a/packages/cli-ui/src/telemetry-command.test.ts
+++ b/packages/cli-ui/src/telemetry-command.test.ts
@@ -70,6 +70,39 @@ describe("automatic suppression rendering", () => {
     expect(out).not.toContain("CI environment detected");
     expect(out).not.toContain("did not turn it off");
   });
+
+  it("explains OPENA2A_TELEMETRY=off instead of suggesting a toggle it overrides", () => {
+    // `telemetry on` cannot survive an env opt-out — env-off always wins —
+    // so the old hint sent the user round a loop that always landed on off.
+    const out = runTelemetryCommand(
+      "status",
+      makeInput({ enabled: false, suppressedBy: "env-opt-out" }),
+    );
+    expect(out).toContain("OPENA2A_TELEMETRY=off is set");
+    expect(out).toContain("overrides the saved preference");
+    expect(out).toContain("unset OPENA2A_TELEMETRY");
+    expect(out).not.toContain("dvaa telemetry on'");
+    expect(out).not.toContain("you did not turn it off");
+  });
+
+  it("'on' under an env opt-out explains why it did not take effect", () => {
+    // Regression guard: this path printed "Preference saved, but telemetry
+    // stays off for dvaa here." with no reason and no remedy — the word
+    // "here" promising an explanation that never came.
+    const out = runTelemetryCommand("on", makeInput({ enabled: false, suppressedBy: "env-opt-out" }));
+    expect(out).toContain("Preference saved");
+    expect(out).toContain("OPENA2A_TELEMETRY=off is set");
+    expect(out).toContain("unset OPENA2A_TELEMETRY");
+  });
+
+  it("every suppression reason renders a remedy", () => {
+    // Fails by construction if a reason is added without a remedy.
+    for (const reason of ["ci", "do-not-track", "env-opt-out"] as const) {
+      const out = runTelemetryCommand("status", makeInput({ enabled: false, suppressedBy: reason }));
+      expect(out, `reason=${reason}`).toMatch(/override:|to re-enable:/);
+      expect(out, `reason=${reason}`).not.toContain("dvaa telemetry on'");
+    }
+  });
 });
 
 describe("runTelemetryCommand", () => {

--- a/packages/cli-ui/src/telemetry-command.ts
+++ b/packages/cli-ui/src/telemetry-command.ts
@@ -106,14 +106,24 @@ function renderStatus(
     );
   } else if (framing === "current") {
     // Suggest the OPPOSITE of the current state — telling someone whose
-    // telemetry is already off how to "turn it off" is useless. The
-    // env-var hint mirrors the same flip.
-    const nextAction = status.enabled ? "off" : "on";
-    const envOverride = status.enabled ? "OPENA2A_TELEMETRY=off" : "OPENA2A_TELEMETRY=on";
-    lines.push(
-      "",
-      chalk.dim(`  toggle: '${input.tool} telemetry ${nextAction}'  or  ${envOverride}`),
-    );
+    // telemetry is already off how to "turn it off" is useless.
+    //
+    // The env-var hint does NOT mirror that flip, because the two
+    // directions are not symmetric. OPENA2A_TELEMETRY=off disables from
+    // any state, so it is a valid partner to `telemetry off`. But
+    // OPENA2A_TELEMETRY=on cannot re-enable a persisted opt-out —
+    // precedence rule 2 says the config file wins — and this hint only
+    // ever prints for an off-state that came from that file. Offering it
+    // sent the user round a loop landing on an identical, unexplained
+    // "off". `telemetry on` alone is the remedy that works here.
+    if (status.enabled) {
+      lines.push(
+        "",
+        chalk.dim(`  toggle: '${input.tool} telemetry off'  or  OPENA2A_TELEMETRY=off`),
+      );
+    } else {
+      lines.push("", chalk.dim(`  toggle: '${input.tool} telemetry on'`));
+    }
   }
   return lines.join("\n");
 }

--- a/packages/cli-ui/src/telemetry-command.ts
+++ b/packages/cli-ui/src/telemetry-command.ts
@@ -75,20 +75,36 @@ function renderStatus(
 ): string {
   const status = input.getStatus();
   const stateWord = status.enabled ? chalk.green("on") : chalk.dim("off");
+  // `telemetry on` under automatic suppression persists the preference but
+  // does not change the effective state. Claiming "enabled" above a
+  // `state: off` line is a straight contradiction — report what the write
+  // actually achieved.
   const header =
     framing === "enabled"
-      ? chalk.green(`Telemetry enabled for ${input.tool}.`)
+      ? status.enabled
+        ? chalk.green(`Telemetry enabled for ${input.tool}.`)
+        : chalk.dim(`Preference saved, but telemetry stays off for ${input.tool} here.`)
       : framing === "disabled"
         ? chalk.dim(`Telemetry disabled for ${input.tool}.`)
         : chalk.bold(`${input.tool} telemetry`);
   const lines = [
     header,
-    `  state:       ${stateWord}`,
+    `  state:       ${stateWord}${suppressionNote(status.suppressedBy)}`,
     `  install_id:  ${chalk.dim(status.installId)}`,
     `  config:      ${chalk.dim(status.configPath)}`,
     `  policy:      ${chalk.cyan(status.policyURL)}`,
   ];
-  if (framing === "current") {
+  if (status.suppressedBy) {
+    // Automatic suppression re-applies on every load, so `telemetry on`
+    // would write enabled=true and change nothing observable. Say what is
+    // actually happening and give the override that does work, rather than
+    // sending someone round a loop that always lands back on "off".
+    lines.push(
+      "",
+      chalk.dim(`  ${suppressionExplanation(status.suppressedBy)}`),
+      chalk.dim(`  override: OPENA2A_TELEMETRY=on ${input.tool} <cmd>`),
+    );
+  } else if (framing === "current") {
     // Suggest the OPPOSITE of the current state — telling someone whose
     // telemetry is already off how to "turn it off" is useless. The
     // env-var hint mirrors the same flip.
@@ -100,4 +116,16 @@ function renderStatus(
     );
   }
   return lines.join("\n");
+}
+
+function suppressionNote(reason: "ci" | "do-not-track" | undefined): string {
+  if (!reason) return "";
+  const label = reason === "ci" ? "CI environment detected" : "DO_NOT_TRACK is set";
+  return chalk.dim(` (${label})`);
+}
+
+function suppressionExplanation(reason: "ci" | "do-not-track"): string {
+  return reason === "ci"
+    ? "Telemetry is suppressed automatically in CI — you did not turn it off."
+    : "Telemetry is suppressed automatically because DO_NOT_TRACK is set.";
 }

--- a/packages/cli-ui/src/telemetry-command.ts
+++ b/packages/cli-ui/src/telemetry-command.ts
@@ -95,14 +95,14 @@ function renderStatus(
     `  policy:      ${chalk.cyan(status.policyURL)}`,
   ];
   if (status.suppressedBy) {
-    // Automatic suppression re-applies on every load, so `telemetry on`
-    // would write enabled=true and change nothing observable. Say what is
-    // actually happening and give the override that does work, rather than
-    // sending someone round a loop that always lands back on "off".
+    // Suppression re-applies on every load, so `telemetry on` would write
+    // enabled=true and change nothing observable. Say what is actually
+    // happening and give the remedy that does work, rather than sending
+    // someone round a loop that always lands back on "off".
     lines.push(
       "",
       chalk.dim(`  ${suppressionExplanation(status.suppressedBy)}`),
-      chalk.dim(`  override: OPENA2A_TELEMETRY=on ${input.tool} <cmd>`),
+      chalk.dim(`  ${suppressionRemedy(status.suppressedBy, input.tool)}`),
     );
   } else if (framing === "current") {
     // Suggest the OPPOSITE of the current state — telling someone whose
@@ -125,7 +125,18 @@ function suppressionNote(reason: "ci" | "do-not-track" | undefined): string {
 }
 
 function suppressionExplanation(reason: "ci" | "do-not-track"): string {
+  // CI is an environmental fact the user did not choose, so say so.
+  // DO_NOT_TRACK *is* the user's own choice — telling them "you did not
+  // turn it off" would be wrong.
   return reason === "ci"
     ? "Telemetry is suppressed automatically in CI — you did not turn it off."
-    : "Telemetry is suppressed automatically because DO_NOT_TRACK is set.";
+    : "DO_NOT_TRACK is set in this environment, so telemetry stays off.";
+}
+
+function suppressionRemedy(reason: "ci" | "do-not-track", tool: string): string {
+  // OPENA2A_TELEMETRY=on deliberately does NOT override DO_NOT_TRACK, so
+  // offering it here would be another dead end.
+  return reason === "ci"
+    ? `override: OPENA2A_TELEMETRY=on ${tool} <cmd>`
+    : "to re-enable: unset DO_NOT_TRACK";
 }

--- a/packages/cli-ui/src/telemetry-command.ts
+++ b/packages/cli-ui/src/telemetry-command.ts
@@ -118,25 +118,42 @@ function renderStatus(
   return lines.join("\n");
 }
 
-function suppressionNote(reason: "ci" | "do-not-track" | undefined): string {
+type SuppressionReason = NonNullable<TelemetryStatusLike["suppressedBy"]>;
+
+const SUPPRESSION_LABEL: Record<SuppressionReason, string> = {
+  ci: "CI environment detected",
+  "do-not-track": "DO_NOT_TRACK is set",
+  "env-opt-out": "OPENA2A_TELEMETRY=off is set",
+};
+
+// CI is an environmental fact the user did not choose, so say so. The other
+// two ARE the user's own doing — telling them "you did not turn it off"
+// would be wrong.
+const SUPPRESSION_EXPLANATION: Record<SuppressionReason, string> = {
+  ci: "Telemetry is suppressed automatically in CI — you did not turn it off.",
+  "do-not-track": "DO_NOT_TRACK is set in this environment, so telemetry stays off.",
+  "env-opt-out": "OPENA2A_TELEMETRY=off is set in this environment, which overrides the saved preference.",
+};
+
+// Each remedy must actually work for its reason. OPENA2A_TELEMETRY=on does
+// not override DO_NOT_TRACK, and no `telemetry on` survives an env opt-out —
+// offering either in the wrong place is how the dead ends got here.
+function suppressionRemedy(reason: SuppressionReason, tool: string): string {
+  switch (reason) {
+    case "ci":
+      return `override: OPENA2A_TELEMETRY=on ${tool} <cmd>`;
+    case "do-not-track":
+      return "to re-enable: unset DO_NOT_TRACK";
+    case "env-opt-out":
+      return "to re-enable: unset OPENA2A_TELEMETRY (or set it to 'on')";
+  }
+}
+
+function suppressionNote(reason: SuppressionReason | undefined): string {
   if (!reason) return "";
-  const label = reason === "ci" ? "CI environment detected" : "DO_NOT_TRACK is set";
-  return chalk.dim(` (${label})`);
+  return chalk.dim(` (${SUPPRESSION_LABEL[reason]})`);
 }
 
-function suppressionExplanation(reason: "ci" | "do-not-track"): string {
-  // CI is an environmental fact the user did not choose, so say so.
-  // DO_NOT_TRACK *is* the user's own choice — telling them "you did not
-  // turn it off" would be wrong.
-  return reason === "ci"
-    ? "Telemetry is suppressed automatically in CI — you did not turn it off."
-    : "DO_NOT_TRACK is set in this environment, so telemetry stays off.";
-}
-
-function suppressionRemedy(reason: "ci" | "do-not-track", tool: string): string {
-  // OPENA2A_TELEMETRY=on deliberately does NOT override DO_NOT_TRACK, so
-  // offering it here would be another dead end.
-  return reason === "ci"
-    ? `override: OPENA2A_TELEMETRY=on ${tool} <cmd>`
-    : "to re-enable: unset DO_NOT_TRACK";
+function suppressionExplanation(reason: SuppressionReason): string {
+  return SUPPRESSION_EXPLANATION[reason];
 }

--- a/packages/cli-ui/src/version-line.ts
+++ b/packages/cli-ui/src/version-line.ts
@@ -9,6 +9,12 @@ import chalk from "chalk";
 export interface TelemetryStatusLike {
   enabled: boolean;
   policyURL: string;
+  /**
+   * Set by @opena2a/telemetry when telemetry is off because of the
+   * environment (CI / DO_NOT_TRACK) rather than a user choice. Optional so
+   * this stays structurally compatible with older SDK versions.
+   */
+  suppressedBy?: "ci" | "do-not-track";
 }
 
 export interface VersionLineInput {

--- a/packages/cli-ui/src/version-line.ts
+++ b/packages/cli-ui/src/version-line.ts
@@ -10,11 +10,15 @@ export interface TelemetryStatusLike {
   enabled: boolean;
   policyURL: string;
   /**
-   * Set by @opena2a/telemetry when telemetry is off because of the
-   * environment (CI / DO_NOT_TRACK) rather than a user choice. Optional so
-   * this stays structurally compatible with older SDK versions.
+   * Set by @opena2a/telemetry when telemetry is off for a reason the
+   * ordinary `<tool> telemetry on` toggle cannot undo — the environment
+   * (CI / DO_NOT_TRACK) or an `OPENA2A_TELEMETRY=off` override. Absent for
+   * a persisted `telemetry off`, where the toggle does work.
+   *
+   * Optional, and structurally typed rather than imported, so this stays
+   * compatible with older SDK versions that never set it.
    */
-  suppressedBy?: "ci" | "do-not-track";
+  suppressedBy?: "ci" | "do-not-track" | "env-opt-out";
 }
 
 export interface VersionLineInput {

--- a/packages/telemetry/CHANGELOG.md
+++ b/packages/telemetry/CHANGELOG.md
@@ -38,10 +38,16 @@
   CI-labeled population — the bulk of it, not the whole class.
 
 - **`status()` now reports *why* telemetry is off.** New optional
-  `suppressedBy: "ci" | "do-not-track"` on `Status`, set only when the
-  environment (not the user) is the cause — a user who ran `telemetry off`
-  is never told CI did it. The field is omitted entirely when nothing
-  suppressed, so existing consumers are unaffected.
+  `suppressedBy: "ci" | "do-not-track" | "env-opt-out"` on `Status` (and the
+  `SuppressionReason` type is exported from the package root), set whenever
+  the reason is one the ordinary `<tool> telemetry on` toggle cannot undo.
+
+  A persisted `telemetry off` deliberately carries **no** reason code: there
+  the toggle works, so a plain hint is the better affordance, and attributing
+  it to the environment would tell the user something untrue about their own
+  choice. Attribution is precedence-ordered, so an `OPENA2A_TELEMETRY=off`
+  inside CI reports `env-opt-out`, never `ci`. The field is omitted entirely
+  when nothing suppressed, so existing consumers are unaffected.
 
   `setOptOut()` now returns the **effective** state rather than the flag it
   just wrote. Previously `telemetry on` inside CI persisted `enabled: true`,

--- a/packages/telemetry/CHANGELOG.md
+++ b/packages/telemetry/CHANGELOG.md
@@ -5,22 +5,37 @@
 ### Added
 
 - **Telemetry is now suppressed automatically in CI and under `DO_NOT_TRACK`.**
-  New `isCI()` and `doNotTrack()` helpers; `loadConfig()` returns
-  `enabled: false` when either fires. An explicit `OPENA2A_TELEMETRY=on`
-  overrides the automatic suppressions (so our own e2e can exercise the real
-  ingest path), but never overrides a deliberate `telemetry off` in the config
-  file. Suppression is computed per-invocation and is never persisted — the
-  config file records the user's choice, not where the process ran.
+  New `isCI()`, `doNotTrack()` and `autoSuppressionReason()` helpers;
+  `loadConfig()` returns `enabled: false` when either fires. Suppression is
+  computed per-invocation and is never persisted — the config file records the
+  user's choice, not where the process ran.
+
+  The two reasons are deliberately **not peers**. `DO_NOT_TRACK` is a
+  deliberate user intent and sits in the same tier as `telemetry off`:
+  **nothing overrides it**. CI-ness is a fact about the machine rather than a
+  choice, so an explicit `OPENA2A_TELEMETRY=on` overrides *CI detection only*
+  — letting our own e2e exercise the real ingest path without allowing a
+  Makefile, Dockerfile `ENV`, or org-wide CI config to silently defeat a
+  privacy signal a user set once in their shell profile.
+
+  `OPENA2A_TELEMETRY` opt-out values are now trimmed before comparison, so
+  `OPENA2A_TELEMETRY="off "` (routine in `.env` files, compose YAML and `$(cmd)`
+  substitution) disables rather than silently failing open.
 
   **Why this is a data-integrity fix, not a privacy nicety.** `install_id` is
   derived from the OS machine-id and falls back to a hash of the hostname when
-  that probe fails. CI runners are ephemeral containers: no machine-id, fresh
-  random hostname per job. Every CI run therefore minted a brand-new
-  `install_id` and was counted as a distinct install and a distinct active
-  user. Adoption metrics tracked our own build frequency rather than real
-  usage, and the error compounded with every added workflow. This is a
-  prerequisite for reporting a truthful install count at all — see the
-  Registry-side note below.
+  that probe fails. CI runners are provisioned fresh per job, so the machine-id
+  (or hostname fallback) differs on every run — a CI run typically minted a
+  brand-new `install_id` and was counted as a distinct install and a distinct
+  active user. Adoption metrics tracked our own build frequency rather than
+  real usage, and the error compounded with every added workflow.
+
+  Scope, stated honestly: `CI` is a proxy for ephemerality, not a synonym. A
+  throwaway `docker run`, a devcontainer rebuild or a sandboxed `npx` hits the
+  same fallback path while setting none of the detected variables, and
+  self-hosted/reused runners have a stable machine-id so they collapse onto one
+  identity instead (a different distortion, not inflation). This covers the
+  CI-labeled population — the bulk of it, not the whole class.
 
 - **`status()` now reports *why* telemetry is off.** New optional
   `suppressedBy: "ci" | "do-not-track"` on `Status`, set only when the
@@ -40,8 +55,10 @@
   called with `start`, `command`, `error`), so the dashboard's Installs column
   reads a permanent 0. Simply dropping that filter would have counted CI
   runners and ephemeral containers as installs — replacing a visible zero with
-  a plausible, wrong number. Landing CI suppression first is what makes the
-  Registry-side fix safe.
+  a plausible, wrong number. This change removes the CI-labeled share of that
+  inflation; the non-CI ephemeral-container share (see Scope above) remains and
+  must be addressed before a per-tool install count can be published as
+  measured.
 
 ### Fixed
 

--- a/packages/telemetry/CHANGELOG.md
+++ b/packages/telemetry/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+### Added
+
+- **Telemetry is now suppressed automatically in CI and under `DO_NOT_TRACK`.**
+  New `isCI()` and `doNotTrack()` helpers; `loadConfig()` returns
+  `enabled: false` when either fires. An explicit `OPENA2A_TELEMETRY=on`
+  overrides the automatic suppressions (so our own e2e can exercise the real
+  ingest path), but never overrides a deliberate `telemetry off` in the config
+  file. Suppression is computed per-invocation and is never persisted — the
+  config file records the user's choice, not where the process ran.
+
+  **Why this is a data-integrity fix, not a privacy nicety.** `install_id` is
+  derived from the OS machine-id and falls back to a hash of the hostname when
+  that probe fails. CI runners are ephemeral containers: no machine-id, fresh
+  random hostname per job. Every CI run therefore minted a brand-new
+  `install_id` and was counted as a distinct install and a distinct active
+  user. Adoption metrics tracked our own build frequency rather than real
+  usage, and the error compounded with every added workflow. This is a
+  prerequisite for reporting a truthful install count at all — see the
+  Registry-side note below.
+
+  Registry context: per-tool installs are counted as
+  `COUNT(DISTINCT install_id) FILTER (WHERE event = 'install')`, and no
+  `install` event has ever been emitted by this SDK (`buildEvent` is only
+  called with `start`, `command`, `error`), so the dashboard's Installs column
+  reads a permanent 0. Simply dropping that filter would have counted CI
+  runners and ephemeral containers as installs — replacing a visible zero with
+  a plausible, wrong number. Landing CI suppression first is what makes the
+  Registry-side fix safe.
+
 ### Fixed
 
 - **`DEFAULT_ENDPOINT` now points at the canonical ingest path** —

--- a/packages/telemetry/CHANGELOG.md
+++ b/packages/telemetry/CHANGELOG.md
@@ -22,6 +22,18 @@
   prerequisite for reporting a truthful install count at all — see the
   Registry-side note below.
 
+- **`status()` now reports *why* telemetry is off.** New optional
+  `suppressedBy: "ci" | "do-not-track"` on `Status`, set only when the
+  environment (not the user) is the cause — a user who ran `telemetry off`
+  is never told CI did it. The field is omitted entirely when nothing
+  suppressed, so existing consumers are unaffected.
+
+  `setOptOut()` now returns the **effective** state rather than the flag it
+  just wrote. Previously `telemetry on` inside CI persisted `enabled: true`,
+  printed "Telemetry enabled", and then the very next `telemetry status`
+  printed "off" — a dead end with nothing explaining the flip, since
+  automatic suppression re-applies on every load.
+
   Registry context: per-tool installs are counted as
   `COUNT(DISTINCT install_id) FILTER (WHERE event = 'install')`, and no
   `install` event has ever been emitted by this SDK (`buildEvent` is only

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -90,6 +90,22 @@ To exercise the real ingest path from your own CI, set an explicit
 `OPENA2A_TELEMETRY=on` (also `1`, `true`, `yes`). That overrides the automatic
 suppressions only — it can **not** re-enable a deliberate `telemetry off`.
 
+`status()` reports which suppression is in force via the optional
+`suppressedBy: "ci" | "do-not-track"` field, so a CLI can explain the state
+rather than implying the user turned telemetry off:
+
+```
+  state:       off (CI environment detected)
+  ...
+  Telemetry is suppressed automatically in CI — you did not turn it off.
+  override: OPENA2A_TELEMETRY=on opena2a <cmd>
+```
+
+The field is absent when nothing suppressed, and is never set when the user
+opted out themselves. Note that `setOptOut(true)` under suppression returns
+`enabled: false` — it reports the effective state, not the flag it wrote,
+because a config flip does not survive automatic suppression.
+
 ## Audit
 
 Runtime audit of every payload:

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -21,7 +21,7 @@ await tele.track("scan", { success: true, durationMs: 312 });
 tele.error("scan", "HMA_TIMEOUT");
 ```
 
-- `init()` loads opt-out config from `~/.config/opena2a/telemetry.json` and `OPENA2A_TELEMETRY` env var. **No first-run banner is emitted** (deliberate — see disclosure surfaces below).
+- `init()` loads opt-out config from `~/.config/opena2a/telemetry.json` and `OPENA2A_TELEMETRY` env var, and suppresses telemetry entirely in CI or under `DO_NOT_TRACK` (see [automatic suppression](#automatic-suppression)). **No first-run banner is emitted** (deliberate — see disclosure surfaces below).
 - `start()` fires a `start` event.
 - `track(name, fields?)` fires a `command` event with the command name and optional `success` / `durationMs`.
 - `error(name, code)` fires an `error` event with the failure code.
@@ -65,6 +65,30 @@ Three ways to disable, in precedence order:
 1. **Per-invocation** — `OPENA2A_TELEMETRY=off` (also `0`, `false`, `no`).
 2. **Persistent** — `<tool> telemetry off` (writes to `~/.config/opena2a/telemetry.json`).
 3. **Direct edit** — `~/.config/opena2a/telemetry.json` → `{"enabled": false}`.
+
+## Automatic suppression
+
+Telemetry is **off by default** in two cases, with no configuration:
+
+- **CI / build environments** — detected via `CI`, `CONTINUOUS_INTEGRATION`, or a
+  vendor marker (`GITHUB_ACTIONS`, `GITLAB_CI`, `CIRCLECI`, `BUILDKITE`, `JENKINS_URL`,
+  `TF_BUILD`, `VERCEL`, `NETLIFY`, and others). `CI=false` / `CI=0` is honored as
+  "not CI".
+- **`DO_NOT_TRACK`** — the [cross-vendor convention](https://consoledonottrack.com/).
+  Any value other than `0` / `false` / `no` opts out.
+
+Why: `install_id` is derived from the OS machine-id, falling back to a hash of the
+hostname when that probe fails. CI runners are ephemeral — no machine-id, fresh
+hostname per job — so **every CI run minted a new `install_id` and was counted as a
+distinct install and active user**. Left unsuppressed, adoption metrics grow with
+build frequency rather than with real usage. Bots are not users.
+
+Suppression here is computed per-invocation and is **never written to the config
+file**: the file records what the user chose, not where the process happened to run.
+
+To exercise the real ingest path from your own CI, set an explicit
+`OPENA2A_TELEMETRY=on` (also `1`, `true`, `yes`). That overrides the automatic
+suppressions only — it can **not** re-enable a deliberate `telemetry off`.
 
 ## Audit
 

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -78,17 +78,35 @@ Telemetry is **off by default** in two cases, with no configuration:
   Any value other than `0` / `false` / `no` opts out.
 
 Why: `install_id` is derived from the OS machine-id, falling back to a hash of the
-hostname when that probe fails. CI runners are ephemeral — no machine-id, fresh
-hostname per job — so **every CI run minted a new `install_id` and was counted as a
-distinct install and active user**. Left unsuppressed, adoption metrics grow with
-build frequency rather than with real usage. Bots are not users.
+hostname when that probe fails. CI runners are provisioned fresh for each job, so
+the machine-id (or the hostname fallback) differs on every run — **a CI run
+typically minted a new `install_id` and was counted as a distinct install and
+active user**. Left unsuppressed, adoption metrics grow with build frequency rather
+than with real usage. Bots are not users.
 
-Suppression here is computed per-invocation and is **never written to the config
-file**: the file records what the user chose, not where the process happened to run.
+Two honest caveats. Self-hosted or reused runners have a *stable* machine-id, so
+they collapse onto one persistent identity rather than inflating — a different
+distortion, not this one. And `CI` is a proxy for ephemerality, not a synonym: a
+throwaway `docker run`, a devcontainer rebuild, or a sandboxed `npx` hits the same
+fallback path while setting none of these variables. This suppression covers the
+CI-labeled population, which is the bulk of it, not the whole class.
+
+The two reasons are **not peers**:
+
+- `DO_NOT_TRACK` is a deliberate user intent, in the same tier as `telemetry off`.
+  **Nothing overrides it** — see below.
+- CI-ness is a fact about the machine, not a choice, so an explicit opt-in may
+  override it.
+
+Suppression is computed per-invocation and is **never written to the config file**:
+the file records what the user chose, not where the process happened to run.
 
 To exercise the real ingest path from your own CI, set an explicit
-`OPENA2A_TELEMETRY=on` (also `1`, `true`, `yes`). That overrides the automatic
-suppressions only — it can **not** re-enable a deliberate `telemetry off`.
+`OPENA2A_TELEMETRY=on` (also `1`, `true`, `yes`). That overrides **CI detection
+only**. It can not re-enable a deliberate `telemetry off`, and it can not override
+`DO_NOT_TRACK` — otherwise any Makefile, Dockerfile `ENV`, or org-wide CI config
+exporting it would silently defeat a privacy signal the user set once in their
+shell profile and never revisited.
 
 `status()` reports which suppression is in force via the optional
 `suppressedBy: "ci" | "do-not-track"` field, so a CLI can explain the state
@@ -99,6 +117,15 @@ rather than implying the user turned telemetry off:
   ...
   Telemetry is suppressed automatically in CI — you did not turn it off.
   override: OPENA2A_TELEMETRY=on opena2a <cmd>
+```
+
+Under `DO_NOT_TRACK` the remedy differs, because the opt-in does not override it:
+
+```
+  state:       off (DO_NOT_TRACK is set)
+  ...
+  DO_NOT_TRACK is set in this environment, so telemetry stays off.
+  to re-enable: unset DO_NOT_TRACK
 ```
 
 The field is absent when nothing suppressed, and is never set when the user

--- a/packages/telemetry/src/config.test.ts
+++ b/packages/telemetry/src/config.test.ts
@@ -157,10 +157,39 @@ describe("loadConfig automatic suppression", () => {
     },
   );
 
-  it("OPENA2A_TELEMETRY=on re-enables under DO_NOT_TRACK", () => {
+  it("OPENA2A_TELEMETRY=on does NOT override DO_NOT_TRACK", () => {
+    // DO_NOT_TRACK is a deliberate user intent, not an environmental fact.
+    // A wrapper script, Makefile, Dockerfile ENV or org-wide CI config that
+    // exports OPENA2A_TELEMETRY=on must never silently re-enable tracking
+    // for a user who set DO_NOT_TRACK in their shell profile and never
+    // touched OPENA2A_TELEMETRY at all.
     process.env.DO_NOT_TRACK = "1";
     process.env.OPENA2A_TELEMETRY = "on";
-    expect(loadConfig().config.enabled).toBe(true);
+    expect(loadConfig().config.enabled).toBe(false);
+  });
+
+  it("DO_NOT_TRACK still wins when CI is also present and opt-in is set", () => {
+    process.env.CI = "true";
+    process.env.DO_NOT_TRACK = "1";
+    process.env.OPENA2A_TELEMETRY = "on";
+    const { config, suppressedBy } = loadConfig();
+    expect(config.enabled).toBe(false);
+    expect(suppressedBy).toBe("do-not-track");
+  });
+
+  it.each([["off "], [" off"], ["off\n"], ["\toff\t"]])(
+    "OPENA2A_TELEMETRY=%j (untrimmed) still disables",
+    (val) => {
+      // Trailing whitespace/newlines are routine in .env files, compose
+      // YAML and $(cmd) substitution. A privacy control must fail closed.
+      process.env.OPENA2A_TELEMETRY = val;
+      expect(loadConfig().config.enabled).toBe(false);
+    },
+  );
+
+  it("DO_NOT_TRACK with surrounding whitespace still opts out", () => {
+    process.env.DO_NOT_TRACK = " 1 ";
+    expect(loadConfig().config.enabled).toBe(false);
   });
 
   it("a deliberate file opt-out still wins over env=on in CI", () => {

--- a/packages/telemetry/src/config.test.ts
+++ b/packages/telemetry/src/config.test.ts
@@ -2,11 +2,14 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { loadConfig, setEnabled, configPaths, endpointURL, debugPrintEnabled, DEFAULT_ENDPOINT } from "./config.js";
+import { loadConfig, setEnabled, configPaths, endpointURL, debugPrintEnabled, isCI, doNotTrack, DEFAULT_ENDPOINT } from "./config.js";
+import { scrubSuppressionEnv, restoreSuppressionEnv, type SavedEnv } from "./test-support.js";
 
 let tmpHome: string;
+let savedEnv: SavedEnv;
 
 beforeEach(() => {
+  savedEnv = scrubSuppressionEnv();
   tmpHome = mkdtempSync(join(tmpdir(), "opena2a-telem-"));
   process.env.XDG_CONFIG_HOME = tmpHome;
   delete process.env.OPENA2A_TELEMETRY;
@@ -15,6 +18,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  restoreSuppressionEnv(savedEnv);
   rmSync(tmpHome, { recursive: true, force: true });
   delete process.env.XDG_CONFIG_HOME;
 });
@@ -76,6 +80,120 @@ describe("loadConfig", () => {
     const result = loadConfig();
     expect(result.config.enabled).toBe(true);
     expect(result.config.installId).toBeTruthy();
+  });
+});
+
+describe("isCI", () => {
+  it("is false on a clean environment", () => {
+    expect(isCI()).toBe(false);
+  });
+
+  it.each([["true"], ["1"], ["yes"], ["anything"]])("CI=%s is CI", (val) => {
+    process.env.CI = val;
+    expect(isCI()).toBe(true);
+  });
+
+  it.each([["false"], ["0"], ["no"], [""]])("CI=%s is not CI", (val) => {
+    process.env.CI = val;
+    expect(isCI()).toBe(false);
+  });
+
+  it.each([
+    ["GITHUB_ACTIONS"],
+    ["GITLAB_CI"],
+    ["CIRCLECI"],
+    ["BUILDKITE"],
+    ["JENKINS_URL"],
+    ["TF_BUILD"],
+    ["VERCEL"],
+  ])("%s presence marks CI even when CI is unset", (key) => {
+    process.env[key] = "true";
+    expect(isCI()).toBe(true);
+  });
+
+  it("reads the passed env rather than process.env", () => {
+    expect(isCI({ CI: "true" } as NodeJS.ProcessEnv)).toBe(true);
+    expect(isCI({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+});
+
+describe("doNotTrack", () => {
+  it.each([["1"], ["true"], ["yes"]])("DO_NOT_TRACK=%s opts out", (val) => {
+    process.env.DO_NOT_TRACK = val;
+    expect(doNotTrack()).toBe(true);
+  });
+
+  it.each([["0"], ["false"], [""]])("DO_NOT_TRACK=%s does not opt out", (val) => {
+    process.env.DO_NOT_TRACK = val;
+    expect(doNotTrack()).toBe(false);
+  });
+
+  it("is false when unset", () => {
+    expect(doNotTrack()).toBe(false);
+  });
+});
+
+describe("loadConfig automatic suppression", () => {
+  // Regression guard for the metric bug this suppression exists to fix:
+  // CI runners are ephemeral (no machine-id, fresh hostname per job), so
+  // every run minted a new install_id and inflated distinct-install and
+  // active-user counts with our own pipelines.
+  it("CI suppresses telemetry despite default-on", () => {
+    process.env.CI = "true";
+    expect(loadConfig().config.enabled).toBe(false);
+  });
+
+  it("DO_NOT_TRACK suppresses telemetry despite default-on", () => {
+    process.env.DO_NOT_TRACK = "1";
+    expect(loadConfig().config.enabled).toBe(false);
+  });
+
+  it.each([["on"], ["1"], ["true"], ["yes"]])(
+    "OPENA2A_TELEMETRY=%s re-enables in CI (escape hatch for our own e2e)",
+    (val) => {
+      process.env.CI = "true";
+      process.env.OPENA2A_TELEMETRY = val;
+      expect(loadConfig().config.enabled).toBe(true);
+    },
+  );
+
+  it("OPENA2A_TELEMETRY=on re-enables under DO_NOT_TRACK", () => {
+    process.env.DO_NOT_TRACK = "1";
+    process.env.OPENA2A_TELEMETRY = "on";
+    expect(loadConfig().config.enabled).toBe(true);
+  });
+
+  it("a deliberate file opt-out still wins over env=on in CI", () => {
+    setEnabled(false);
+    process.env.CI = "true";
+    process.env.OPENA2A_TELEMETRY = "on";
+    expect(loadConfig().config.enabled).toBe(false);
+  });
+
+  it("env=off still wins over env-based re-enable paths", () => {
+    process.env.CI = "true";
+    process.env.OPENA2A_TELEMETRY = "off";
+    expect(loadConfig().config.enabled).toBe(false);
+  });
+
+  it("does not persist CI suppression to the config file", () => {
+    process.env.CI = "true";
+    const { config, paths } = loadConfig();
+    expect(config.enabled).toBe(false);
+    // The file records the user's choice, not where the process ran —
+    // otherwise one CI run would poison a developer's real config.
+    const persisted = JSON.parse(readFileSync(paths.file, "utf8"));
+    expect(persisted.enabled).toBe(true);
+
+    delete process.env.CI;
+    expect(loadConfig().config.enabled).toBe(true);
+  });
+
+  it("still persists a stable install_id while suppressed", () => {
+    process.env.CI = "true";
+    const a = loadConfig().config.installId;
+    const b = loadConfig().config.installId;
+    expect(a).toBe(b);
   });
 });
 

--- a/packages/telemetry/src/config.test.ts
+++ b/packages/telemetry/src/config.test.ts
@@ -135,9 +135,10 @@ describe("doNotTrack", () => {
 
 describe("loadConfig automatic suppression", () => {
   // Regression guard for the metric bug this suppression exists to fix:
-  // CI runners are ephemeral (no machine-id, fresh hostname per job), so
-  // every run minted a new install_id and inflated distinct-install and
-  // active-user counts with our own pipelines.
+  // CI runners are provisioned fresh per job, so the machine-id (or the
+  // hostname fallback) differs every run — a CI run typically minted a new
+  // install_id and inflated distinct-install and active-user counts with
+  // our own pipelines.
   it("CI suppresses telemetry despite default-on", () => {
     process.env.CI = "true";
     expect(loadConfig().config.enabled).toBe(false);
@@ -190,6 +191,28 @@ describe("loadConfig automatic suppression", () => {
   it("DO_NOT_TRACK with surrounding whitespace still opts out", () => {
     process.env.DO_NOT_TRACK = " 1 ";
     expect(loadConfig().config.enabled).toBe(false);
+  });
+
+  it("attributes an env opt-out so a CLI can explain it", () => {
+    // Without a reason code a CLI can only print a bare "off" and suggest
+    // `telemetry on` — which cannot work, since env-off wins outright.
+    process.env.OPENA2A_TELEMETRY = "off";
+    const { config, suppressedBy } = loadConfig();
+    expect(config.enabled).toBe(false);
+    expect(suppressedBy).toBe("env-opt-out");
+  });
+
+  it("env opt-out outranks CI in attribution", () => {
+    process.env.OPENA2A_TELEMETRY = "off";
+    process.env.CI = "true";
+    expect(loadConfig().suppressedBy).toBe("env-opt-out");
+  });
+
+  it("a persisted opt-out gets NO reason code (the plain toggle works there)", () => {
+    setEnabled(false);
+    const { config, suppressedBy } = loadConfig();
+    expect(config.enabled).toBe(false);
+    expect(suppressedBy).toBeNull();
   });
 
   it("a deliberate file opt-out still wins over env=on in CI", () => {

--- a/packages/telemetry/src/config.ts
+++ b/packages/telemetry/src/config.ts
@@ -9,6 +9,33 @@ export const DEFAULT_ENDPOINT = "https://api.oa2a.org/api/v1/telemetry/v1/event"
 const ENV_OPT_OUT = "OPENA2A_TELEMETRY";
 const ENV_ENDPOINT = "OPENA2A_TELEMETRY_URL";
 const ENV_DEBUG = "OPENA2A_TELEMETRY_DEBUG";
+const ENV_DO_NOT_TRACK = "DO_NOT_TRACK";
+
+/**
+ * Vendor markers that indicate a CI/build environment by their mere
+ * presence. `CI` and `CONTINUOUS_INTEGRATION` are handled separately
+ * because they carry a meaningful value (some runners export `CI=false`).
+ */
+const CI_VENDOR_ENV_VARS = [
+  "GITHUB_ACTIONS",
+  "GITLAB_CI",
+  "CIRCLECI",
+  "TRAVIS",
+  "JENKINS_URL",
+  "BUILDKITE",
+  "DRONE",
+  "TEAMCITY_VERSION",
+  "TF_BUILD",
+  "CODEBUILD_BUILD_ID",
+  "APPVEYOR",
+  "BITBUCKET_BUILD_NUMBER",
+  "HEROKU_TEST_RUN_ID",
+  "SEMAPHORE",
+  "WOODPECKER_CI",
+  "NETLIFY",
+  "VERCEL",
+  "CF_PAGES",
+] as const;
 
 export interface TelemetryConfig {
   enabled: boolean;
@@ -163,15 +190,77 @@ function envOptOut(env: NodeJS.ProcessEnv): boolean {
 }
 
 /**
+ * True when the variable is set to something other than an explicit
+ * "no" value. Unset, empty, "0", "false" and "no" all read as false.
+ */
+function envTruthy(v: string | undefined): boolean {
+  if (v === undefined) return false;
+  const lower = v.trim().toLowerCase();
+  if (lower === "") return false;
+  return lower !== "0" && lower !== "false" && lower !== "no";
+}
+
+/**
+ * Explicit opt-IN. Only overrides the automatic suppressions below
+ * (CI / DO_NOT_TRACK) — never a deliberate opt-out held in the config
+ * file. Lets us exercise the real ingest path from our own CI without
+ * reopening the door to every other runner on the internet.
+ */
+function envOptIn(env: NodeJS.ProcessEnv): boolean {
+  const v = env[ENV_OPT_OUT];
+  if (v === undefined) return false;
+  const lower = v.toLowerCase();
+  return lower === "on" || lower === "1" || lower === "true" || lower === "yes";
+}
+
+/**
+ * Detect a CI / build environment.
+ *
+ * Why this exists: install_id is derived from the OS machine-id, and
+ * falls back to a hash of the hostname when that probe fails (see
+ * `deriveInstallId`). CI runners are ephemeral containers — no
+ * machine-id, and a fresh random hostname per job. Every CI run
+ * therefore minted a brand-new install_id and was counted as a distinct
+ * install/active user. With no suppression, adoption metrics measure
+ * our own pipelines more than our users, and the error grows with build
+ * frequency rather than with real usage.
+ *
+ * Bots are not users. Suppressing here (rather than filtering
+ * server-side) means the event is never sent at all — cheaper, and it
+ * keeps the Registry from having to guess which IDs were real.
+ */
+export function isCI(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (envTruthy(env.CI)) return true;
+  if (envTruthy(env.CONTINUOUS_INTEGRATION)) return true;
+  return CI_VENDOR_ENV_VARS.some((key) => envTruthy(env[key]));
+}
+
+/**
+ * Honor the cross-vendor `DO_NOT_TRACK` convention
+ * (https://consoledonottrack.com/). Any value except an explicit
+ * "no" value opts the user out.
+ */
+export function doNotTrack(env: NodeJS.ProcessEnv = process.env): boolean {
+  return envTruthy(env[ENV_DO_NOT_TRACK]);
+}
+
+/**
  * Load (and lazily create) the telemetry config.
  *
  * Precedence for `enabled`:
- *   1. OPENA2A_TELEMETRY env var (always wins, per-invocation)
- *   2. config file `enabled` field
- *   3. default ON (matches spec)
+ *   1. OPENA2A_TELEMETRY set to an off value — always wins.
+ *   2. config file `enabled: false` — a deliberate opt-out; nothing
+ *      re-enables it, including OPENA2A_TELEMETRY=on.
+ *   3. CI environment or DO_NOT_TRACK — suppressed, unless
+ *      OPENA2A_TELEMETRY is set to an explicit on value.
+ *   4. default ON (matches spec).
  *
  * The install_id is always persisted on first call so subsequent runs
  * (and subsequent tools on the same machine) report the same ID.
+ *
+ * Note that CI/DO_NOT_TRACK suppression is computed per-invocation and
+ * deliberately NOT written to the config file: the file records what the
+ * user chose, not where the process happened to run.
  */
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): {
   config: TelemetryConfig;
@@ -182,7 +271,9 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): {
   const installId = file?.installId ?? deriveInstallId();
   const fileEnabled = file?.enabled ?? true;
   const envDisabled = envOptOut(env);
-  const enabled = !envDisabled && fileEnabled;
+  const autoSuppressed = isCI(env) || doNotTrack(env);
+  const enabled =
+    !envDisabled && fileEnabled && (envOptIn(env) || !autoSuppressed);
 
   if (!file || !file.installId || file.enabled === undefined) {
     try {

--- a/packages/telemetry/src/config.ts
+++ b/packages/telemetry/src/config.ts
@@ -17,7 +17,7 @@ const ENV_DO_NOT_TRACK = "DO_NOT_TRACK";
  * presence. `CI` and `CONTINUOUS_INTEGRATION` are handled separately
  * because they carry a meaningful value (some runners export `CI=false`).
  */
-const CI_VENDOR_ENV_VARS = [
+export const CI_VENDOR_ENV_VARS = [
   "GITHUB_ACTIONS",
   "GITLAB_CI",
   "CIRCLECI",
@@ -186,7 +186,10 @@ function deriveInstallId(): string {
 function envOptOut(env: NodeJS.ProcessEnv): boolean {
   const v = env[ENV_OPT_OUT];
   if (v === undefined) return false;
-  const lower = v.toLowerCase();
+  // Trim: trailing whitespace and newlines are routine in .env files,
+  // docker-compose YAML, Dockerfile ENV, and $(cmd) substitution. An
+  // opt-out must never fail open because the value had a stray space.
+  const lower = v.trim().toLowerCase();
   return lower === "off" || lower === "0" || lower === "false" || lower === "no";
 }
 
@@ -202,15 +205,15 @@ function envTruthy(v: string | undefined): boolean {
 }
 
 /**
- * Explicit opt-IN. Only overrides the automatic suppressions below
- * (CI / DO_NOT_TRACK) — never a deliberate opt-out held in the config
- * file. Lets us exercise the real ingest path from our own CI without
- * reopening the door to every other runner on the internet.
+ * Explicit opt-IN. Overrides *CI detection only* — never a deliberate
+ * opt-out, whether that lives in the config file or in DO_NOT_TRACK. Lets
+ * us exercise the real ingest path from our own CI without reopening the
+ * door to every other runner on the internet.
  */
 function envOptIn(env: NodeJS.ProcessEnv): boolean {
   const v = env[ENV_OPT_OUT];
   if (v === undefined) return false;
-  const lower = v.toLowerCase();
+  const lower = v.trim().toLowerCase();
   return lower === "on" || lower === "1" || lower === "true" || lower === "yes";
 }
 
@@ -246,19 +249,29 @@ export function doNotTrack(env: NodeJS.ProcessEnv = process.env): boolean {
 }
 
 /**
- * Which automatic suppression (if any) is currently in force.
+ * Which environmental suppression (if any) is currently in force.
  *
- * Returns null when an explicit OPENA2A_TELEMETRY=on overrides them, or
- * when neither applies. Exposed so `status()` can explain *why* telemetry
- * is off — a bare "off" reads as "you turned this off", and sends users
- * chasing a config flip that automatic suppression will just re-apply.
+ * Exposed so `status()` can explain *why* telemetry is off — a bare "off"
+ * reads as "you turned this off", and sends users chasing a config flip
+ * that suppression will just re-apply.
+ *
+ * Order matters, and the two reasons are NOT peers:
+ *
+ *   - `DO_NOT_TRACK` is a deliberate user *intent*. A user exports it once
+ *     in their shell profile and expects every tool to honor it. It sits in
+ *     the same tier as `telemetry off` and is checked FIRST, so that
+ *     `OPENA2A_TELEMETRY=on` — which we tell people to put in CI configs,
+ *     Dockerfiles and Makefiles — can never silently override a privacy
+ *     signal the user never touched.
+ *   - CI-ness is an environmental *fact*, not a choice, so an explicit
+ *     opt-in may override it. That is the only thing the opt-in overrides.
  */
 export function autoSuppressionReason(
   env: NodeJS.ProcessEnv = process.env,
 ): SuppressionReason | null {
+  if (doNotTrack(env)) return "do-not-track";
   if (envOptIn(env)) return null;
   if (isCI(env)) return "ci";
-  if (doNotTrack(env)) return "do-not-track";
   return null;
 }
 
@@ -269,9 +282,12 @@ export function autoSuppressionReason(
  *   1. OPENA2A_TELEMETRY set to an off value — always wins.
  *   2. config file `enabled: false` — a deliberate opt-out; nothing
  *      re-enables it, including OPENA2A_TELEMETRY=on.
- *   3. CI environment or DO_NOT_TRACK — suppressed, unless
- *      OPENA2A_TELEMETRY is set to an explicit on value.
- *   4. default ON (matches spec).
+ *   3. DO_NOT_TRACK — also a deliberate opt-out; likewise nothing
+ *      re-enables it. Same tier as (2), not an environmental default.
+ *   4. CI environment — suppressed, unless OPENA2A_TELEMETRY is set to an
+ *      explicit on value. CI-ness is a fact about the machine, not a
+ *      choice by the user, so an explicit opt-in may override it.
+ *   5. default ON (matches spec).
  *
  * The install_id is always persisted on first call so subsequent runs
  * (and subsequent tools on the same machine) report the same ID.

--- a/packages/telemetry/src/config.ts
+++ b/packages/telemetry/src/config.ts
@@ -222,12 +222,20 @@ function envOptIn(env: NodeJS.ProcessEnv): boolean {
  *
  * Why this exists: install_id is derived from the OS machine-id, and
  * falls back to a hash of the hostname when that probe fails (see
- * `deriveInstallId`). CI runners are ephemeral containers — no
- * machine-id, and a fresh random hostname per job. Every CI run
- * therefore minted a brand-new install_id and was counted as a distinct
- * install/active user. With no suppression, adoption metrics measure
- * our own pipelines more than our users, and the error grows with build
- * frequency rather than with real usage.
+ * `deriveInstallId`). CI runners are provisioned fresh for each job, so
+ * the machine-id (or the hostname fallback) differs on every run — a CI
+ * run typically minted a brand-new install_id and was counted as a
+ * distinct install/active user. With no suppression, adoption metrics
+ * measure our own pipelines more than our users, and the error grows
+ * with build frequency rather than with real usage.
+ *
+ * Two limits worth knowing, since this reads like a complete fix and is
+ * not one. Self-hosted or reused runners have a stable machine-id, so
+ * they collapse onto a single persistent identity instead of inflating —
+ * a different distortion. And `CI` is a proxy for ephemerality, not a
+ * synonym: a throwaway `docker run`, a devcontainer rebuild or a
+ * sandboxed `npx` hits the same fallback path while setting none of
+ * these variables. This covers the CI-labeled share, not the whole class.
  *
  * Bots are not users. Suppressing here (rather than filtering
  * server-side) means the event is never sent at all — cheaper, and it
@@ -306,8 +314,8 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): {
   const installId = file?.installId ?? deriveInstallId();
   const fileEnabled = file?.enabled ?? true;
   const envDisabled = envOptOut(env);
-  const suppressedBy = autoSuppressionReason(env);
-  const enabled = !envDisabled && fileEnabled && suppressedBy === null;
+  const autoReason = autoSuppressionReason(env);
+  const enabled = !envDisabled && fileEnabled && autoReason === null;
 
   if (!file || !file.installId || file.enabled === undefined) {
     try {
@@ -317,16 +325,24 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): {
     }
   }
 
-  // Only attribute the off-state to the environment when the user has NOT
-  // opted out themselves. Someone who ran `telemetry off` should not be
-  // told CI is the reason.
-  const userOptedOut = envDisabled || !fileEnabled;
+  // Attribute the off-state to the reason a consumer must actually explain,
+  // in precedence order:
+  //
+  //   - OPENA2A_TELEMETRY=off wins outright, so report it. Without a code
+  //     here a CLI can only say a bare "off" and suggest `telemetry on` —
+  //     which cannot work, because rule 1 says env-off always wins.
+  //   - A persisted `telemetry off` gets NO code: the ordinary toggle works,
+  //     so a plain hint is the better affordance, and attributing it to the
+  //     environment would tell the user something untrue about their own
+  //     choice.
+  //   - Otherwise the environment is the cause (DO_NOT_TRACK / CI).
+  const suppressedBy: SuppressionReason | null = envDisabled
+    ? "env-opt-out"
+    : !fileEnabled
+      ? null
+      : autoReason;
 
-  return {
-    config: { enabled, installId },
-    paths,
-    suppressedBy: userOptedOut ? null : suppressedBy,
-  };
+  return { config: { enabled, installId }, paths, suppressedBy };
 }
 
 export function setEnabled(enabled: boolean): TelemetryConfig {

--- a/packages/telemetry/src/config.ts
+++ b/packages/telemetry/src/config.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { randomUUID, createHash } from "node:crypto";
 import { execSync } from "node:child_process";
+import type { SuppressionReason } from "./types.js";
 
 export const POLICY_URL = "https://opena2a.org/telemetry";
 export const DEFAULT_ENDPOINT = "https://api.oa2a.org/api/v1/telemetry/v1/event";
@@ -245,6 +246,23 @@ export function doNotTrack(env: NodeJS.ProcessEnv = process.env): boolean {
 }
 
 /**
+ * Which automatic suppression (if any) is currently in force.
+ *
+ * Returns null when an explicit OPENA2A_TELEMETRY=on overrides them, or
+ * when neither applies. Exposed so `status()` can explain *why* telemetry
+ * is off — a bare "off" reads as "you turned this off", and sends users
+ * chasing a config flip that automatic suppression will just re-apply.
+ */
+export function autoSuppressionReason(
+  env: NodeJS.ProcessEnv = process.env,
+): SuppressionReason | null {
+  if (envOptIn(env)) return null;
+  if (isCI(env)) return "ci";
+  if (doNotTrack(env)) return "do-not-track";
+  return null;
+}
+
+/**
  * Load (and lazily create) the telemetry config.
  *
  * Precedence for `enabled`:
@@ -265,15 +283,15 @@ export function doNotTrack(env: NodeJS.ProcessEnv = process.env): boolean {
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): {
   config: TelemetryConfig;
   paths: ConfigPaths;
+  suppressedBy: SuppressionReason | null;
 } {
   const paths = configPaths();
   const file = readConfigFile(paths.file);
   const installId = file?.installId ?? deriveInstallId();
   const fileEnabled = file?.enabled ?? true;
   const envDisabled = envOptOut(env);
-  const autoSuppressed = isCI(env) || doNotTrack(env);
-  const enabled =
-    !envDisabled && fileEnabled && (envOptIn(env) || !autoSuppressed);
+  const suppressedBy = autoSuppressionReason(env);
+  const enabled = !envDisabled && fileEnabled && suppressedBy === null;
 
   if (!file || !file.installId || file.enabled === undefined) {
     try {
@@ -283,7 +301,16 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): {
     }
   }
 
-  return { config: { enabled, installId }, paths };
+  // Only attribute the off-state to the environment when the user has NOT
+  // opted out themselves. Someone who ran `telemetry off` should not be
+  // told CI is the reason.
+  const userOptedOut = envDisabled || !fileEnabled;
+
+  return {
+    config: { enabled, installId },
+    paths,
+    suppressedBy: userOptedOut ? null : suppressedBy,
+  };
 }
 
 export function setEnabled(enabled: boolean): TelemetryConfig {

--- a/packages/telemetry/src/index.test.ts
+++ b/packages/telemetry/src/index.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { scrubSuppressionEnv, restoreSuppressionEnv, type SavedEnv } from "./test-support.js";
 
 let tmpHome: string;
 let fetchMock: ReturnType<typeof vi.fn>;
+let savedEnv: SavedEnv;
 
 async function freshSdk() {
   vi.resetModules();
@@ -12,6 +14,9 @@ async function freshSdk() {
 }
 
 beforeEach(() => {
+  // These suites assert telemetry actually fires; CI suppression would
+  // silence every event and fail them on a runner. See test-support.ts.
+  savedEnv = scrubSuppressionEnv();
   tmpHome = mkdtempSync(join(tmpdir(), "opena2a-telem-sdk-"));
   process.env.XDG_CONFIG_HOME = tmpHome;
   process.env.OPENA2A_TELEMETRY_URL = "http://test.local/event";
@@ -22,10 +27,47 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  restoreSuppressionEnv(savedEnv);
   rmSync(tmpHome, { recursive: true, force: true });
   vi.unstubAllGlobals();
   delete process.env.XDG_CONFIG_HOME;
   delete process.env.OPENA2A_TELEMETRY_URL;
+});
+
+describe("CI suppression (end to end)", () => {
+  // The bug this guards: CI runners are ephemeral, so each job derived a
+  // fresh install_id and was counted as a new install / active user.
+  // Adoption metrics tracked our own build frequency instead of usage.
+  it("emits nothing at all when running in CI", async () => {
+    process.env.CI = "true";
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.9.3" });
+    tele.start();
+    await tele.track("scan", { success: true, durationMs: 10 });
+    tele.error("scan", "BOOM");
+    await tele.flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("emits nothing when DO_NOT_TRACK is set", async () => {
+    process.env.DO_NOT_TRACK = "1";
+    const tele = await freshSdk();
+    await tele.init({ tool: "hackmyagent", version: "0.25.0" });
+    tele.start();
+    await tele.track("scan", { success: true });
+    await tele.flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("still emits in CI when explicitly opted in", async () => {
+    process.env.CI = "true";
+    process.env.OPENA2A_TELEMETRY = "on";
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.9.3" });
+    await tele.track("scan", { success: true });
+    await tele.flush();
+    expect(fetchMock).toHaveBeenCalled();
+  });
 });
 
 describe("init + start", () => {

--- a/packages/telemetry/src/index.test.ts
+++ b/packages/telemetry/src/index.test.ts
@@ -59,6 +59,19 @@ describe("CI suppression (end to end)", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("emits nothing under DO_NOT_TRACK even with an explicit opt-in", async () => {
+    // The opt-in escape hatch exists for CI only. It must not defeat a
+    // user's deliberate privacy signal.
+    process.env.DO_NOT_TRACK = "1";
+    process.env.OPENA2A_TELEMETRY = "on";
+    const tele = await freshSdk();
+    await tele.init({ tool: "hackmyagent", version: "0.25.0" });
+    tele.start();
+    await tele.track("scan", { success: true });
+    await tele.flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("still emits in CI when explicitly opted in", async () => {
     process.env.CI = "true";
     process.env.OPENA2A_TELEMETRY = "on";

--- a/packages/telemetry/src/index.test.ts
+++ b/packages/telemetry/src/index.test.ts
@@ -35,9 +35,9 @@ afterEach(() => {
 });
 
 describe("CI suppression (end to end)", () => {
-  // The bug this guards: CI runners are ephemeral, so each job derived a
-  // fresh install_id and was counted as a new install / active user.
-  // Adoption metrics tracked our own build frequency instead of usage.
+  // The bug this guards: CI runners are provisioned fresh per job, so each
+  // job derived a new install_id and was counted as a new install / active
+  // user. Adoption metrics tracked our own build frequency, not usage.
   it("emits nothing at all when running in CI", async () => {
     process.env.CI = "true";
     const tele = await freshSdk();
@@ -109,14 +109,28 @@ describe("status reports why telemetry is off", () => {
     expect("suppressedBy" in s).toBe(false);
   });
 
-  it("does not blame CI when the user opted out themselves", async () => {
+  it("does not blame CI when the user opted out via the env var", async () => {
     process.env.CI = "true";
     process.env.OPENA2A_TELEMETRY = "off";
     const tele = await freshSdk();
     await tele.init({ tool: "dvaa", version: "0.9.3" });
     const s = tele.status();
     expect(s.enabled).toBe(false);
-    // The user's own opt-out is the reason; attributing it to CI would be wrong.
+    // The user's own opt-out is the reason, and it outranks CI. Blaming CI
+    // here would tell them something untrue about their own choice.
+    expect(s.suppressedBy).toBe("env-opt-out");
+    expect(s.suppressedBy).not.toBe("ci");
+  });
+
+  it("does not blame CI when the user opted out persistently", async () => {
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.9.3" });
+    tele.setOptOut(false);
+    process.env.CI = "true";
+    const s = tele.status();
+    expect(s.enabled).toBe(false);
+    // A persisted opt-out gets no reason code at all — `telemetry on` is a
+    // working remedy there, so the plain toggle hint is the right affordance.
     expect(s.suppressedBy).toBeUndefined();
   });
 

--- a/packages/telemetry/src/index.test.ts
+++ b/packages/telemetry/src/index.test.ts
@@ -70,6 +70,71 @@ describe("CI suppression (end to end)", () => {
   });
 });
 
+describe("status reports why telemetry is off", () => {
+  it("reports suppressedBy=ci in CI", async () => {
+    process.env.CI = "true";
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.9.3" });
+    const s = tele.status();
+    expect(s.enabled).toBe(false);
+    expect(s.suppressedBy).toBe("ci");
+  });
+
+  it("reports suppressedBy=do-not-track under DO_NOT_TRACK", async () => {
+    process.env.DO_NOT_TRACK = "1";
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.9.3" });
+    expect(tele.status().suppressedBy).toBe("do-not-track");
+  });
+
+  it("omits suppressedBy entirely when nothing suppressed", async () => {
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.9.3" });
+    const s = tele.status();
+    expect(s.enabled).toBe(true);
+    expect(s.suppressedBy).toBeUndefined();
+    expect("suppressedBy" in s).toBe(false);
+  });
+
+  it("does not blame CI when the user opted out themselves", async () => {
+    process.env.CI = "true";
+    process.env.OPENA2A_TELEMETRY = "off";
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.9.3" });
+    const s = tele.status();
+    expect(s.enabled).toBe(false);
+    // The user's own opt-out is the reason; attributing it to CI would be wrong.
+    expect(s.suppressedBy).toBeUndefined();
+  });
+
+  it("status() before init() also reports the reason", async () => {
+    process.env.CI = "true";
+    const tele = await freshSdk();
+    expect(tele.status().suppressedBy).toBe("ci");
+  });
+
+  it("setOptOut(true) in CI reports the effective state, not the written flag", async () => {
+    process.env.CI = "true";
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.9.3" });
+    const s = tele.setOptOut(true);
+    // Regression guard: returning `enabled: true` here would print "on"
+    // and the next `telemetry status` would print "off", with nothing
+    // explaining the flip.
+    expect(s.enabled).toBe(false);
+    expect(s.suppressedBy).toBe("ci");
+    expect(tele.status().enabled).toBe(false);
+  });
+
+  it("setOptOut(true) outside CI still enables", async () => {
+    const tele = await freshSdk();
+    await tele.init({ tool: "dvaa", version: "0.9.3" });
+    const s = tele.setOptOut(true);
+    expect(s.enabled).toBe(true);
+    expect(s.suppressedBy).toBeUndefined();
+  });
+});
+
 describe("init + start", () => {
   it("init() does not emit a banner to stderr", async () => {
     const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -189,4 +189,10 @@ export function successFromExitCode(
 }
 
 export { POLICY_URL } from "./config.js";
-export type { InitOptions, Status, TrackFields, UsageEvent } from "./types.js";
+export type {
+  InitOptions,
+  Status,
+  SuppressionReason,
+  TrackFields,
+  UsageEvent,
+} from "./types.js";

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -8,11 +8,33 @@
 import { platform as osPlatform } from "node:os";
 import { loadConfig, setEnabled, configPaths, POLICY_URL } from "./config.js";
 import { sendEvent } from "./sender.js";
-import type { InitOptions, Status, TrackFields, UsageEvent } from "./types.js";
+import type { InitOptions, Status, SuppressionReason, TrackFields, UsageEvent } from "./types.js";
 
 export { flush } from "./sender.js";
 
-let session: { tool: string; version: string; installId: string; enabled: boolean } | null = null;
+let session: {
+  tool: string;
+  version: string;
+  installId: string;
+  enabled: boolean;
+  suppressedBy: SuppressionReason | null;
+} | null = null;
+
+/** Build a Status, omitting `suppressedBy` entirely when nothing suppressed. */
+function toStatus(
+  enabled: boolean,
+  installId: string,
+  configPath: string,
+  suppressedBy: SuppressionReason | null,
+): Status {
+  return {
+    enabled,
+    configPath,
+    policyURL: POLICY_URL,
+    installId,
+    ...(suppressedBy ? { suppressedBy } : {}),
+  };
+}
 
 function nodeMajor(): number {
   return parseInt(process.versions.node.split(".")[0], 10);
@@ -24,12 +46,13 @@ function nodeMajor(): number {
  * call rebinds the session — useful in test harnesses).
  */
 export async function init(opts: InitOptions): Promise<void> {
-  const { config } = loadConfig();
+  const { config, suppressedBy } = loadConfig();
   session = {
     tool: opts.tool,
     version: opts.version,
     installId: config.installId,
     enabled: config.enabled,
+    suppressedBy,
   };
 }
 
@@ -72,35 +95,36 @@ export function error(name: string, code: string): void {
 
 export function status(): Status {
   if (!session) {
-    const { config, paths } = loadConfig();
-    return {
-      enabled: config.enabled,
-      configPath: paths.file,
-      policyURL: POLICY_URL,
-      installId: config.installId,
-    };
+    const { config, paths, suppressedBy } = loadConfig();
+    return toStatus(config.enabled, config.installId, paths.file, suppressedBy);
   }
-  return {
-    enabled: session.enabled,
-    configPath: configPaths().file,
-    policyURL: POLICY_URL,
-    installId: session.installId,
-  };
+  return toStatus(
+    session.enabled,
+    session.installId,
+    configPaths().file,
+    session.suppressedBy,
+  );
 }
 
 /**
  * Persist enabled=true|false to the config file.
  * Used by `<tool> telemetry on|off` subcommands.
+ *
+ * Returns the *effective* state, not the flag just written. In a CI
+ * environment `telemetry on` writes enabled=true and still returns
+ * `enabled: false, suppressedBy: "ci"` — because automatic suppression
+ * re-applies on every load. Reporting the written flag instead would
+ * print "on" and then have the very next `telemetry status` print "off",
+ * with nothing explaining the flip.
  */
 export function setOptOut(enabled: boolean): Status {
-  const cfg = setEnabled(enabled);
-  if (session) session.enabled = enabled;
-  return {
-    enabled: cfg.enabled,
-    configPath: configPaths().file,
-    policyURL: POLICY_URL,
-    installId: cfg.installId,
-  };
+  setEnabled(enabled);
+  const { config, paths, suppressedBy } = loadConfig();
+  if (session) {
+    session.enabled = config.enabled;
+    session.suppressedBy = suppressedBy;
+  }
+  return toStatus(config.enabled, config.installId, paths.file, suppressedBy);
 }
 
 /**

--- a/packages/telemetry/src/test-support.ts
+++ b/packages/telemetry/src/test-support.ts
@@ -1,0 +1,57 @@
+/**
+ * Test-only helpers. Excluded from the published build via the tsconfig
+ * `exclude` list, so this never reaches `dist` or npm.
+ *
+ * Why this file exists: the suites assert default-ON telemetry behaviour,
+ * but telemetry is deliberately suppressed in CI (see `isCI` in config.ts).
+ * Running the suites on a GitHub Actions runner — where CI=true and
+ * GITHUB_ACTIONS=true are always set — would otherwise flip every
+ * default-ON assertion and turn the build red for the wrong reason.
+ * Scrub the suppression signals so the tests exercise the behaviour they
+ * claim to, on a laptop and on a runner alike.
+ */
+
+/** Every env var that suppresses telemetry. Keep in sync with config.ts. */
+export const SUPPRESSION_ENV_VARS = [
+  "CI",
+  "CONTINUOUS_INTEGRATION",
+  "DO_NOT_TRACK",
+  "GITHUB_ACTIONS",
+  "GITLAB_CI",
+  "CIRCLECI",
+  "TRAVIS",
+  "JENKINS_URL",
+  "BUILDKITE",
+  "DRONE",
+  "TEAMCITY_VERSION",
+  "TF_BUILD",
+  "CODEBUILD_BUILD_ID",
+  "APPVEYOR",
+  "BITBUCKET_BUILD_NUMBER",
+  "HEROKU_TEST_RUN_ID",
+  "SEMAPHORE",
+  "WOODPECKER_CI",
+  "NETLIFY",
+  "VERCEL",
+  "CF_PAGES",
+] as const;
+
+export type SavedEnv = Record<string, string | undefined>;
+
+/** Clear every suppression var, returning the prior values for restore. */
+export function scrubSuppressionEnv(): SavedEnv {
+  const saved: SavedEnv = {};
+  for (const key of SUPPRESSION_ENV_VARS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  return saved;
+}
+
+/** Restore what `scrubSuppressionEnv` cleared. */
+export function restoreSuppressionEnv(saved: SavedEnv): void {
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}

--- a/packages/telemetry/src/test-support.ts
+++ b/packages/telemetry/src/test-support.ts
@@ -11,29 +11,22 @@
  * claim to, on a laptop and on a runner alike.
  */
 
-/** Every env var that suppresses telemetry. Keep in sync with config.ts. */
+import { CI_VENDOR_ENV_VARS } from "./config.js";
+
+/**
+ * Every env var that suppresses telemetry.
+ *
+ * Derived from the real vendor list rather than hand-copied, so adding a
+ * vendor to config.ts cannot silently desync this. A duplicated list would
+ * fail only on a contributor's machine that happens to set the new var —
+ * never on our own runners, which set CI/GITHUB_ACTIONS and are already
+ * scrubbed — surfacing later as an unrelated-looking test failure.
+ */
 export const SUPPRESSION_ENV_VARS = [
+  ...CI_VENDOR_ENV_VARS,
   "CI",
   "CONTINUOUS_INTEGRATION",
   "DO_NOT_TRACK",
-  "GITHUB_ACTIONS",
-  "GITLAB_CI",
-  "CIRCLECI",
-  "TRAVIS",
-  "JENKINS_URL",
-  "BUILDKITE",
-  "DRONE",
-  "TEAMCITY_VERSION",
-  "TF_BUILD",
-  "CODEBUILD_BUILD_ID",
-  "APPVEYOR",
-  "BITBUCKET_BUILD_NUMBER",
-  "HEROKU_TEST_RUN_ID",
-  "SEMAPHORE",
-  "WOODPECKER_CI",
-  "NETLIFY",
-  "VERCEL",
-  "CF_PAGES",
 ] as const;
 
 export type SavedEnv = Record<string, string | undefined>;

--- a/packages/telemetry/src/types.ts
+++ b/packages/telemetry/src/types.ts
@@ -28,9 +28,23 @@ export interface TrackFields {
   durationMs?: number;
 }
 
+/**
+ * Why telemetry is off despite the user never having opted out.
+ * See `autoSuppressionReason` in config.ts.
+ */
+export type SuppressionReason = "ci" | "do-not-track";
+
 export interface Status {
   enabled: boolean;
   configPath: string;
   policyURL: string;
   installId: string;
+  /**
+   * Present only when telemetry is off because of the *environment*
+   * (CI / DO_NOT_TRACK) rather than a user choice. Consumers should say so
+   * rather than implying the user turned it off — and must not suggest
+   * `<tool> telemetry on` as the remedy, because a config-file flip does
+   * not survive automatic suppression.
+   */
+  suppressedBy?: SuppressionReason;
 }

--- a/packages/telemetry/src/types.ts
+++ b/packages/telemetry/src/types.ts
@@ -29,10 +29,17 @@ export interface TrackFields {
 }
 
 /**
- * Why telemetry is off despite the user never having opted out.
- * See `autoSuppressionReason` in config.ts.
+ * Why telemetry is off, when the reason lives in the *environment* rather
+ * than in the config file.
+ *
+ * A persisted `<tool> telemetry off` deliberately has NO reason code: for
+ * that state the ordinary `<tool> telemetry on` toggle works, so a plain
+ * hint is the right affordance. These three are the cases where that toggle
+ * would not work, and so must be explained instead.
+ *
+ * See `autoSuppressionReason` and `loadConfig` in config.ts.
  */
-export type SuppressionReason = "ci" | "do-not-track";
+export type SuppressionReason = "ci" | "do-not-track" | "env-opt-out";
 
 export interface Status {
   enabled: boolean;

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -6,5 +6,5 @@
     "composite": true
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts", "src/test-support.ts"]
 }


### PR DESCRIPTION
## Why

The analytics dashboard reports `Installs = 0` for all five tools while showing non-zero MAU/WAU. Tracing it produced a worse finding than the zero itself.

The Registry counts installs as `COUNT(DISTINCT install_id) FILTER (WHERE event = 'install')`, and this SDK **has never emitted an `install` event** — `buildEvent` is only called with `start`, `command`, `error`. `"install"` is dead schema surface. Hence a permanent 0.

The obvious one-line fix — drop the filter — is **unsafe**, and that is what this PR is really about. The SDK had **no CI suppression at all**: telemetry is opt-out, on by default, and read only `XDG_CONFIG_HOME` plus three `OPENA2A_TELEMETRY*` vars. No `CI`, no `DO_NOT_TRACK`. `install_id` derives from the OS machine-id, falling back to a hash of the hostname. CI runners are provisioned fresh per job, so **every CI run minted a new `install_id` and counted as a new install and active user**.

Dropping the filter without this change would have rendered *hundreds of installs* — matching intuition, and fabricated. A wrong number that confirms what you expected is worse than a visible zero, because nothing prompts anyone to question it.

## What changed

- **CI / `DO_NOT_TRACK` suppression** at the source; the event is never sent, so the Registry never has to guess which IDs were real.
- The two reasons are **not peers**. `DO_NOT_TRACK` is deliberate user intent, same tier as `telemetry off` — **nothing overrides it**. CI-ness is a fact about the machine, so an explicit `OPENA2A_TELEMETRY=on` overrides *CI detection only*.
- `OPENA2A_TELEMETRY` values are now **trimmed**. `OPENA2A_TELEMETRY="off "` previously failed **open** and sent telemetry.
- `Status.suppressedBy` (`"ci" | "do-not-track" | "env-opt-out"`) so a CLI can explain *why* it's off. A persisted `telemetry off` carries no code — the plain toggle works there.
- `setOptOut()` returns the **effective** state, not the flag it wrote.
- cli-ui gives a **per-reason remedy that actually works**, and no longer offers `OPENA2A_TELEMETRY=on` where it cannot re-enable anything.

## Every off-state, verified against the built CLI

| State | Output | Remedy works |
|---|---|---|
| `OPENA2A_TELEMETRY=off` | `off (OPENA2A_TELEMETRY=off is set)` | unset the var |
| CI | `off (CI environment detected)` + "you did not turn it off" | `OPENA2A_TELEMETRY=on` |
| `DO_NOT_TRACK` | `off (DO_NOT_TRACK is set)` | unset it |
| persisted `telemetry off` | plain `off` + toggle | toggle works |
| normal user | `on` | unchanged |

## Scope, stated honestly

`CI` is a proxy for ephemerality, **not a synonym**. A throwaway `docker run`, a devcontainer rebuild, or a sandboxed `npx` hits the same fresh-`install_id` path while setting none of these variables. Self-hosted/reused runners have a stable machine-id and collapse onto one identity instead — a different distortion.

**This removes the CI-labeled share of the inflation, not the whole class.** The per-tool install count is still not publishable as measured. `dvaa` (177 MAU / 1 engaged, Docker-first, no volume for `~/.config`) is the remaining population and the next fix.

## Review

Three adversarial rounds, each of which found something real:

1. **HIGH** — `OPENA2A_TELEMETRY=on` overrode `DO_NOT_TRACK`. A privacy control failing open, locked in by both a test and the README.
2. **MEDIUM ×2** — dead ends: `telemetry on` in CI claimed success then silently reverted; env-opt-out had no explanation.
3. **MEDIUM** — the off-state hint offered an env var that cannot re-enable a persisted opt-out.

Final round: 48/48 precedence cells verified identical for `enabled`; fail-by-construction confirmed by adding a hypothetical 4th union member and watching `tsc` reject it at all three sites.

## Verification

- telemetry **114** tests, cli-ui **258** tests — green clean **and** under a simulated GitHub Actions env.
- Both suites scrubbed CI vars via `test-support.ts` (build-excluded, verified absent from the tarball). Without it, every default-ON assertion would pass locally and **fail on the runner**.
- build 11/11 · lint 16/16 · typecheck 15/15 · HMA 96/100 (2 LOW, pre-existing git hygiene).
- **No version bump** — deferred to publish time to avoid the lockfile desync and the exact-pin cascade.

## Not in this PR

- **No publish.** Gated on explicit approval.
- At publish time, two docs go stale and must be updated: `opena2a.org/telemetry` (the GDPR/CCPA disclosure page) and `opena2a-registry/docs/telemetry-spec.md` — whose line 12 justified building telemetry *because* npm downloads "over-count (CI systems, mirrors, npm's own caches)", and whose line 120 assumed CI operators would opt out by hand.
