### PR TITLE
Add a dispatchable concurrency stress job for the shield event lock

### DIFF
--- a/.github/workflows/concurrency-stress.yml
+++ b/.github/workflows/concurrency-stress.yml
@@ -1,0 +1,81 @@
+name: Concurrency stress
+
+# The PR gate runs the shield concurrent-writer test at N=8 for two rounds, which
+# accumulates four iterations across two CI runs. With zero observed failures in
+# n trials, the one-sided 95% upper bound on the per-iteration failure
+# probability is approximately 3/n. Four iterations bound it at roughly 75%,
+# which is uninformative — it is consistent with a lock that fails one time in
+# two. This job exists to reach a bound worth quoting.
+#
+# Re-derive the iteration count from that rule, do not copy the literal. If the
+# runner, the lock implementation or the filesystem changes, the required n
+# changes with the bound you need, not with what was written here.
+#
+# It is workflow_dispatch on purpose. ci.yml triggers on pull_request only, so
+# nothing has ever run against the commit a release tag is cut from. Dispatch
+# this against main's tip before cutting a tag.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Ref to run against. Use main for a pre-tag gate run.'
+        required: false
+        default: 'main'
+
+jobs:
+  stress:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # 100 iterations total: 40 + 40 + 20. The bound needs the count; the
+          # spread across writer counts is what exercises different contention
+          # regimes on a 4-core runner.
+          - writers: 2
+            rounds: 40
+          - writers: 8
+            rounds: 40
+          - writers: 32
+            rounds: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+
+      # Prove the harness can fail before trusting that it passed. The test must
+      # reject an override that would silently reduce coverage to zero
+      # iterations; if it accepts one, every green run below is meaningless.
+      - name: Calibrate the override guard (MUST fail)
+        working-directory: packages/cli
+        env:
+          SHIELD_CONCURRENT_WRITERS: 'eight'
+          SHIELD_CONCURRENT_ROUNDS: '2'
+        run: |
+          if npx vitest run __tests__/shield/concurrent-write.test.ts >/dev/null 2>&1; then
+            echo "::error::Calibration failed: a non-integer writer count was accepted. A typo'd override would run zero iterations and still report success."
+            exit 1
+          fi
+          echo "Calibration passed: the override guard rejects a non-integer writer count."
+
+      - name: Stress the shield event lock
+        working-directory: packages/cli
+        env:
+          SHIELD_CONCURRENT_WRITERS: ${{ matrix.writers }}
+          SHIELD_CONCURRENT_ROUNDS: ${{ matrix.rounds }}
+        run: |
+          echo "Running ${{ matrix.rounds }} rounds at N=${{ matrix.writers }} concurrent writers."
+          npx vitest run __tests__/shield/concurrent-write.test.ts --reporter=verbose
+
+      - name: Record what this leg actually ran
+        if: always()
+        run: |
+          echo "ref=${{ inputs.ref }} commit=${{ github.sha }} writers=${{ matrix.writers }} rounds=${{ matrix.rounds }}" >> "$GITHUB_STEP_SUMMARY"

--- a/packages/cli/__tests__/shield/concurrent-write.test.ts
+++ b/packages/cli/__tests__/shield/concurrent-write.test.ts
@@ -95,10 +95,26 @@ function readLog(home: string): { lines: string[]; shieldDir: string } {
 }
 
 describe('concurrent writeEvent (#231)', () => {
-  const N = 8;
+  // Defaults are the PR-gate configuration and must not change: 8 writers, two
+  // rounds. The env overrides exist so the dispatchable stress job in
+  // concurrency-stress.yml can drive the SAME test at higher writer counts and
+  // more rounds, rather than forking a second copy that can drift from this one.
+  const N = Number(process.env.SHIELD_CONCURRENT_WRITERS ?? 8);
+  const ROUNDS = Number(process.env.SHIELD_CONCURRENT_ROUNDS ?? 2);
+
+  if (!Number.isInteger(N) || N < 1 || !Number.isInteger(ROUNDS) || ROUNDS < 1) {
+    // A typo'd override must not silently reduce coverage to nothing. Without
+    // this, SHIELD_CONCURRENT_WRITERS=eight yields NaN, the loop body never
+    // runs, and the job reports success having tested zero writers — the same
+    // shape as a gate that passes because it measured nothing.
+    throw new Error(
+      `Invalid concurrency override: SHIELD_CONCURRENT_WRITERS=${process.env.SHIELD_CONCURRENT_WRITERS}, ` +
+      `SHIELD_CONCURRENT_ROUNDS=${process.env.SHIELD_CONCURRENT_ROUNDS}. Both must be positive integers.`,
+    );
+  }
 
   // Two rounds: one clean round can hide a lock that only mostly works.
-  for (const round of [1, 2]) {
+  for (const round of Array.from({ length: ROUNDS }, (_, i) => i + 1)) {
     it(`keeps the chain intact across ${N} concurrent writer processes (round ${round})`, async () => {
       const home = makeHome();
       await runChildren(home, N);


### PR DESCRIPTION
Closes CPO's release gate 1 for `0.11.0` on the reading CPO confirmed it meant.

## Why

The gate wording was "a **repeated** concurrent-writer run **on the CI runner**, not one green local run". What runs on CI today is the PR-gate test at N=8 for two rounds — **four accumulated iterations across two CI runs**. The 102-iteration campaign at N=2/8/16/32 under CPU saturation was **local only** (16 cores; `ubuntu-latest` is 4-core). No dispatchable stress job existed.

CPO ruled the conjunctive reading, explicitly declining the reading that would have let the release proceed.

## The count is derived, not chosen

With zero observed failures in `n` trials, the one-sided 95% upper bound on the per-iteration failure probability is approximately `3/n`.

| iterations | 95% upper bound on failure rate |
|---|---|
| 4 (today) | ~75% — consistent with a lock that fails one time in two |
| 100 (this job) | ~3% |

The derivation is in the workflow comment so that anyone changing the runner, the filesystem or the lock re-derives the required `n` rather than copying the literal.

## Parameterised, not forked

`concurrent-write.test.ts` now reads `SHIELD_CONCURRENT_WRITERS` and `SHIELD_CONCURRENT_ROUNDS`, both defaulting to today's values. The stress path and the PR gate therefore exercise the **same** test and cannot drift.

## The guard, and why it is not decoration

A bad override must not silently reduce coverage to zero. `SHIELD_CONCURRENT_WRITERS=eight` yields `NaN`, `Array.from({length: NaN})` is empty, the round loop never executes, and vitest reports success having tested **nothing** — the same shape as the `sast` gate this repo fixed in #280. The test now rejects any non-integer or non-positive override, and the job **calibrates that guard before running anything real**: it asserts a typo'd override fails, then runs the matrix.

## Verified locally

| run | result |
|---|---|
| default (PR-gate config) | 12 tests, unchanged |
| `WRITERS=3 ROUNDS=4` | 14 tests; four rounds at three writers |
| `WRITERS=eight` | exit 1 |
| `ROUNDS=0` | exit 1 |

## How the gate closes

Dispatch against `main`'s tip (not a PR head — `ci.yml` is `pull_request`-only, so nothing has ever run against the commit the tag will be cut from). One green dispatched run whose log shows the iteration counts and N values closes gate 1. Any failure reopens `0.11.0` in full.

## Tracked, not blocking

No mutation harness is committed — no stryker config, no script. PR #276's 100% score is not reproducible from the repo. Reopens at the next release that cites a mutation score.