### PR TITLE
credential-patterns 0.1.3: scan MCP configs (.mcp.json), secret-gated connection strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4339,7 +4339,7 @@
         "@opena2a/aicomply": "2.2.0",
         "@opena2a/cli-ui": "0.5.2",
         "@opena2a/contribute": "0.1.0",
-        "@opena2a/credential-patterns": "0.1.2",
+        "@opena2a/credential-patterns": "0.1.3",
         "@opena2a/registry-client": "0.2.0",
         "@opena2a/shared": "0.1.0",
         "@opena2a/telemetry": "0.3.0",
@@ -4393,12 +4393,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@opena2a/contribute/-/contribute-0.1.0.tgz",
       "integrity": "sha512-nKrm2UFGzRKqrn+3uWmQujQjsWl7uKXR7NtgbL6bSdDAXI4af+00YFgNBn/kZCODlJlGiYTasKOCnk10tbk0Sg==",
-      "license": "Apache-2.0"
-    },
-    "packages/cli/node_modules/@opena2a/credential-patterns": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@opena2a/credential-patterns/-/credential-patterns-0.1.2.tgz",
-      "integrity": "sha512-0X85+XCAG1XkXUSFHuFjHmG5ZISS+/sFqq65lAd5quZel6SHg4QqLokD0KhOFD0nRs45sHQiBa8HH9uuU7P/Ww==",
       "license": "Apache-2.0"
     },
     "packages/cli/node_modules/@opena2a/shared": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4395,6 +4395,12 @@
       "integrity": "sha512-nKrm2UFGzRKqrn+3uWmQujQjsWl7uKXR7NtgbL6bSdDAXI4af+00YFgNBn/kZCODlJlGiYTasKOCnk10tbk0Sg==",
       "license": "Apache-2.0"
     },
+    "packages/cli/node_modules/@opena2a/credential-patterns": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@opena2a/credential-patterns/-/credential-patterns-0.1.2.tgz",
+      "integrity": "sha512-0X85+XCAG1XkXUSFHuFjHmG5ZISS+/sFqq65lAd5quZel6SHg4QqLokD0KhOFD0nRs45sHQiBa8HH9uuU7P/Ww==",
+      "license": "Apache-2.0"
+    },
     "packages/cli/node_modules/@opena2a/shared": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@opena2a/shared/-/shared-0.1.0.tgz",
