### PR TITLE
Run CI against main's tip, and stop the concurrency key collapsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,36 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'packages/**'
-      - 'package.json'
-      - 'turbo.json'
-      - 'tsconfig.base.json'
-      # A lone ATX_CONFORMANCE_REF bump must still run the fixture drift gate.
-      - '.github/workflows/ci.yml'
+  # A release tag is cut from main, and until now nothing here had ever run
+  # against a commit on main -- only against pull request heads. This repository
+  # squash-merges, so the squash commit's tree can differ from any tree CI saw.
+  push:
+    branches: [main]
+  # Lets a red or missing run on main's tip be re-checked without an empty
+  # commit, which cannot re-trigger a workflow anyway.
+  workflow_dispatch:
+
+# The paths filter is deliberately absent from BOTH triggers.
+#
+# On push it would be wrong in kind: this trigger answers "is main's tip green",
+# which is a property of the tip, not of a diff, and a filtered push can leave a
+# commit with no run at all.
+#
+# On pull_request it was a coverage gap in its own right: a change touching only
+# release.yml, security.yml or scripts/ got no CI, and would then meet CI for the
+# first time on main. Cost of removing it is about two minutes on a docs-only
+# pull request, and standard runners are free on a public repository.
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number }}
+  # Was `ci-${{ github.event.pull_request.number }}`, which evaluates to the
+  # literal `ci-` on any non-pull-request event. With cancel-in-progress, every
+  # push to main would have shared one group and each merge would have cancelled
+  # the previous tip's run.
+  #
+  # event_name is part of the key so that a manual re-check does not cancel the
+  # in-flight push run for the same commit -- github.ref is refs/heads/main for
+  # both, so ref alone is not enough to separate them.
+  group: ci-${{ github.event.pull_request.number || format('{0}-{1}', github.event_name, github.ref) }}
   cancel-in-progress: true
 
 jobs:
@@ -67,8 +87,24 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Clone pinned atx-conformance suite
+        # Retried, and its failure is labelled, because this job now runs on
+        # main. A single un-retried clone of a third party's repository means a
+        # transient network failure leaves main's tip red, and a red tip is
+        # indistinguishable from real fixture drift -- which is a supply-chain
+        # signal. Never let an outage read as tampering, or the reverse.
         run: |
-          git clone --no-checkout https://github.com/opena2a-standards/atx-conformance.git /tmp/atx-conformance
+          for attempt in 1 2 3; do
+            if git clone --no-checkout https://github.com/opena2a-standards/atx-conformance.git /tmp/atx-conformance; then
+              break
+            fi
+            if [ "$attempt" = 3 ]; then
+              echo "::error::Could not reach github.com/opena2a-standards/atx-conformance after 3 attempts. This is a NETWORK failure, not fixture drift. Re-run this job; do not treat it as a conformance finding."
+              exit 1
+            fi
+            echo "Clone attempt $attempt failed, retrying in $((attempt * 5))s."
+            sleep $((attempt * 5))
+            rm -rf /tmp/atx-conformance
+          done
           git -C /tmp/atx-conformance checkout "$ATX_CONFORMANCE_REF"
 
       - name: MANIFEST.sha256 integrity


### PR DESCRIPTION
Ruled by CHIEF-CISO 2026-08-11, routed to it by CHIEF-CPO which said this is "gate-trigger configuration and belongs to CISO". Adversarially reviewed; this PR ships only the parts the review **could not break**.

## The gap

`ci.yml` triggered on `pull_request` only. A release tag is cut from `main`, so `build`, `typecheck`, `lint` and `atx-fixture-drift` had **never run against any commit on main** — only against PR heads.

Not theoretical here. This repo squash-merges — the last five first-parent commits on main each have exactly one parent. With `strict: false`, a PR can be green against a base that is no longer main's tip, and the squash commit's tree is then a tree CI never saw. Nothing runs afterwards to notice.

## What changed

- **`push: branches: [main]` and `workflow_dispatch`.** The dispatch matters because an empty commit cannot re-trigger a workflow, so without it a red or missing run on the tip has no way to be re-checked.
- **`paths:` deleted from BOTH triggers.** On push it is wrong in kind: the question is "is main's tip green" — a property of the tip, not of a diff — and a filtered push can leave a commit with no run at all. On `pull_request` it was its own gap: a change touching only `release.yml`, `security.yml` or `scripts/` got no CI and would meet it for the first time on main.
- **A live concurrency bug, fixed in the same change because the push trigger would otherwise expose it.** The group was `ci-${{ github.event.pull_request.number }}`, which evaluates to the literal `ci-` on any non-PR event. With `cancel-in-progress`, every push to main would have shared one group and each merge would have cancelled the previous tip's run. `event_name` is in the key too, so a manual re-check does not cancel the in-flight push run for the same commit — `github.ref` is `refs/heads/main` for both, so ref alone does not separate them.
- **The atx-conformance clone is retried and its failure labelled.** That job clones a third party's repo with no retry. Now that it runs on main, one transient network failure leaves the tip red — and a red tip is indistinguishable from real fixture drift, which is a supply-chain signal. An outage must never read as tampering, or the reverse.

## Cost, measured

Public repo, so standard runners are free (`actions/runs/<id>/timing` returns `billable.UBUNTU.total_ms: 0`). A run is ~110s. Main took **21 first-parent commits in the last 30 days**. So this buys ~21 runs/month at ~2 minutes, at no cost.

## Safety

The only PR-scoped reference in the whole file was the concurrency key, so all four jobs are push-safe as written. No job body changed. YAML and the retry block's shell both validated locally.

## Deliberately NOT in this PR

- **`strict: true`** — CISO ruled for it and the adversary confirmed it is cheap (2 of 22 merged PRs in the last 30 days would have needed *Update branch*). Held only because it changes merge mechanics for several concurrent sessions during an unattended window. One `PATCH` when someone is watching.
- **A "CI must be green on the tagged commit" gate in `release.yml`** — CISO ruled for it; the adversary **broke it**. As written it reads only completed runs, and a tag is pushed 44–81s after the merge commit while CI cannot finish before merge+97s — so it would have failed closed on 5 of the last 6 releases. It needs a bounded poll before it ships.

Both are recorded with the corrections in `todo/COUNCIL_LEDGER.md`.