### PR TITLE
An unreadable event log is unknown, not intact

### DIFF
--- a/packages/cli/__tests__/shield/shield-read-failure.test.ts
+++ b/packages/cli/__tests__/shield/shield-read-failure.test.ts
@@ -1,0 +1,69 @@
+/**
+ * An unreadable event log is UNKNOWN, and unknown is not intact.
+ *
+ * `runShieldPhase` wraps `readVerifiedEvents` in a try/catch. That catch used
+ * to fall back to `chainBroken: false` with zero events, which reports an
+ * unreadable log as a clean one -- the same fail-open shape the chain
+ * verification exists to close, one layer up.
+ *
+ * The branch is unreachable in production today: `readAllEvents` swallows its
+ * own I/O errors and `verifyEventChain` is total over JSON-derived input. That
+ * is precisely why it needs a test. An unreachable branch is where a wrong
+ * default survives unnoticed -- a mutation of that line cannot be killed by any
+ * test that only drives the phase through real logs, so the mutation score of
+ * the surrounding work said nothing about it either way.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+
+const throwing = vi.hoisted(() => ({ shouldThrow: false }));
+
+vi.mock('../../src/shield/events.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/shield/events.js')>();
+  return {
+    ...actual,
+    readVerifiedEvents: (...args: Parameters<typeof actual.readVerifiedEvents>) => {
+      if (throwing.shouldThrow) throw new Error('event log unreadable');
+      return actual.readVerifiedEvents(...args);
+    },
+  };
+});
+
+let targetDir: string;
+
+beforeEach(() => {
+  throwing.shouldThrow = false;
+  targetDir = fs.mkdtempSync(path.join(tmpdir(), 'shield-read-failure-'));
+});
+
+afterEach(() => {
+  throwing.shouldThrow = false;
+  fs.rmSync(targetDir, { recursive: true, force: true });
+});
+
+describe('runShieldPhase when the event log cannot be read', () => {
+  it('reports the chain as broken, not intact', async () => {
+    const { runShieldPhase } = await import('../../src/commands/review.js');
+
+    throwing.shouldThrow = true;
+    const data = runShieldPhase(targetDir);
+
+    expect(data.chainBroken).toBe(true);
+    expect(data.eventCount).toBe(0);
+  });
+
+  it('does not score better than a readable log with the same zero events', async () => {
+    const { runShieldPhase } = await import('../../src/commands/review.js');
+
+    throwing.shouldThrow = false;
+    const readable = runShieldPhase(targetDir);
+
+    throwing.shouldThrow = true;
+    const unreadable = runShieldPhase(targetDir);
+
+    // The whole point: failing to read must never be the cheaper outcome.
+    expect(unreadable.shieldPostureScore).toBeLessThanOrEqual(readable.shieldPostureScore);
+  });
+});

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -842,8 +842,16 @@ export function runShieldPhase(targetDir: string): ShieldPhaseData {
   try {
     verified = readVerifiedEvents({ since: '7d' });
   } catch {
+    // A log we could not read is UNKNOWN, and unknown is not intact. This
+    // previously reported `chainBroken: false` with zero events, which renders
+    // an unreadable log as a clean one -- the same fail-open shape this phase
+    // exists to close, one layer up. `readAllEvents` currently swallows its own
+    // I/O errors and `verifyEventChain` is total over JSON-derived input, so
+    // this block is unreachable today; it is corrected now because it goes live
+    // the moment either of those properties changes, and because an unreachable
+    // branch is exactly where a wrong default survives unnoticed.
     verified = {
-      events: [], untrusted: [], chainBroken: false, brokenAt: null,
+      events: [], untrusted: [], chainBroken: true, brokenAt: 0,
       untrustedCount: 0, firstUntrusted: null,
     };
   }


### PR DESCRIPTION
`runShieldPhase` wraps `readVerifiedEvents` in a try/catch whose fallback was `chainBroken: false` with zero events. That reports a log we could not read as a clean one — the same fail-open shape the chain verification exists to close, one layer up. It now reports the chain as broken.

The branch is unreachable today: `readAllEvents` swallows its own I/O errors and `verifyEventChain` is total over JSON-derived input. Corrected anyway, because it goes live the moment either property changes.

**The unreachability is the more useful finding.** No test drove this line, so a mutation of it could not be killed by any test that exercises the phase through real logs — which means the mutation testing reported for the surrounding work never covered it in either direction. A mutation score says nothing about lines the selector could not reach, and an unreachable default is the easiest kind of line for a selector to miss.

Adds a test that injects a throwing `readVerifiedEvents` so the branch is reachable, asserts the chain reads as broken, and asserts the unreadable path never scores better than the readable one on the same zero events.

Calibrated: reverting the fix turns both new tests red. Full suite **1563 passed** across 99 files (was 1561/98).