### PR TITLE
fix(self-register): require confirmation before writing to the public registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-Nothing yet.
+### Security
+- `self-register` no longer writes to the public registry without consent. The command submits community scan-result records to `api.oa2a.org`; `--dry-run` existed but the destructive path was the default and nothing was asked before it ran. A release-test harness invoking the bare command published records from a developer laptop — a sandboxed `HOME` did not prevent it, and `OPENA2A_TELEMETRY_URL` does not apply because `self-register` talks to the registry directly. It now confirms interactively, and a non-interactive shell (`--ci`, or any pipe where stdin is not a TTY) must pass `--yes`. The refusal exits 2 and names both `--yes` and `--dry-run`, in text and in JSON (`code: CONFIRMATION_REQUIRED`), so an automated caller relying on the old behavior fails visibly rather than silently doing nothing. The gate sits ahead of the per-tool loop, so a refused run performs no existence checks and no HMA scans — previously a bare invocation made 33 requests before finishing.
 
 ## [0.10.12] - 2026-07-29
 

--- a/packages/cli/__tests__/commands/self-register-confirmation.test.ts
+++ b/packages/cli/__tests__/commands/self-register-confirmation.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { selfRegister } from '../../src/commands/self-register.js';
+import type { SelfRegisterOptions } from '../../src/commands/self-register.js';
+
+// `self-register` writes to the PUBLIC registry (POST
+// /api/v1/registry/community/scan-result). Before this gate, the destructive
+// path was the default: `--dry-run` was opt-in and nothing else stood between
+// an invocation and a production write. A fresh-user release-test subagent ran
+// the bare command and submitted scan results for the whole tool manifest to
+// https://api.oa2a.org from a developer laptop. A sandboxed HOME did not stop
+// it, and OPENA2A_TELEMETRY_URL does not apply — self-register talks to the
+// registry directly.
+//
+// The contract these tests pin: no network WRITE without either an explicit
+// `--yes` or an interactive confirmation. Refusal must be non-zero so a script
+// that assumed the old behavior fails loudly instead of silently doing nothing.
+
+const mockFetch = vi.fn();
+
+function captureStdout(fn: () => Promise<number>): Promise<{ exitCode: number; output: string }> {
+  const chunks: string[] = [];
+  const origWrite = process.stdout.write;
+  process.stdout.write = ((chunk: any) => {
+    chunks.push(String(chunk));
+    return true;
+  }) as any;
+
+  return fn().then(exitCode => {
+    process.stdout.write = origWrite;
+    return { exitCode, output: chunks.join('') };
+  }).catch(err => {
+    process.stdout.write = origWrite;
+    throw err;
+  });
+}
+
+/** Mock that accepts every registry call, so any write attempt is visible. */
+function mockAcceptEverything() {
+  mockFetch.mockImplementation(async (url: string) => {
+    if (String(url).includes('by-name')) {
+      return { ok: true, json: async () => ({ data: { id: 'pkg-1' } }) };
+    }
+    if (String(url).includes('request-scan-token')) {
+      return { ok: true, json: async () => ({ scanToken: 'tok-123' }) };
+    }
+    if (String(url).includes('scan-result')) {
+      return { ok: true, json: async () => ({ status: 'accepted' }) };
+    }
+    return { ok: false, status: 500 };
+  });
+}
+
+/** Registry calls that mutate state. GETs (existence checks) are harmless. */
+function writeCalls(): string[] {
+  return mockFetch.mock.calls
+    .map(c => String(c[0]))
+    .filter(u => u.includes('scan-result') || u.includes('request-scan-token'));
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('self-register confirmation gate', () => {
+  it('makes NO registry write non-interactively without --yes, and exits non-zero', async () => {
+    mockAcceptEverything();
+
+    const options: SelfRegisterOptions = {
+      ci: true, // non-interactive: cannot prompt
+      format: 'json',
+      only: ['hackmyagent'],
+    };
+
+    const { exitCode } = await captureStdout(() => selfRegister(options));
+
+    // The load-bearing assertion: nothing was submitted to the registry.
+    expect(writeCalls()).toEqual([]);
+    // And the refusal is loud, not a silent no-op.
+    expect(exitCode).not.toBe(0);
+  });
+
+  it('names --yes and --dry-run in the refusal so the user is not left guessing', async () => {
+    mockAcceptEverything();
+
+    const { output } = await captureStdout(() => selfRegister({
+      ci: true,
+      format: 'text',
+      only: ['hackmyagent'],
+    }));
+
+    expect(output).toContain('--yes');
+    expect(output).toContain('--dry-run');
+  });
+
+  it('DOES write when --yes is given (gate is not simply blocking everything)', async () => {
+    mockAcceptEverything();
+
+    const { exitCode } = await captureStdout(() => selfRegister({
+      ci: true,
+      yes: true,
+      skipScan: true,
+      format: 'json',
+      only: ['hackmyagent'],
+    }));
+
+    // Positive control: without this, a fix that blocks unconditionally passes.
+    expect(writeCalls().length).toBeGreaterThan(0);
+    expect(exitCode).toBe(0);
+  });
+
+  it('still allows --dry-run with no --yes, and makes no request at all', async () => {
+    mockAcceptEverything();
+
+    const { exitCode } = await captureStdout(() => selfRegister({
+      dryRun: true,
+      ci: true,
+      format: 'json',
+      only: ['hackmyagent'],
+    }));
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(exitCode).toBe(0);
+  });
+
+  it('refuses before any per-tool work, not after scanning the whole manifest', async () => {
+    mockAcceptEverything();
+
+    // No `only` filter: the full 11-tool manifest. A gate placed inside the
+    // per-tool loop would still fire HMA scans and existence checks before
+    // refusing; the gate belongs ahead of the loop.
+    await captureStdout(() => selfRegister({ ci: true, format: 'json' }));
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/__tests__/commands/self-register.test.ts
+++ b/packages/cli/__tests__/commands/self-register.test.ts
@@ -181,6 +181,9 @@ describe('selfRegister', () => {
     const options: SelfRegisterOptions = {
       skipScan: true,
       ci: true,
+      // Non-interactive writes require explicit consent; see
+      // self-register-confirmation.test.ts for the gate itself.
+      yes: true,
       format: 'json',
       only: ['hackmyagent'],
     };
@@ -214,6 +217,7 @@ describe('selfRegister', () => {
     const options: SelfRegisterOptions = {
       skipScan: true,
       ci: true,
+      yes: true, // non-interactive write requires explicit consent
       format: 'json',
       only: ['hackmyagent', 'dvaa'],
     };

--- a/packages/cli/src/commands/self-register.ts
+++ b/packages/cli/src/commands/self-register.ts
@@ -237,8 +237,15 @@ async function confirmPublicWrite(
   try {
     const { confirm } = await import('@inquirer/prompts');
     return await confirm({ message: 'Publish these records?', default: false });
-  } catch {
-    // Prompt unavailable or cancelled (e.g. Ctrl-C) -- treat as refusal.
+  } catch (err) {
+    // Always refuse on error -- this path must fail closed. But say why:
+    // silently returning false makes a cancelled prompt and a broken prompt
+    // look identical, and the user is left guessing which happened.
+    const cancelled = err instanceof Error && err.name === 'ExitPromptError';
+    process.stderr.write(cancelled
+      ? dim('Cancelled. Nothing was published.\n')
+      : yellow(`Could not show the confirmation prompt (${err instanceof Error ? err.message : String(err)}).\n`) +
+        dim('  Nothing was published. Use --yes to publish non-interactively, or --dry-run to preview.\n'));
     return false;
   }
 }

--- a/packages/cli/src/commands/self-register.ts
+++ b/packages/cli/src/commands/self-register.ts
@@ -33,6 +33,8 @@ export interface SelfRegisterOptions {
   skipScan?: boolean;
   only?: string[];
   dryRun?: boolean;
+  /** Skip the interactive confirmation. Required to write from a non-interactive shell. */
+  yes?: boolean;
   ci?: boolean;
   format?: 'text' | 'json';
   verbose?: boolean;
@@ -184,6 +186,63 @@ export const TOOL_MANIFEST: ToolManifest[] = [
   },
 ];
 
+// --- Confirmation ---
+
+/**
+ * Gate the destructive default path. Returns true only when the operator has
+ * actually agreed to a public write.
+ *
+ * Non-interactive callers (--ci, or any pipe/CI runner where stdin is not a
+ * TTY) cannot be prompted, so they must pass --yes. Refusing there rather than
+ * assuming consent is the whole point: a release-test harness running the bare
+ * command previously published to the production registry with nothing asked.
+ * The refusal exits non-zero so an automated caller that relied on the old
+ * behavior fails visibly instead of silently writing nothing.
+ */
+async function confirmPublicWrite(
+  registryUrl: string,
+  toolCount: number,
+  isCi: boolean,
+  isJson: boolean,
+): Promise<boolean> {
+  const target = registryUrl || '(no registry configured)';
+  const interactive = !isCi && !isJson && process.stdin.isTTY === true;
+
+  if (!interactive) {
+    const message =
+      `Refusing to publish without confirmation.\n` +
+      `  ${toolCount} tool record(s) would be submitted to ${target}.\n` +
+      `  This writes to a public registry and cannot be undone from the CLI.\n` +
+      `  Re-run with --yes to proceed, or --dry-run to preview.\n`;
+    if (isJson) {
+      process.stdout.write(JSON.stringify({
+        error: 'confirmation required',
+        code: 'CONFIRMATION_REQUIRED',
+        registryUrl: target,
+        toolCount,
+        hint: 'Re-run with --yes to proceed, or --dry-run to preview.',
+        tools: [],
+      }) + '\n');
+    } else {
+      process.stdout.write(yellow(message));
+    }
+    return false;
+  }
+
+  process.stdout.write(
+    yellow(`About to submit ${toolCount} tool record(s) to ${cyan(target)}.\n`) +
+    dim('  This writes to a public registry and cannot be undone from the CLI.\n\n'),
+  );
+
+  try {
+    const { confirm } = await import('@inquirer/prompts');
+    return await confirm({ message: 'Publish these records?', default: false });
+  } catch {
+    // Prompt unavailable or cancelled (e.g. Ctrl-C) -- treat as refusal.
+    return false;
+  }
+}
+
 // --- Core ---
 
 export async function selfRegister(options: SelfRegisterOptions): Promise<number> {
@@ -208,6 +267,17 @@ export async function selfRegister(options: SelfRegisterOptions): Promise<number
 
   if (options.dryRun && !isJson) {
     process.stdout.write(yellow('[DRY RUN] No HTTP requests will be made.\n\n'));
+  }
+
+  // This command writes to a PUBLIC registry, so it asks before it does.
+  // The gate sits ahead of the per-tool loop on purpose: placing it inside
+  // would still fire existence checks and HMA scans for every tool before
+  // refusing. A dry run is already read-only and needs no confirmation.
+  if (!options.dryRun && !options.yes) {
+    const confirmed = await confirmPublicWrite(registryUrl, tools.length, isCi, isJson);
+    if (!confirmed) {
+      return 2;
+    }
   }
 
   const results: ToolResult[] = [];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -863,6 +863,7 @@ analysis runs and results can be shared with the community.
     .option('--skip-scan', 'Skip HMA scanning, register metadata only')
     .option('--only <tools>', 'Comma-separated tool names')
     .option('--dry-run', 'Show what would happen without making changes')
+    .option('-y, --yes', 'Skip the confirmation prompt (required non-interactively)')
     .action(async (opts) => {
       const { selfRegister } = await import('./commands/self-register.js');
       const globalOpts = program.opts();
@@ -871,6 +872,7 @@ analysis runs and results can be shared with the community.
         skipScan: opts.skipScan,
         only: opts.only?.split(','),
         dryRun: opts.dryRun,
+        yes: opts.yes,
         ci: globalOpts.ci,
         format: globalOpts.format,
         verbose: globalOpts.verbose,


### PR DESCRIPTION
## The problem

`self-register` submits community scan-result records to the public registry (`POST /api/v1/registry/community/scan-result` at `api.oa2a.org`). It had a `--dry-run`, but **the destructive path was the default and nothing was asked before it ran.**

This is not hypothetical. During the 0.10.12 release test a fresh-user subagent ran the bare command and published from a developer laptop. Two things that look like they should have prevented it did not:

- a sandboxed `HOME` — irrelevant, the target is a remote registry, not local state;
- `OPENA2A_TELEMETRY_URL` pointing at a dead endpoint — irrelevant, `self-register` talks to the registry directly and never consults that variable.

There is also no removal command in the CLI surface, so a mistaken run cannot be undone by the tool that made it.

## The fix

| Invocation | Before | After |
|---|---|---|
| `self-register` (TTY) | publishes immediately | prompts, default **No** |
| `self-register --ci` | publishes immediately | refuses, exit 2 |
| piped / non-TTY | publishes immediately | refuses, exit 2 |
| `--ci --yes` | publishes | publishes |
| `--dry-run` | read-only | read-only, unchanged |

The refusal names both `--yes` and `--dry-run`, in text and in JSON (`code: CONFIRMATION_REQUIRED`), and exits **non-zero** so an automated caller that relied on the old behavior fails visibly rather than silently doing nothing.

**The gate sits ahead of the per-tool loop, not inside it.** A gate in the loop would still run existence checks and HMA scans for all 11 tools before refusing. Measured on the pre-fix build, a bare invocation issued **33 requests**; it now issues zero. There is a test pinning that specifically.

## Verification

Regression tests were confirmed **red before the fix** — 3 of 5 failing, including the 33-request case. The suite includes a **positive control** asserting `--yes` still writes, so a fix that simply blocks everything cannot pass it.

Real CLI behavior, not just mocks:

```
$ opena2a self-register --ci --only hackmyagent          # exit 2
Refusing to publish without confirmation.
  1 tool record(s) would be submitted to https://api.oa2a.org.
  This writes to a public registry and cannot be undone from the CLI.
  Re-run with --yes to proceed, or --dry-run to preview.

$ opena2a self-register --ci --format json ...           # exit 2
{"error":"confirmation required","code":"CONFIRMATION_REQUIRED",...}

$ opena2a self-register --ci --dry-run --format json ... # exit 0, unchanged
```

Suite: **1416 tests pass** (was 1411), 89 files, typecheck 15/15, lint 16/16.

The two pre-existing tests that drove non-interactive writes now pass `yes: true` explicitly. That states the contract rather than assuming it — they previously encoded the unsafe default.

## Note on Phase 4 of the gate

`hackmyagent secure --ci` currently reports 0/100 on this repo, but that is **not attributable to this branch**: a control scan of a clean worktree at `origin/main` reproduces it exactly. 85 of the 91 criticals cite `~/.openclaw/sandboxes/**`, outside the scanned directory, which appeared on the machine between two runs of the same binary and moved the score 69 -> 0. Filed as opena2a-org/hackmyagent#337. The in-repo test-fixture false positives are opena2a-org/hackmyagent#335.

## Not covered here

Whether the records written during the release test can be identified and deleted, and whether they moved any public counts, is still open — see the session notes. Public reads suggest little or nothing landed (no packages were created; `ai-trust` and `cryptoserve` are still 404; `hackmyagent`'s `lastScannedAt` is unchanged since 2026-03-02), but that cannot be confirmed without registry logs or DB access. Submissions are identifiable if they did land: `scanId` has a `self-register-` prefix and `rawReport.generator` is `opena2a-self-register`.