### PR TITLE
Refuse to publish from a commit that is not on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The ancestry guard below needs real history; the default shallow
+          # clone cannot answer whether the tagged commit is on main.
+          fetch-depth: 0
+
+      - name: Tagged commit must be on main
+        run: |
+          # The tag push IS the publish event, and it publishes whatever commit
+          # the tag points at -- including one on a branch that was never
+          # merged, or force-pushed somewhere unreviewed. Every gate on `main`
+          # is bypassed by tagging around it, so this is the check that makes
+          # those gates mean something at publish time.
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag ${GITHUB_REF_NAME} points at $GITHUB_SHA, which is not an ancestor of origin/main."
+            echo "Publishing from a commit that is not on main bypasses every check that gates main."
+            echo "Merge it first, then tag the merged commit."
+            exit 1
+          fi
+          echo "$GITHUB_SHA is on main."
+
       - uses: actions/setup-node@v4
         with:
           node-version: 24


### PR DESCRIPTION
The tag push is the publish event, and it publishes whatever commit the tag points at. Nothing checked that the commit was on `main`.

So every gate that protects `main` — the required review check, the build matrix, branch protection, `enforce_admins` — could be bypassed by tagging around it. A tag on an unmerged branch published exactly the same way as a tag on a reviewed commit.

Adds an ancestry check before any publish step, plus `fetch-depth: 0` on the checkout, because the default shallow clone cannot answer the question.

## Pairs with a ruleset added the same day

`Release tags are immutable` (ruleset `20674001`, active) blocks `deletion` and `non_fast_forward` on all **twelve** release tag patterns this workflow triggers on — not just `cli-v*`/`v*`. Before today, `gh api repos/opena2a-org/opena2a/tags/protection` returned 404 and `rulesets` returned `[]`: the publish event had no server-side control of any kind.

Between the two: a release tag cannot be moved after the fact, and cannot point at code that never reached `main` in the first place.

## Verified both directions

```
commit on main            -> merge-base --is-ancestor: PASS  (guard allows)
commit on unmerged branch -> merge-base --is-ancestor: FAIL  (guard blocks)
```

Run against this branch's own tip, which is genuinely not on `main`.

## What this does not do

It does not decide *who* may create a release tag. With a single maintainer that would be a lockout risk rather than a control, and it is a separate decision.