@@ -4415,7 +4421,7 @@
     },
     "packages/credential-patterns": {
       "name": "@opena2a/credential-patterns",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
     "@opena2a/aicomply": "2.2.0",
     "@opena2a/cli-ui": "0.5.2",
     "@opena2a/contribute": "0.1.0",
-    "@opena2a/credential-patterns": "0.1.2",
+    "@opena2a/credential-patterns": "0.1.3",
     "@opena2a/registry-client": "0.2.0",
     "@opena2a/shared": "0.1.0",
     "@opena2a/telemetry": "0.3.0",

--- a/packages/credential-patterns/CHANGELOG.md
+++ b/packages/credential-patterns/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `@opena2a/credential-patterns` will be documented in this file.
 
+## 0.1.3 — 2026-07-22
+
+### `CONFIG_FILES`
+
+- **Added `.mcp.json`** — the Claude Code project-scope MCP config. It sits at the
+  project root and is committed to repos, making it a high-risk home for plaintext
+  `env` credentials, yet no consumer scanned it (found by the secretless-ai 0.20.0
+  release test: a planted Anthropic key in `.mcp.json` survived `scan`, `mcp-status`,
+  `status`, and a PASS from `verify`).
+- **Fixed the `.curse/mcp.json` typo to `.cursor/mcp.json`** — Cursor's project MCP
+  config was unreachable since the entry was introduced; `.curse/` matches nothing.
+
 ## 0.1.2 — 2026-06-08
 
 Name-gated AWS secret-access-key detection (ports hackmyagent's scanner rule to the shared catalog).

--- a/packages/credential-patterns/CHANGELOG.md
+++ b/packages/credential-patterns/CHANGELOG.md
@@ -21,12 +21,48 @@ All notable changes to `@opena2a/credential-patterns` will be documented in this
 ### Database connection-string precision
 
 - **`mongodb`, `postgres`, `mysql`, and `redis` now flag only URIs that embed a
-  secret** — a userinfo password (`user:pass@`, `:pass@`) or a `password=` query
-  param. Previously any URI ≥ 10 chars matched, so the canonical credential-free
-  MCP server layout (`"args": ["postgresql://localhost:5432/mydb"]`) produced a
-  CRITICAL "PostgreSQL Connection String" finding with nothing secret in it.
-  Deliberate narrowing note: username-only URIs (`rediss://user@host`) no longer
-  match — a username without a password is topology, not a credential.
+  secret.** Previously any URI ≥ 10 chars matched, so the canonical
+  credential-free MCP server layout (`"args":
+  ["postgresql://localhost:5432/mydb"]`) produced a CRITICAL "PostgreSQL
+  Connection String" finding with nothing secret in it. A URI now matches when
+  it carries a userinfo password (`user:pass@`, `:pass@`), a
+  `password=`/`pwd=`/`sslpassword=` query param (case-insensitive), or — redis
+  only — any single userinfo token (`redis://your-password@host`): pre-ACL Redis has
+  no usernames, so a lone token there is a password, not topology. For
+  `postgres`/`mysql`/`mongodb`, username-only URIs (`postgres://user@host`) are
+  a deliberate non-match: no password, no secret.
+- **Plain `mongodb://` URIs are now covered** — the old pattern only matched
+  `mongodb+srv://`, so `mongodb://root:pass@host/admin` was never detected.
+- **Matches cannot cross JSON string boundaries** — the character classes
+  exclude quotes and commas, so minified content like
+  `{"cache":"redis://localhost:6379","owner":"ops@corp.io"}` neither
+  false-positives nor gets destructively over-masked by `replace()`-based
+  redaction consumers.
+- **Env-var-interpolated passwords are not secrets** — the user/password
+  classes exclude `$ { } | ;`, so `postgres://app:${POSTGRES_PASSWORD}@db`
+  (the recommended secure shape), `$VAR` forms, markdown-table cells, and
+  compound `;`-joined env lines no longer read as literal credentials. Hosts
+  deliberately keep `$ { }`: a real password next to an interpolated host
+  (`redis://:realpass@${REDIS_HOST}:6379`) still flags. The redis single-token
+  rule carves out the literal `default@` (the standard Redis 6+ ACL username);
+  other username-only redis URIs still flag on the safe side, since a lone
+  userinfo token is indistinguishable from a pre-ACL password.
+- **`CREDENTIAL_PREFIX_QUICK_CHECK` derives `redis` from `rediss?`, not
+  `rediss`** — the prefix extractor kept the char an optional quantifier
+  applies to, so consumers' `${VAR}`-line skip dropped plain `redis://` lines
+  before the pattern ever ran: `redis://:realpass@${REDIS_HOST}:6379` was a
+  silent miss. The extractor now trims a trailing `X?` char, with a regression
+  test pinning `redis://` recognition.
+- **Every run is length-bounded** (user ≤ 64, password ≤ 256, host/query ≤ 512
+  chars), keeping scan time linear on scheme-stuffed one-line files
+  (adversarially measured: 220 KB of repeated `postgres://` dropped from
+  multi-second quadratic scans to ~30 ms); the ReDoS perf suite gains
+  scheme-literal-prefixed inputs, which the previous inputs never exercised.
+  Known edges, accepted: a password containing a raw unencoded `&`, `,`,
+  quote, `$`, `{`, `}`, `|`, or `;` is missed or masked only partially
+  (percent-encoded forms are caught), format-string templates
+  (`postgres://%s:%s@%s`) still match, and secrets placed beyond ~512 chars
+  into a single URI's query string are not matched.
 
 ## 0.1.2 — 2026-06-08
 

--- a/packages/credential-patterns/CHANGELOG.md
+++ b/packages/credential-patterns/CHANGELOG.md
@@ -13,6 +13,20 @@ All notable changes to `@opena2a/credential-patterns` will be documented in this
   `status`, and a PASS from `verify`).
 - **Fixed the `.curse/mcp.json` typo to `.cursor/mcp.json`** — Cursor's project MCP
   config was unreachable since the entry was introduced; `.curse/` matches nothing.
+- **Added `.mcp/config.json`, `.claude/settings.local.json`, and
+  `.windsurf/mcp.json`** — MCP/agent config locations the org's tools already
+  enumerate elsewhere (opena2a-cli `ai-config`/`detect`, secretless MCP discovery)
+  but the shared scan list lacked.
+
+### Database connection-string precision
+
+- **`mongodb`, `postgres`, `mysql`, and `redis` now flag only URIs that embed a
+  secret** — a userinfo password (`user:pass@`, `:pass@`) or a `password=` query
+  param. Previously any URI ≥ 10 chars matched, so the canonical credential-free
+  MCP server layout (`"args": ["postgresql://localhost:5432/mydb"]`) produced a
+  CRITICAL "PostgreSQL Connection String" finding with nothing secret in it.
+  Deliberate narrowing note: username-only URIs (`rediss://user@host`) no longer
+  match — a username without a password is topology, not a credential.
 
 ## 0.1.2 — 2026-06-08
 

--- a/packages/credential-patterns/package.json
+++ b/packages/credential-patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/credential-patterns",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Canonical credential regex catalog and match-with-allowlist helpers for OpenA2A security tools (secretless-ai, hackmyagent).",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/credential-patterns/src/patterns.test.ts
+++ b/packages/credential-patterns/src/patterns.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { CREDENTIAL_PATTERNS, CREDENTIAL_PREFIX_QUICK_CHECK } from './patterns.js';
+import { CONFIG_FILES, CREDENTIAL_PATTERNS, CREDENTIAL_PREFIX_QUICK_CHECK } from './patterns.js';
 
 /**
  * Test data for each pattern: valid strings that MUST match, invalid strings that MUST NOT.
@@ -393,5 +393,16 @@ describe('CREDENTIAL_PREFIX_QUICK_CHECK', () => {
   it('does not match random text', () => {
     expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('hello world')).toBe(false);
     expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('just some normal text')).toBe(false);
+  });
+});
+
+describe('CONFIG_FILES — MCP config coverage', () => {
+  it('covers Claude Code project-scope .mcp.json (committed to repos)', () => {
+    expect(CONFIG_FILES).toContain('.mcp.json');
+  });
+
+  it('covers .cursor/mcp.json under its real directory name (".curse" typo regression)', () => {
+    expect(CONFIG_FILES).toContain('.cursor/mcp.json');
+    expect(CONFIG_FILES.some(f => f.includes('.curse/'))).toBe(false);
   });
 });

--- a/packages/credential-patterns/src/patterns.test.ts
+++ b/packages/credential-patterns/src/patterns.test.ts
@@ -211,22 +211,32 @@ const PATTERN_TEST_CASES: Record<string, { valid: string[]; invalid: string[] }>
     invalid: ['sq0csp-short', 'sq0CSP-' + 'a'.repeat(22)],
   },
 
-  // Database
+  // Database — connection strings flag only when a secret is embedded
+  // (userinfo password or password= query param). Credential-free and
+  // username-only URIs are topology, not exposures.
   'mongodb': {
     valid: ['mongodb+srv://user:pass@cluster.mongodb.net/db'],
-    invalid: ['mongodb://lo', 'mongo+srv://x'],
+    invalid: ['mongodb://lo', 'mongo+srv://x', 'mongodb+srv://cluster.mongodb.net/db'],
   },
   'postgres': {
-    valid: ['postgres://user:pass@localhost:5432/mydb'],
-    invalid: ['postgres://s', 'pg://user:pass@host/db'],
+    valid: [
+      'postgres://user:pass@localhost:5432/mydb',
+      'postgresql://localhost:5432/mydb?password=hunter2',
+    ],
+    invalid: [
+      'postgres://s',
+      'pg://user:pass@host/db',
+      'postgres://localhost:5432/mydb',
+      'postgresql://localhost:5432/mydb',
+    ],
   },
   'mysql': {
     valid: ['mysql://user:pass@localhost:3306/mydb'],
-    invalid: ['mysql://sh', 'msql://user:pass@host/db'],
+    invalid: ['mysql://sh', 'msql://user:pass@host/db', 'mysql://localhost:3306/mydb'],
   },
   'redis': {
-    valid: ['redis://user:pass@localhost:6379/0', 'rediss://secure@host:6379'],
-    invalid: ['redis://sh', 'rds://host:6379'],
+    valid: ['redis://user:pass@localhost:6379/0', 'rediss://:secure@host:6379'],
+    invalid: ['redis://sh', 'rds://host:6379', 'redis://localhost:6379', 'rediss://secure@host:6379'],
   },
 
   // Auth & Crypto
@@ -399,6 +409,12 @@ describe('CREDENTIAL_PREFIX_QUICK_CHECK', () => {
 describe('CONFIG_FILES — MCP config coverage', () => {
   it('covers Claude Code project-scope .mcp.json (committed to repos)', () => {
     expect(CONFIG_FILES).toContain('.mcp.json');
+  });
+
+  it('covers the other org-known MCP/agent config locations', () => {
+    expect(CONFIG_FILES).toContain('.mcp/config.json');
+    expect(CONFIG_FILES).toContain('.claude/settings.local.json');
+    expect(CONFIG_FILES).toContain('.windsurf/mcp.json');
   });
 
   it('covers .cursor/mcp.json under its real directory name (".curse" typo regression)', () => {

--- a/packages/credential-patterns/src/patterns.test.ts
+++ b/packages/credential-patterns/src/patterns.test.ts
@@ -211,23 +211,42 @@ const PATTERN_TEST_CASES: Record<string, { valid: string[]; invalid: string[] }>
     invalid: ['sq0csp-short', 'sq0CSP-' + 'a'.repeat(22)],
   },
 
-  // Database — connection strings flag only when a secret is embedded
-  // (userinfo password or password= query param). Credential-free and
-  // username-only URIs are topology, not exposures.
+  // Database — connection strings flag only when a secret is embedded:
+  // a userinfo password (or, for redis, any single userinfo token — pre-ACL
+  // Redis has no usernames) or a password=/pwd=/sslpassword= query param.
+  // Credential-free URIs are topology, not exposures, and matches must not
+  // cross JSON string boundaries on minified content.
   'mongodb': {
-    valid: ['mongodb+srv://user:pass@cluster.mongodb.net/db'],
+    valid: [
+      'mongodb+srv://user:pass@cluster.mongodb.net/db',
+      'mongodb://admin:hunter2@mongo1:27017,mongo2:27017/db',
+    ],
     invalid: ['mongodb://lo', 'mongo+srv://x', 'mongodb+srv://cluster.mongodb.net/db'],
   },
   'postgres': {
     valid: [
       'postgres://user:pass@localhost:5432/mydb',
       'postgresql://localhost:5432/mydb?password=hunter2',
+      'postgresql://localhost:5432/mydb?Password=hunter2',
+      'postgresql://host:5432/db?sslmode=verify-full&sslpassword=keypass',
+      'postgres://user:p%40ssw0rd@host/db',
+      'postgres://u:p@[::1]:5432/db',
+      'postgres://u:p@h1:5432,h2:5432/db',
+      'postgresql:///db?host=/cloudsql/proj:region:inst&password=y',
     ],
     invalid: [
       'postgres://s',
       'pg://user:pass@host/db',
       'postgres://localhost:5432/mydb',
       'postgresql://localhost:5432/mydb',
+      '{"conn":"postgres://localhost:5432/db","email":"a@b.com"}',
+      '{"x":"postgres://","y":"a:b@c"}',
+      '{"a":"postgres://localhost/db","note":"?password=hunter2"}',
+      'DATABASE_URL: postgres://app:${POSTGRES_PASSWORD}@db:5432/app',
+      'db_url: postgres://app:$DB_PASSWORD@db:5432/app',
+      'notes: postgres://reporting:5432/warehouse|oncall@corp.io',
+      'DATABASE_URL=postgres://localhost:5432/db;EMAIL=admin@example.com',
+      'postgresql://h/db?password=${DB_PASS}',
     ],
   },
   'mysql': {
@@ -235,8 +254,20 @@ const PATTERN_TEST_CASES: Record<string, { valid: string[]; invalid: string[] }>
     invalid: ['mysql://sh', 'msql://user:pass@host/db', 'mysql://localhost:3306/mydb'],
   },
   'redis': {
-    valid: ['redis://user:pass@localhost:6379/0', 'rediss://:secure@host:6379'],
-    invalid: ['redis://sh', 'rds://host:6379', 'redis://localhost:6379', 'rediss://secure@host:6379'],
+    valid: [
+      'redis://user:pass@localhost:6379/0',
+      'rediss://:secure@host:6379',
+      'rediss://secure@host:6379',
+      'redis://mysecretpassword@redis-host:6379',
+      'redis://:s3cretRedisPw99Xy@${REDIS_HOST}:6379/0',
+    ],
+    invalid: [
+      'redis://sh',
+      'rds://host:6379',
+      'redis://localhost:6379',
+      '{"cache":"redis://localhost:6379","owner":"ops@corp.io"}',
+      'redis://default@cache.prod.internal:6379',
+    ],
   },
 
   // Auth & Crypto
@@ -370,15 +401,30 @@ describe('CREDENTIAL_PATTERNS', () => {
     { name: '10k after ghp_', value: 'ghp_' + 'a'.repeat(10000) },
     { name: '10k newlines', value: '\n'.repeat(10000) },
     { name: 'mixed long', value: ('aB1_-/.' as string).repeat(2000) },
+    // Scheme-literal stuffing: every failed match attempt at each scheme
+    // occurrence must stay bounded, not rescan to end-of-line (the quadratic
+    // blowup an unbounded userinfo/query run produces on a one-line file).
+    { name: '20k repeated postgres://', value: 'postgres://'.repeat(2000) },
+    { name: '20k repeated redis://', value: 'redis://'.repeat(2500) },
+    { name: '20k repeated mongodb://', value: 'mongodb://'.repeat(2000) },
+    { name: 'postgres:// with long @-free tail', value: 'postgres://' + 'a:b/'.repeat(5000) },
+    { name: 'minified no-space db inventory', value: ('{"u":"postgres://h' + 'x'.repeat(60) + '/db"},').repeat(250) },
   ];
 
   for (const input of REDOS_INPUTS) {
     it(`no regex causes ReDoS on adversarial input "${input.name}" (every pattern <50ms)`, () => {
       for (const pattern of CREDENTIAL_PATTERNS) {
-        const start = performance.now();
-        pattern.regex.test(input.value);
-        const elapsed = performance.now() - start;
-        expect(elapsed, `Pattern ${pattern.id} took ${elapsed}ms on "${input.name}"`).toBeLessThan(50);
+        // Best of 3: the first .test() pays regex-compile/JIT cost, and under
+        // a parallel test run CPU contention can multiply one sample past the
+        // budget. A real quadratic blowup is orders of magnitude over budget
+        // on every sample, so the minimum still catches it.
+        let elapsed = Infinity;
+        for (let run = 0; run < 3; run++) {
+          const start = performance.now();
+          pattern.regex.test(input.value);
+          elapsed = Math.min(elapsed, performance.now() - start);
+        }
+        expect(elapsed, `Pattern ${pattern.id} took ${elapsed}ms (best of 3) on "${input.name}"`).toBeLessThan(50);
       }
     });
   }
@@ -403,6 +449,12 @@ describe('CREDENTIAL_PREFIX_QUICK_CHECK', () => {
   it('does not match random text', () => {
     expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('hello world')).toBe(false);
     expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('just some normal text')).toBe(false);
+  });
+
+  it('derives "redis" from the rediss? pattern, not "rediss" (optional-quantifier trim)', () => {
+    // A 'rediss' prefix would make consumers' ${VAR}-skip drop plain
+    // redis:// lines before the real pattern runs — a silent miss.
+    expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('redis://x')).toBe(true);
   });
 });
 

--- a/packages/credential-patterns/src/patterns.ts
+++ b/packages/credential-patterns/src/patterns.ts
@@ -86,10 +86,13 @@ export const CREDENTIAL_PATTERNS: CredentialPattern[] = [
   { id: 'square', name: 'Square API Key', regex: /sq0[a-z]{3}-[a-zA-Z0-9_-]{22,}/, envPrefix: 'SQUARE_ACCESS_TOKEN', category: 'payment' },
 
   // ── Database (category: database) ─────────────────────────────────────
-  { id: 'mongodb', name: 'MongoDB Connection String', regex: /mongodb\+srv:\/\/[^\s]{10,}/, envPrefix: 'MONGODB_URI', category: 'database' },
-  { id: 'postgres', name: 'PostgreSQL Connection String', regex: /postgres(?:ql)?:\/\/[^\s]{10,}/, envPrefix: 'DATABASE_URL', category: 'database' },
-  { id: 'mysql', name: 'MySQL Connection String', regex: /mysql:\/\/[^\s]{10,}/, envPrefix: 'DATABASE_URL', category: 'database' },
-  { id: 'redis', name: 'Redis Connection String', regex: /rediss?:\/\/[^\s]{10,}/, envPrefix: 'REDIS_URL', category: 'database' },
+  // Connection strings flag only when they embed a secret (userinfo password or
+  // a password= query param). A credential-free URI (postgresql://localhost/db —
+  // the canonical MCP server layout) is topology, not a credential exposure.
+  { id: 'mongodb', name: 'MongoDB Connection String', regex: /mongodb\+srv:\/\/(?:[^\s:@\/]*:[^\s@]+@[^\s]+|[^\s]*[?&]password=[^\s&"']+)/, envPrefix: 'MONGODB_URI', category: 'database' },
+  { id: 'postgres', name: 'PostgreSQL Connection String', regex: /postgres(?:ql)?:\/\/(?:[^\s:@\/]*:[^\s@]+@[^\s]+|[^\s]*[?&]password=[^\s&"']+)/, envPrefix: 'DATABASE_URL', category: 'database' },
+  { id: 'mysql', name: 'MySQL Connection String', regex: /mysql:\/\/(?:[^\s:@\/]*:[^\s@]+@[^\s]+|[^\s]*[?&]password=[^\s&"']+)/, envPrefix: 'DATABASE_URL', category: 'database' },
+  { id: 'redis', name: 'Redis Connection String', regex: /rediss?:\/\/(?:[^\s:@\/]*:[^\s@]+@[^\s]+|[^\s]*[?&]password=[^\s&"']+)/, envPrefix: 'REDIS_URL', category: 'database' },
 
   // ── Auth & Crypto (category: auth) ────────────────────────────────────
   { id: 'google', name: 'Google API Key', regex: /AIza[0-9A-Za-z_-]{35}/, envPrefix: 'GOOGLE_API_KEY', category: 'auth' },
@@ -182,12 +185,12 @@ export const SECRET_FILE_PATTERNS: string[] = [
 export const CONFIG_FILES = [
   'config.json', 'config.yaml', 'config.yml',
   '.env', '.env.local',
-  'package.json', 'mcp.json', '.mcp.json',
+  'package.json', 'mcp.json', '.mcp.json', '.mcp/config.json',
   'CLAUDE.md',
   '.openclaw/config.json', '.moltbot/config.json',
   'openclaw.json', 'moltbot.json',
-  '.cursor/mcp.json', '.vscode/mcp.json',
-  '.claude/settings.json',
+  '.cursor/mcp.json', '.vscode/mcp.json', '.windsurf/mcp.json',
+  '.claude/settings.json', '.claude/settings.local.json',
   '.cursor/settings.json',
   '.github/copilot-instructions.md',
   // Nanobot variants

--- a/packages/credential-patterns/src/patterns.ts
+++ b/packages/credential-patterns/src/patterns.ts
@@ -182,11 +182,11 @@ export const SECRET_FILE_PATTERNS: string[] = [
 export const CONFIG_FILES = [
   'config.json', 'config.yaml', 'config.yml',
   '.env', '.env.local',
-  'package.json', 'mcp.json',
+  'package.json', 'mcp.json', '.mcp.json',
   'CLAUDE.md',
   '.openclaw/config.json', '.moltbot/config.json',
   'openclaw.json', 'moltbot.json',
-  '.curse/mcp.json', '.vscode/mcp.json',
+  '.cursor/mcp.json', '.vscode/mcp.json',
   '.claude/settings.json',
   '.cursor/settings.json',
   '.github/copilot-instructions.md',

--- a/packages/credential-patterns/src/patterns.ts
+++ b/packages/credential-patterns/src/patterns.ts
@@ -86,13 +86,24 @@ export const CREDENTIAL_PATTERNS: CredentialPattern[] = [
   { id: 'square', name: 'Square API Key', regex: /sq0[a-z]{3}-[a-zA-Z0-9_-]{22,}/, envPrefix: 'SQUARE_ACCESS_TOKEN', category: 'payment' },
 
   // ── Database (category: database) ─────────────────────────────────────
-  // Connection strings flag only when they embed a secret (userinfo password or
-  // a password= query param). A credential-free URI (postgresql://localhost/db —
-  // the canonical MCP server layout) is topology, not a credential exposure.
-  { id: 'mongodb', name: 'MongoDB Connection String', regex: /mongodb\+srv:\/\/(?:[^\s:@\/]*:[^\s@]+@[^\s]+|[^\s]*[?&]password=[^\s&"']+)/, envPrefix: 'MONGODB_URI', category: 'database' },
-  { id: 'postgres', name: 'PostgreSQL Connection String', regex: /postgres(?:ql)?:\/\/(?:[^\s:@\/]*:[^\s@]+@[^\s]+|[^\s]*[?&]password=[^\s&"']+)/, envPrefix: 'DATABASE_URL', category: 'database' },
-  { id: 'mysql', name: 'MySQL Connection String', regex: /mysql:\/\/(?:[^\s:@\/]*:[^\s@]+@[^\s]+|[^\s]*[?&]password=[^\s&"']+)/, envPrefix: 'DATABASE_URL', category: 'database' },
-  { id: 'redis', name: 'Redis Connection String', regex: /rediss?:\/\/(?:[^\s:@\/]*:[^\s@]+@[^\s]+|[^\s]*[?&]password=[^\s&"']+)/, envPrefix: 'REDIS_URL', category: 'database' },
+  // Connection strings flag only when they embed a secret: a userinfo password
+  // (user:pass@ / :pass@ — and for redis, any single userinfo token, since
+  // pre-ACL Redis has no usernames) or a password=/pwd=/sslpassword= query
+  // param. A credential-free URI (postgresql://localhost/db — the canonical MCP
+  // server layout) is topology, not a credential exposure. Character classes
+  // exclude quotes and commas so a match can never cross a JSON string boundary
+  // on minified content, and every run is length-bounded so a line stuffed with
+  // scheme literals stays linear-time (both adversarially verified).
+  // The user/password classes additionally exclude $ { } | ; so an
+  // env-var-interpolated password (postgres://app:${DB_PASSWORD}@db — the
+  // recommended secure shape) and markdown-table/compound-env lines never read
+  // as literal secrets; hosts keep $ { } (an interpolated HOST next to a real
+  // password must still flag). Redis carves out the literal `default@` — the
+  // standard Redis 6+ ACL username — from its single-token rule.
+  { id: 'mongodb', name: 'MongoDB Connection String', regex: /mongodb(?:\+srv)?:\/\/(?:[^\s:@\/"',${}|;]{0,64}:[^\s@"',${}|;]{1,256}@[^\s"',]{1,512}|[^\s"']{0,512}[?&](?:password|pwd|sslpassword)=[^\s&"'${}]{1,256})/i, envPrefix: 'MONGODB_URI', category: 'database' },
+  { id: 'postgres', name: 'PostgreSQL Connection String', regex: /postgres(?:ql)?:\/\/(?:[^\s:@\/"',${}|;]{0,64}:[^\s@"',${}|;]{1,256}@[^\s"',]{1,512}|[^\s"']{0,512}[?&](?:password|pwd|sslpassword)=[^\s&"'${}]{1,256})/i, envPrefix: 'DATABASE_URL', category: 'database' },
+  { id: 'mysql', name: 'MySQL Connection String', regex: /mysql:\/\/(?:[^\s:@\/"',${}|;]{0,64}:[^\s@"',${}|;]{1,256}@[^\s"',]{1,512}|[^\s"']{0,512}[?&](?:password|pwd|sslpassword)=[^\s&"'${}]{1,256})/i, envPrefix: 'DATABASE_URL', category: 'database' },
+  { id: 'redis', name: 'Redis Connection String', regex: /rediss?:\/\/(?:(?:[^\s:@\/"',${}|;]{0,64}:)?(?!default@)[^\s@"',${}|;]{1,256}@[^\s"',]{1,512}|[^\s"']{0,512}[?&](?:password|pwd|sslpassword)=[^\s&"'${}]{1,256})/i, envPrefix: 'REDIS_URL', category: 'database' },
 
   // ── Auth & Crypto (category: auth) ────────────────────────────────────
   { id: 'google', name: 'Google API Key', regex: /AIza[0-9A-Za-z_-]{35}/, envPrefix: 'GOOGLE_API_KEY', category: 'auth' },
@@ -117,7 +128,12 @@ export const CREDENTIAL_PREFIX_QUICK_CHECK = new RegExp(
     const src = p.regex.source;
     // Extract leading literal prefix (up to first quantifier or alternation)
     const m = src.match(/^([a-zA-Z0-9_\-.+:/]{3,})/);
-    return m ? m[1].replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : null;
+    if (!m) return null;
+    // A trailing X? quantifier makes the last extracted char optional
+    // (rediss? must yield 'redis', not 'rediss') — trim it, or the
+    // quick-check would exclude lines the real pattern matches.
+    const lit = src[m[1].length] === '?' ? m[1].slice(0, -1) : m[1];
+    return lit.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   })
   .filter(Boolean)
   // Deduplicate prefixes (e.g. multiple sk- patterns)


### PR DESCRIPTION
## Summary

Found by the secretless-ai 0.20.0 release test: a planted Anthropic key inside `.mcp.json` (the Claude Code project-scope MCP config, committed to repos) survived every scanner surface. The canonical list lives here, so the fix does too.

### CONFIG_FILES
- Adds `.mcp.json`, `.mcp/config.json`, `.claude/settings.local.json`, `.windsurf/mcp.json`.
- Fixes the `.curse/mcp.json` typo → `.cursor/mcp.json` (Cursor's project MCP config was unreachable since the entry was introduced).

### Database connection-string precision
Detection-change classification: **(d) expanded-detection + (a) preserved-detection FP-suppress**, per the adversarial-review protocol (three review passes; every attack string is baked into the vector suite in both directions):
- URIs flag only when they embed a secret: userinfo password, `password=`/`pwd=`/`sslpassword=` param (case-insensitive), or — redis only — a single userinfo token (pre-ACL Redis has no usernames; the Redis 6+ ACL username `default@` is carved out). The credential-free canonical MCP layout (`postgresql://localhost:5432/mydb`) no longer produces a CRITICAL.
- Env-var-interpolated passwords (`postgres://app:${POSTGRES_PASSWORD}@db` — the recommended secure shape) no longer flag; an interpolated **host** next to a real password still does.
- Plain `mongodb://` scheme now covered (previously only `+srv`).
- Matches cannot cross JSON string boundaries on minified content (no destructive over-masking in replace()-based redaction consumers).
- All runs length-bounded: a 220 KB scheme-stuffed line dropped from 11–14 s (quadratic) to ~30 ms; the ReDoS suite gains scheme-literal-prefixed inputs (its previous inputs never entered the slow path) and takes best-of-3 timing to be robust to parallel-run contention.
- `CREDENTIAL_PREFIX_QUICK_CHECK` now derives `redis` from `rediss?` — the `rediss` prefix made consumers' `${VAR}`-line skip silently drop plain `redis://` lines before scanning (a real miss, regression-tested).
- Documented narrowing: username-only URIs for postgres/mysql/mongodb no longer match — no password, no secret.

### Consumer re-link
`packages/cli`'s exact pin moves 0.1.2 → 0.1.3 so the workspace package resolves again (the version bump had silently resolved the stale published tarball into `packages/cli/node_modules`).

Long-tail follow-ups (full MCP client matrix, structural JSON config parsing, quick-check prefix gaps, consolidating the CLI's 7 local config lists) are tracked internally.

## Test plan
- credential-patterns: 276/276 (new: membership tests, both-direction vector corpus incl. minified-JSON boundary cases, quick-check `redis://` regression, scheme-stuffed ReDoS inputs).
- Monorepo: 22/22 turbo tasks green; CLI resolves workspace 0.1.3 (verified via require.resolve).
- Cross-verified end-to-end in secretless (consumer): planted key in `.mcp.json` now caught by scan/verify/mcp-status; interpolated-password compose file scans clean; real redis password on a `${REDIS_HOST}` line is caught (was silently skipped).