### PR TITLE
Rename dependency-audit to build-tree-audit, and refresh it to honest green

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  dependency-audit:
+  # Named for the artifact it measures, not "dependency-audit" claiming the
+  # whole domain — that naming let this job's own 25-run red streak on `main`
+  # read as ambiguous with the consumer jobs below, which measure a DIFFERENT
+  # tree. This one audits what our own CI runner and maintainer machines
+  # install and execute: `packages/*`, devDependencies, and the committed
+  # lockfile, in the repo that holds `id-token: write` and publishes with
+  # `--provenance`. A gate may not stay red across more than one merge to
+  # `main` — no lowered --audit-level, no `|| true`, no deletion to make the
+  # surface look better; the remedy is a lockfile that is actually current,
+  # or (for a transitive advisory whose owning package's own declared range
+  # cannot reach the fix) a root-level `overrides` entry scoped to what WE
+  # install — never something that changes what gets published.
+  build-tree-audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +46,7 @@ jobs:
   # `hackmyagent`'s own dependency-audit workflow was green throughout, which
   # is why that repo added a consumer-resolution job. This is the same gate for
   # the package that actually shipped it. Kept as a separate job rather than
-  # folded into `dependency-audit` so the two numbers stay legible as the two
+  # folded into `build-tree-audit` so the two numbers stay legible as the two
   # different measurements they are: a reviewer seeing "N here, M there" should
   # be able to tell which tree each one describes.
   #

--- a/package-lock.json
+++ b/package-lock.json
@@ -604,12 +604,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -2030,12 +2030,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/ai-trust": {
@@ -2187,21 +2187,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -2932,9 +2945,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -3295,9 +3308,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.26",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
-      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3366,9 +3379,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3909,9 +3922,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -4157,9 +4170,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -4177,7 +4190,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4742,17 +4755,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "packageManager": "npm@10.0.0"
+  "packageManager": "npm@10.0.0",
+  "overrides": {
+    "adm-zip": "0.6.0"
+  }
 }


### PR DESCRIPTION
CISO ruled (`COUNCIL_LEDGER.md`, 2026-08-11) that a permanently-red non-required gate is worse than none, and banned "red and tolerated" as a gate state: a gate is green and honest, red with a named owner actively driving it green, or deleted with a recorded reason and a replacement measurement. `dependency-audit` had failed 50 consecutive runs across all branches (25 on `main`) since 2026-07-16.

## Rename

`dependency-audit` -> `build-tree-audit`, naming the artifact it measures rather than the whole domain. The two `consumer-audit-*` jobs beside it measure what a stranger installs from the published `opena2a-cli` tarball; this one measures what our own CI runner and maintainer machines install and execute — in the repo that holds `id-token: write` and publishes with `--provenance`. The ambiguous name is part of why the red streak read as belonging to a gate this repo already treats as informational.

## Refresh

`npm audit fix --package-lock-only` (the real command, not `--dry-run` — that reports `added 0 / removed 0 / changed 0` against this tree and is a false negative that would tell an operator the step doesn't work). Re-measured against the current tree **after** #284 merged, not the recorded pre-pin count, since that PR had already moved it once:

| | total | high |
|---|---|---|
| before this PR | 10 | 6 |
| after the refresh alone | 3 | 2 |

Zero packages added or removed. Nine version-only bumps (`@hono/node-server`, `body-parser`, `fast-uri`, `hono`, `ip-address`, `nanoid`, `postcss`, plus `adm-zip` covered below) and two harmless nested `content-type` dedup entries.

## The remaining two highs

Both are one advisory, `GHSA-xcpc-8h2w-3j85`: `onnxruntime-node`'s own declared range (`^0.5.16`) cannot reach the fixed `adm-zip@0.6.0`, so no lockfile refresh closes it without going outside that range. A root-level `overrides` entry does — npm only honours `overrides` in a project's **root** manifest, which is exactly why we can apply this to our own tree and a consumer of the published `opena2a-cli` tarball cannot (their root is their own project, not ours; nothing about this override is part of what gets published).

Verified before shipping, not assumed:
- `adm-zip@0.6.0` has no dependencies of its own; `engines.node >=14.0` is inside this repo's `>=18.0.0`.
- Same maintainer and GitHub repo (`cthackers/adm-zip`) across the whole `0.5.16` -> `0.6.0` history, normal monthly-ish cadence — no hijack pattern.
- `onnxruntime-node`'s install script (`script/install-utils.js`) uses only `adm-zip`'s three most stable methods — constructor, `getEntry`, `extractEntryTo` — confirmed working end-to-end against `0.6.0` with a real zip round-trip.
- A from-scratch lockfile regeneration was tried first and **rejected**: on this (darwin-arm64) machine it silently dropped every non-current-platform optional entry, including `@esbuild/linux-x64`, which `ubuntu-latest` CI needs. The `adm-zip` lockfile entry is hand-patched instead, using the exact version/resolved/integrity/engines the registry itself reports (matches byte-for-byte what a real `npm install` in an isolated single-package test produced), keeping every other platform entry intact.
- `npm ci` (full delete-and-reinstall from this lockfile) succeeds; full build/typecheck/lint/1573-test suite green; `release-smoke:corpus` 12 passed/0 failed; self-scan byte-identical to before (60/100, same pre-existing findings).

## Result

`build-tree-audit` now reports **zero high/critical** — genuinely green, zero new waivers of any kind. One low remains (`esbuild`, `GHSA-g7r4-m6w7-qqqr`, dev-server file-read on Windows), below the job's own `--audit-level=high` threshold.
