### PR TITLE
Stop claiming review controls we cannot show

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,11 +111,10 @@ Some checks on this repository need credentials that GitHub does not provide
 to workflows triggered from a fork. Those checks will not report a result on
 your pull request, and that is not a problem with your change.
 
-When that happens, a maintainer runs the build, the type check and the full
-test suite against the merged tree before merging, and records the result on
-the pull request. You do not need to do anything differently. Running
-`npx turbo build` and `npx turbo test` locally before you open the pull
-request is the fastest way to keep that step short.
+Run `npx turbo build` and `npx turbo test` locally before you open the pull
+request, and put what you ran and what it returned in the description. When a
+check cannot report, that description is the only record of the change being
+exercised, so it is worth writing out in full.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Full index: [docs/USE-CASES.md](docs/USE-CASES.md).
 
 ## Contributing
 
-Apache 2.0. PRs from outside the org welcome. [CONTRIBUTING.md](CONTRIBUTING.md) has the dev loop, test conventions, and pre-push review gates.
+Apache 2.0. PRs from outside the org welcome. [CONTRIBUTING.md](CONTRIBUTING.md) has the dev loop, the test conventions, and what to expect on a pull request opened from a fork.
 
 ```bash
 git clone https://github.com/opena2a-org/opena2a.git


### PR DESCRIPTION
Two sentences told outside contributors that a control runs. Neither has a source behind it. Ruled by CHIEF-CCO 2026-08-11; recorded in `todo/COUNCIL_LEDGER.md`.

## README.md:234

Said `CONTRIBUTING.md` "has the dev loop, test conventions, and **pre-push review gates**" — in the same sentence that invites PRs from outside the org, pointing at a file that contains no occurrence of `gate`, `required`, `review` or `approv`. A claim with no source.

Replaced with three referents that do exist and were verified on `origin/main`: `## Development Setup` (:22), `## Running Tests` (:39), `## Pull requests from forks` (:108).

## CONTRIBUTING.md:114-118

Asserted that "a maintainer runs the build, the type check and the full test suite against the merged tree before merging, and records the result on the pull request."

That describes a control, undated and unsourced, and it is not what happened on the most recent fork PR. Replaced with an instruction to the contributor — which asserts nothing about what we do — keeping the genuinely useful part: when a check cannot report, the PR description is the only record that the change was exercised.

## What is deliberately absent

Neither sentence now says anything about what CI does on a fork PR. That is measured for this repository and not for the others carrying the same sentence, and asserting it uniformly would reproduce the defect being fixed.

## Verification

`grep -rniE "review gate|pre-push review|all changes are reviewed|require.*code review"` over `README.md`, `CONTRIBUTING.md` and `SECURITY.md` now returns nothing.

## Not in this PR

The same sentence exists at `hackmyagent/README.md:393` and `agent-identity-management/README.md:315`, and a related claim at `ai-browserguard/README.md:97`. Those repos have their own active sessions and are handed off rather than edited here.

A `SECURITY.md` known-advisories section was also drafted and is deliberately **held** — it describes an unremediated weakness and points at an install path that is the subject of an open escalation. It ships once that is answered.