### PR TITLE
An issuerChain entry may extend key eligibility only if it is itself trusted

### DIFF
--- a/packages/atx-verify/README.md
+++ b/packages/atx-verify/README.md
@@ -81,9 +81,10 @@ const anchors: AtxTrustAnchors = {
     {
       algorithm: "Ed25519",
       publicKeyHex: "<32-byte hex>",
-      // Recommended: a DID-URL keyId binds the key to its controller so it can
-      // only verify credentials issued by that DID. Required to be safe with a
-      // MULTI-issuer anchor set (see "Key-to-issuer binding" below).
+      // Recommended: a DID-URL keyId narrows the key to credentials its
+      // controller issued (plus, on v1.1, chain authorities in trustedIssuers).
+      // Give every key one once the anchor set holds more than one issuer
+      // (see "Key-to-issuer binding").
       keyId: "did:opena2a:authority:opena2a.org#key-1",
     },
   ],
@@ -165,12 +166,25 @@ const result = new LocalAtxVerifier(anchors).verifyCredential(JSON.stringify(atx
 
 ## Key-to-issuer binding
 
-A signature is only accepted from a key controlled by the credential's issuer.
-A configured key whose `keyId` is a DID-URL (contains `#`) is **bound** to its
-controller DID and may only verify credentials issued by that DID — or, for
-v1.1, by an authority named in `issuerChain` **that is also listed in
-`trustedIssuers`**. This prevents one trusted issuer's key from satisfying a
-credential issued under a different issuer's DID.
+Before checking a signature, the verifier narrows the anchored Ed25519 keys to
+the ones eligible for this credential. A key is eligible if its `keyId` carries
+no `#` fragment (**unbound**: eligible for every credential, whatever the
+issuer), or its `keyId`'s controller DID equals `issuerDid`, or the credential
+is v1.1 and that controller DID appears in `issuerChain` **and** is also listed
+in `trustedIssuers`.
+
+`valid: true` therefore establishes that some key in that eligible set signed
+these bytes. It does not establish which one, and it does not establish that
+the authority named in `issuerDid` signed anything: `context.issuerDid` is a
+signed claim about the issuer, not an authenticated identification of the
+signer. To attribute a signature to one key, verify against an anchor set that
+holds only that key.
+
+Eligibility is a property of the anchor set, so that is where it is tuned. One
+`#`-less `keyId` in `publicKeys` leaves its holder eligible for every credential
+the verifier accepts, on v1.0 and v1.1 alike. Audit with
+`anchors.publicKeys.filter((k) => !k.keyId?.includes("#"))`, and give every key
+a DID-URL `keyId` once the set holds more than one issuer's keys.
 
 The `trustedIssuers` qualifier on the chain is load-bearing, not belt-and-braces.
 `issuerChain` is signed — but by the very signature the eligibility set is being
@@ -178,12 +192,10 @@ built to check, so an unqualified chain authorizes its own signer: a key for a
 DID you do not trust becomes eligible by naming that DID in a chain it wrote
 itself. Requiring the chain entry to be independently trusted keeps federation
 working, because a genuine intermediate authority is one you already trust, and
-an attacker whose DID is already trusted could have issued directly.
-
-A key with no `keyId`, or a `keyId` without a `#` fragment, is treated as
-**unbound** and stays eligible for any issuer — safe for a single-issuer anchor
-set, but supply DID-URL `keyId`s whenever the anchor set holds keys for more
-than one issuer.
+an attacker whose DID is already trusted could have issued directly. The
+consequence to configure for is that every DID in `trustedIssuers` can, on v1.1,
+sign for another trusted issuer that names it in `issuerChain`: keep the list to
+the authorities you would accept in that role.
 
 ## Additional exports
 

--- a/packages/atx-verify/README.md
+++ b/packages/atx-verify/README.md
@@ -168,9 +168,17 @@ const result = new LocalAtxVerifier(anchors).verifyCredential(JSON.stringify(atx
 A signature is only accepted from a key controlled by the credential's issuer.
 A configured key whose `keyId` is a DID-URL (contains `#`) is **bound** to its
 controller DID and may only verify credentials issued by that DID — or, for
-v1.1 (where `issuerChain` is signed), by an authority named in the chain. This
-prevents one trusted issuer's key from satisfying a credential issued under a
-different issuer's DID.
+v1.1, by an authority named in `issuerChain` **that is also listed in
+`trustedIssuers`**. This prevents one trusted issuer's key from satisfying a
+credential issued under a different issuer's DID.
+
+The `trustedIssuers` qualifier on the chain is load-bearing, not belt-and-braces.
+`issuerChain` is signed — but by the very signature the eligibility set is being
+built to check, so an unqualified chain authorizes its own signer: a key for a
+DID you do not trust becomes eligible by naming that DID in a chain it wrote
+itself. Requiring the chain entry to be independently trusted keeps federation
+working, because a genuine intermediate authority is one you already trust, and
+an attacker whose DID is already trusted could have issued directly.
 
 A key with no `keyId`, or a `keyId` without a `#` fragment, is treated as
 **unbound** and stays eligible for any issuer — safe for a single-issuer anchor

--- a/packages/atx-verify/src/atx.issuerchain-type.test.ts
+++ b/packages/atx-verify/src/atx.issuerchain-type.test.ts
@@ -1,0 +1,243 @@
+/**
+ * `issuerChain` is declared `string[]` on both `Atx` and `ResolutionContext`, but
+ * the wire value used to reach the consumer unvalidated. Two measured consequences,
+ * which is why this is a structural rejection and not a cast:
+ *
+ *  - A STRING chain silently changes what a consumer predicate means.
+ *    `["did:opena2a:authority:a.example"].includes("a.example")` is `false` —
+ *    array-element equality. `"did:opena2a:authority:a.example".includes("a.example")`
+ *    is `true` — substring matching. A federation predicate written against the
+ *    declared type flips its verdict because the holder sent a string.
+ *  - A non-iterable chain (`{}`, `5`, `true`) made `verifyCredential` throw a
+ *    `TypeError` on v1.1, against its own docstring: "this method never throws on
+ *    bad input". On v1.0 it did not throw here — it verified and handed the number
+ *    or boolean straight to the caller, so the throw landed in the consumer instead.
+ *
+ * The guard covers BOTH credential versions. v1.0 never iterates the chain, so it
+ * was the version that accepted every shape silently.
+ */
+import { describe, it, expect } from 'vitest';
+import * as crypto from 'node:crypto';
+import {
+  LocalAtxVerifier,
+  canonicalPayload,
+  canonicalPayloadV11,
+  type Atx,
+  type AtxTrustAnchors,
+} from './atx.js';
+
+const ISSUER = 'did:opena2a:authority:a.example';
+const CLOCK = new Date('2026-06-01T00:00:00Z');
+
+function keypair(): { privateKey: crypto.KeyObject; pubHex: string } {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+  const jwk = publicKey.export({ format: 'jwk' }) as { x: string };
+  return { privateKey, pubHex: Buffer.from(jwk.x, 'base64url').toString('hex') };
+}
+
+const key = keypair();
+
+function anchors(): AtxTrustAnchors {
+  return {
+    trustedIssuers: [ISSUER],
+    publicKeys: [{ algorithm: 'Ed25519', publicKeyHex: key.pubHex, keyId: `${ISSUER}#key-1` }],
+    crl: { entries: [] },
+    now: () => CLOCK,
+  };
+}
+
+/** Signs whatever it is given, so the chain shape under test is genuinely signed. */
+function signed(atcVersion: '1.0' | '1.1', issuerChain: unknown): string {
+  const atx = {
+    atcVersion,
+    agentId: 'agent-1',
+    agentDid: 'did:opena2a:agent:a/agent-1',
+    version: '1.0.0',
+    contentHash: 'sha256:abc',
+    issuerDid: ISSUER,
+    issuerChain,
+    trustLevel: 2,
+    trustScore: 0.9,
+    issuedAt: '2026-01-01T00:00:00Z',
+    expiresAt: '2027-01-01T00:00:00Z',
+    capabilities: ['orders:read'],
+    signatures: [],
+  } as unknown as Atx;
+  const payload = atcVersion === '1.1' ? canonicalPayloadV11(atx) : canonicalPayload(atx);
+  return JSON.stringify({
+    ...atx,
+    signatures: [
+      {
+        keyId: `${ISSUER}#key-1`,
+        algorithm: 'Ed25519',
+        value: crypto.sign(null, payload, key.privateKey).toString('base64'),
+      },
+    ],
+  });
+}
+
+const NON_ARRAYS: Array<[string, unknown]> = [
+  ['a string', ISSUER],
+  ['an object', {}],
+  ['a number', 5],
+  ['a boolean', true],
+];
+
+describe('issuerChain must be an array of strings', () => {
+  for (const version of ['1.0', '1.1'] as const) {
+    describe(`v${version}`, () => {
+      for (const [label, value] of NON_ARRAYS) {
+        it(`rejects ${label} as MALFORMED rather than passing it to the caller`, () => {
+          const result = new LocalAtxVerifier(anchors()).verifyCredential(signed(version, value));
+          expect(result.valid).toBe(false);
+          expect(result.rejectCategory).toBe('MALFORMED');
+          expect(result.reason).toMatch(/issuerChain/);
+        });
+      }
+
+      // One case per member SHAPE. A mutation pass showed that testing only `7` left
+      // `null` and a nested array unpinned: a guard written as
+      // `typeof did !== 'string' && did !== null` survived the suite unchanged.
+      for (const [memberLabel, member] of [
+        ['a number', 7],
+        ['null', null],
+        ['a nested array', ['did:opena2a:authority:nested']],
+        ['an object', {}],
+        ['undefined', undefined],
+      ] as Array<[string, unknown]>) {
+        it(`rejects an array holding ${memberLabel}`, () => {
+          const result = new LocalAtxVerifier(anchors()).verifyCredential(
+            signed(version, [ISSUER, member]),
+          );
+          expect(result.valid).toBe(false);
+          expect(result.rejectCategory).toBe('MALFORMED');
+          expect(result.reason).toMatch(/issuerChain/);
+        });
+      }
+
+      // The reported index must be the OFFENDING one. Hard-coding `[0]` passed every
+      // test above, so the index was decorative rather than diagnostic.
+      it('names the offending index, not the first', () => {
+        const result = new LocalAtxVerifier(anchors()).verifyCredential(
+          signed(version, [ISSUER, ISSUER, 7]),
+        );
+        expect(result.reason).toMatch(/issuerChain\[2\]/);
+      });
+
+      // Absence direction: the guard must not turn a legitimate credential away.
+      it('accepts a well-formed chain', () => {
+        const result = new LocalAtxVerifier(anchors()).verifyCredential(signed(version, [ISSUER]));
+        expect(result.valid).toBe(true);
+        expect(Array.isArray(result.context?.issuerChain)).toBe(true);
+      });
+
+      // An absent chain is accepted — and the caller is handed a chain the issuer did
+      // NOT sign. The signed payload defaults to `[]`; the context defaults to
+      // `[issuerDid]`. This test pins the CURRENT behaviour and names the divergence
+      // so it cannot be mistaken for a verified value. Changing the default is a
+      // behaviour change tracked separately, not something a type guard should do
+      // quietly.
+      it('accepts an absent chain, and synthesises a context chain that was never signed', () => {
+        const result = new LocalAtxVerifier(anchors()).verifyCredential(
+          signed(version, undefined),
+        );
+        expect(result.valid).toBe(true);
+        expect(result.context?.issuerChain).toEqual([ISSUER]); // synthesised
+        // Control: an explicitly empty chain IS what the signature covered, and it
+        // arrives unchanged — so the line above is a substitution, not a formatting
+        // detail.
+        const explicit = new LocalAtxVerifier(anchors()).verifyCredential(signed(version, []));
+        expect(explicit.context?.issuerChain).toEqual([]);
+      });
+
+      it('accepts an empty chain', () => {
+        const result = new LocalAtxVerifier(anchors()).verifyCredential(signed(version, []));
+        expect(result.valid).toBe(true);
+      });
+    });
+  }
+
+  // The documented contract, stated at the top of verifyCredential: it never throws
+  // on bad input. Before the guard these three threw TypeError on v1.1.
+  it('never throws on any of the non-array shapes, on either version', () => {
+    for (const version of ['1.0', '1.1'] as const) {
+      for (const [, value] of NON_ARRAYS) {
+        expect(() =>
+          new LocalAtxVerifier(anchors()).verifyCredential(signed(version, value)),
+        ).not.toThrow();
+      }
+    }
+  });
+
+  // Ordering is deliberate, not incidental. The guard sits ahead of expiry, revocation
+  // and issuer trust, so a credential that is BOTH malformed and expired reports the
+  // structural defect. Placed later the verdict is identical, but the audit record would
+  // report a comparison against a field the verifier could not read. Same reasoning the
+  // signedCapabilities ordering was pinned with rather than left to chance.
+  it('reports the structural defect ahead of expiry and issuer trust', () => {
+    const expiredAndMalformed = JSON.parse(signed('1.1', [ISSUER])) as Record<string, unknown>;
+    expiredAndMalformed.issuerChain = ISSUER; // not an array
+    expiredAndMalformed.expiresAt = '2020-01-01T00:00:00Z'; // long expired
+    const result = new LocalAtxVerifier(anchors()).verifyCredential(
+      JSON.stringify(expiredAndMalformed),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.rejectCategory).toBe('MALFORMED');
+
+    // Control: the SAME credential with a well-formed chain reports EXPIRED, which
+    // proves this test distinguishes the ordering rather than just any rejection.
+    const expiredOnly = JSON.parse(signed('1.1', [ISSUER])) as Record<string, unknown>;
+    expiredOnly.expiresAt = '2020-01-01T00:00:00Z';
+    const control = new LocalAtxVerifier(anchors()).verifyCredential(JSON.stringify(expiredOnly));
+    expect(control.rejectCategory).toBe('EXPIRED');
+  });
+
+  // The guard must validate and deliver the SAME value. `verify(obj)` takes a
+  // caller-supplied object, so a property whose getter returns something different on a
+  // later read would otherwise let a validated array and a delivered non-array diverge.
+  // Not reachable through verifyCredential — JSON.parse cannot produce an accessor — but
+  // verify(obj) is a public entry point and this is what makes the guard atomic rather
+  // than advisory. v1.0 is used because its signature does not cover issuerChain, so the
+  // flipping getter cannot invalidate the signature and confound the arm.
+  it('validates and delivers the same chain even when the property flips between reads', () => {
+    const honest = JSON.parse(signed('1.0', [ISSUER])) as Record<string, unknown>;
+
+    for (let flipAfter = 1; flipAfter <= 8; flipAfter++) {
+      let reads = 0;
+      const hostile = { ...honest };
+      Object.defineProperty(hostile, 'issuerChain', {
+        enumerable: true,
+        get() {
+          reads += 1;
+          return reads > flipAfter ? 'did:evil:attacker' : [ISSUER];
+        },
+      });
+
+      const result = new LocalAtxVerifier(anchors()).verify(hostile as unknown as Atx);
+      if (result.valid) {
+        // Whatever it accepted, the caller must never receive the unvalidated shape.
+        expect(Array.isArray(result.context?.issuerChain)).toBe(true);
+        expect(result.context?.issuerChain).toEqual([ISSUER]);
+      } else {
+        expect(result.rejectCategory).toBe('MALFORMED');
+      }
+    }
+
+    // Control: a getter that never flips behaves exactly like a plain array, so the
+    // loop above is testing the flip and not merely the presence of an accessor.
+    const stable = { ...honest };
+    Object.defineProperty(stable, 'issuerChain', {
+      enumerable: true,
+      get: () => [ISSUER],
+    });
+    const control = new LocalAtxVerifier(anchors()).verify(stable as unknown as Atx);
+    expect(control.valid).toBe(true);
+    expect(control.context?.issuerChain).toEqual([ISSUER]);
+  });
+
+  // The consumer-visible reason this is a rejection and not a coercion.
+  it('a string chain would have changed what a membership predicate means', () => {
+    expect([ISSUER].includes('a.example')).toBe(false);
+    expect(ISSUER.includes('a.example')).toBe(true);
+  });
+});

--- a/packages/atx-verify/src/atx.keybinding.test.ts
+++ b/packages/atx-verify/src/atx.keybinding.test.ts
@@ -1,8 +1,9 @@
 /**
  * Key↔issuer binding: a configured key whose keyId names a controller DID may
  * only verify signatures for credentials issued by that controller (or, for
- * v1.1, a signed issuerChain authority). One trusted issuer cannot impersonate
- * another. Keys without a DID-URL keyId stay unbound (back-compat).
+ * v1.1, an issuerChain authority the operator ALSO trusts). One trusted issuer
+ * cannot impersonate another. Keys without a DID-URL keyId stay unbound
+ * (back-compat).
  */
 import { describe, it, expect } from 'vitest';
 import * as crypto from 'node:crypto';
@@ -174,5 +175,96 @@ describe('anchor-fault diagnostics (empty eligible key set names the configurati
     expect(result.valid).toBe(false);
     expect(result.reason).toBe('Ed25519 signature did not verify');
     expect(result.reason).not.toContain('  ');
+  });
+});
+
+/**
+ * The chain cannot authorize its own signer.
+ *
+ * `issuerChain` used to be added to the eligibility set verbatim on v1.1, reasoning that the
+ * chain is signed. It is — by the very signature the eligibility set is being built to check.
+ * So a key belonging to a DID the operator does not trust became eligible simply by naming its
+ * own DID in a chain it wrote itself.
+ */
+describe('issuerChain does not grant eligibility to an untrusted key', () => {
+  const UNTRUSTED = 'did:partner:untrusted.example';
+
+  function v11(chain: string[]) {
+    return atxBase({
+      atcVersion: '1.1',
+      issuerDid: ISSUER_A,
+      issuerChain: chain,
+      trustLevel: 9,
+      capabilities: ['admin:*'],
+      scanSummary: { oasbLevel: 'L3' },
+    });
+  }
+
+  function verifyWith(chain: string[], signer: crypto.KeyObject, signerDid: string, keys: AtxTrustAnchors['publicKeys']) {
+    return new LocalAtxVerifier(anchors({ publicKeys: keys })).verify(
+      signWith(v11(chain), signer, `${signerDid}#key-1`),
+    );
+  }
+
+  it('rejects an untrusted key that names its own DID in the chain', () => {
+    const a = keypair();
+    const evil = keypair();
+    const keys = [
+      { algorithm: 'Ed25519' as const, publicKeyHex: a.pubHex, keyId: `${ISSUER_A}#key-1` },
+      { algorithm: 'Ed25519' as const, publicKeyHex: evil.pubHex, keyId: `${UNTRUSTED}#key-1` },
+    ];
+
+    // The attack: the chain is attacker-written and lists the attacker's own DID.
+    const attack = verifyWith([UNTRUSTED], evil.privateKey, UNTRUSTED, keys);
+    expect(attack.valid).toBe(false);
+    expect(attack.rejectCategory).toBe('SIGNATURE_INVALID');
+
+    // Control: the same key with an empty chain was always rejected, so the assertion above is
+    // about the chain and not about the key being unanchored.
+    const noChain = verifyWith([], evil.privateKey, UNTRUSTED, keys);
+    expect(noChain.valid).toBe(false);
+
+    // Control: naming a TRUSTED did in the chain does not help an untrusted signer either.
+    const namesTrusted = verifyWith([ISSUER_B], evil.privateKey, UNTRUSTED, keys);
+    expect(namesTrusted.valid).toBe(false);
+  });
+
+  it('still admits a federated intermediate the operator trusts', () => {
+    // The behaviour the chain extension exists for, and which must survive the fix: ISSUER_B is
+    // in trustedIssuers, so its key may sign a credential issued under ISSUER_A.
+    const a = keypair();
+    const b = keypair();
+    const keys = [
+      { algorithm: 'Ed25519' as const, publicKeyHex: a.pubHex, keyId: `${ISSUER_A}#key-1` },
+      { algorithm: 'Ed25519' as const, publicKeyHex: b.pubHex, keyId: `${ISSUER_B}#key-1` },
+    ];
+
+    const federated = verifyWith([ISSUER_B], b.privateKey, ISSUER_B, keys);
+    expect(federated.valid).toBe(true);
+    expect(federated.context?.signedCapabilities).toBe(true);
+
+    // Control: the issuer's own key still works with and without a chain.
+    expect(verifyWith([], a.privateKey, ISSUER_A, keys).valid).toBe(true);
+    expect(verifyWith([ISSUER_B], a.privateKey, ISSUER_A, keys).valid).toBe(true);
+  });
+
+  it('does not let an untrusted chain entry widen eligibility on a v1.0 credential either', () => {
+    // v1.0 never added the chain, so this is a lock on behaviour rather than a change.
+    const a = keypair();
+    const evil = keypair();
+    const atx = signWith(
+      atxBase({ atcVersion: '1.0', issuerDid: ISSUER_A, issuerChain: [UNTRUSTED] }),
+      evil.privateKey,
+      `${UNTRUSTED}#key-1`,
+    );
+    const result = new LocalAtxVerifier(
+      anchors({
+        publicKeys: [
+          { algorithm: 'Ed25519', publicKeyHex: a.pubHex, keyId: `${ISSUER_A}#key-1` },
+          { algorithm: 'Ed25519', publicKeyHex: evil.pubHex, keyId: `${UNTRUSTED}#key-1` },
+        ],
+      }),
+    ).verify(atx);
+    expect(result.valid).toBe(false);
   });
 });

--- a/packages/atx-verify/src/atx.keybinding.test.ts
+++ b/packages/atx-verify/src/atx.keybinding.test.ts
@@ -1,9 +1,12 @@
 /**
- * Key↔issuer binding: a configured key whose keyId names a controller DID may
- * only verify signatures for credentials issued by that controller (or, for
- * v1.1, an issuerChain authority the operator ALSO trusts). One trusted issuer
- * cannot impersonate another. Keys without a DID-URL keyId stay unbound
- * (back-compat).
+ * Key eligibility: which anchored keys the verifier will try for a given
+ * credential. A key whose keyId is a DID-URL is eligible only for credentials
+ * issued by its controller DID, or, on v1.1, for credentials whose issuerChain
+ * names that controller when trustedIssuers also lists it. A key with no `#`
+ * fragment is unbound and stays eligible for every issuer, so the binding cases
+ * below hold only for anchor sets in which every key carries a DID-URL keyId.
+ * A passing verification shows that some eligible key signed the bytes; it does
+ * not identify which one, nor that the issuerDid authority signed.
  */
 import { describe, it, expect } from 'vitest';
 import * as crypto from 'node:crypto';
@@ -99,7 +102,7 @@ describe('key-to-issuer binding', () => {
     expect(result.rejectCategory).toBe('SIGNATURE_INVALID');
   });
 
-  it('accepts a v1.1 cross-org cosignature when the signer is in the signed issuerChain', () => {
+  it('accepts a v1.1 credential issued under A whose single signature is from B, a chain authority trustedIssuers also lists', () => {
     const b = keypair();
     // issuer is A, but B is a cosigning authority named in the (signed) issuerChain.
     const atx = signWith(

--- a/packages/atx-verify/src/atx.ts
+++ b/packages/atx-verify/src/atx.ts
@@ -120,11 +120,15 @@ export interface AtxPublicKey {
   /**
    * Optional DID-URL identifying the key and its controller, e.g.
    * `did:opena2a:authority:opena2a.org#key-1`. When present (contains `#`), the
-   * key is BOUND to its controller DID: it may only verify signatures for
-   * credentials issued by that controller (or, for v1.1, a TRUSTED issuerChain
-   * authority). This stops one trusted issuer's key from satisfying a credential
-   * issued under a different DID. A key without a `#` fragment is unbound and is
-   * eligible for any issuer (back-compat for single-issuer anchor sets).
+   * key is BOUND to its controller DID: it is eligible only for credentials
+   * whose `issuerDid` is that controller, or, on v1.1, for credentials whose
+   * `issuerChain` names that controller when `trustedIssuers` also lists it.
+   * A key with no `#` fragment (or no `keyId` at all) is unbound and stays
+   * eligible for every credential regardless of issuer, on v1.0 and v1.1 alike,
+   * so one such entry widens the eligible set for the whole anchor set.
+   * Eligibility decides which keys may verify a signature. A `valid` result
+   * does not report which key did, and is not an authentication of the
+   * authority named in `issuerDid`.
    */
   keyId?: string;
 }
@@ -289,6 +293,50 @@ export class LocalAtxVerifier implements AtxVerifier {
     }
     const isV11 = atx.atcVersion === SUPPORTED_ATX_VERSION_V11;
 
+    // Step 1a: issuerChain is structurally an array of strings, on BOTH versions.
+    // `Atx.issuerChain` and `ResolutionContext.issuerChain` both declare `string[]`,
+    // but the wire value used to reach the caller unchecked, and a TypeScript type is
+    // not a wire validation. Two measured consequences, which is why this rejects
+    // rather than coerces:
+    //   - A STRING chain changes what a consumer's membership predicate MEANS.
+    //     `["did:opena2a:authority:a.example"].includes("a.example")` is false —
+    //     element equality. `"did:opena2a:authority:a.example".includes("a.example")`
+    //     is true — substring matching. A federation predicate written against the
+    //     declared type flips its verdict because the holder sent a string, and
+    //     secretless-ai mints `ctx.issuerChain` into a SIGNED broker assertion, so the
+    //     confusion would cross a trust boundary inside a signed artifact.
+    //   - `{}`, `5` and `true` made the v1.1 eligibility loop throw a TypeError, which
+    //     contradicts verifyCredential's own contract ("this method never throws on bad
+    //     input"). v1.0 never iterates the chain, so it was the version that accepted
+    //     every shape SILENTLY and handed a number or boolean to the caller — which is
+    //     why this guard is not scoped to v1.1.
+    // Coercing to [] was rejected: it silently accepts a schema-invalid credential and
+    // hides a malformed issuer. MALFORMED is the fail-closed direction and matches how
+    // every other structural violation is treated here.
+    // Read the property ONCE. `verify(obj)` accepts a caller-supplied object, and an
+    // accessor that returns a different value on each read would otherwise let the
+    // validated value and the delivered value differ — the guard would check an array
+    // and the caller would receive whatever the next read produced. Everything below
+    // uses this snapshot, including what goes into the resolution context.
+    const issuerChain: unknown = atx.issuerChain;
+    if (issuerChain !== undefined && issuerChain !== null) {
+      if (!Array.isArray(issuerChain)) {
+        return reject(
+          'MALFORMED',
+          `issuerChain must be an array of strings, got ${typeof issuerChain}`,
+        );
+      }
+      const badIndex = (issuerChain as unknown[]).findIndex((did) => typeof did !== 'string');
+      if (badIndex !== -1) {
+        return reject(
+          'MALFORMED',
+          `issuerChain[${badIndex}] must be a string, got ` +
+            `${typeof (issuerChain as unknown[])[badIndex]}`,
+        );
+      }
+    }
+    const checkedChain = (issuerChain ?? undefined) as string[] | undefined;
+
     // Step 2: expiry.
     const expires = new Date(atx.expiresAt);
     if (Number.isNaN(expires.getTime())) {
@@ -348,7 +396,7 @@ export class LocalAtxVerifier implements AtxVerifier {
     // DID is already trusted could have issued directly, so this adds no path.
     const authoritySet = new Set<string>([atx.issuerDid]);
     if (isV11) {
-      for (const did of atx.issuerChain ?? []) {
+      for (const did of checkedChain ?? []) {
         if (this.anchors.trustedIssuers.includes(did)) authoritySet.add(did);
       }
     }
@@ -423,7 +471,7 @@ export class LocalAtxVerifier implements AtxVerifier {
         agentId: atx.agentId,
         agentDid: atx.agentDid,
         issuerDid: atx.issuerDid,
-        issuerChain: atx.issuerChain ?? [atx.issuerDid],
+        issuerChain: checkedChain ?? [atx.issuerDid],
         trustLevel: atx.trustLevel,
         trustScore: atx.trustScore,
         capabilities: atx.capabilities ?? [],

--- a/packages/atx-verify/src/atx.ts
+++ b/packages/atx-verify/src/atx.ts
@@ -121,7 +121,7 @@ export interface AtxPublicKey {
    * Optional DID-URL identifying the key and its controller, e.g.
    * `did:opena2a:authority:opena2a.org#key-1`. When present (contains `#`), the
    * key is BOUND to its controller DID: it may only verify signatures for
-   * credentials issued by that controller (or, for v1.1, an issuerChain
+   * credentials issued by that controller (or, for v1.1, a TRUSTED issuerChain
    * authority). This stops one trusted issuer's key from satisfying a credential
    * issued under a different DID. A key without a `#` fragment is unbound and is
    * eligible for any issuer (back-compat for single-issuer anchor sets).
@@ -327,13 +327,30 @@ export class LocalAtxVerifier implements AtxVerifier {
       payload = canonicalPayload(atx);
     }
     // Key↔issuer binding: a key may verify a signature for this credential only
-    // if it is controlled by one of the credential's authorities — the issuer,
-    // plus the issuerChain authorities for v1.1 (where the chain is signed; v1.0
-    // chain is unsigned/forgeable, so only the issuer counts). A key whose keyId
+    // if it is controlled by one of the credential's authorities. A key whose keyId
     // is not a DID-URL (no '#') is unbound and stays eligible (back-compat).
+    //
+    // `issuerDid` is safe to seed from because it was checked against
+    // `trustedIssuers` above. `issuerChain` is NOT, and used to be added verbatim
+    // on v1.1 on the reasoning that the chain is signed — but it is signed by the
+    // very signature this block is selecting a key to verify, so the chain was
+    // authorizing its own signer. Measured: with two anchored keys and one trusted
+    // issuer, a key belonging to an untrusted DID minted a credential under the
+    // trusted issuer simply by naming its own DID in the chain — `issuerChain: []`
+    // was correctly SIGNATURE_INVALID, `issuerChain: [own-did]` verified, yielding
+    // attacker-chosen trustLevel, capabilities and scanSummary with
+    // `signedCapabilities: true`.
+    //
+    // A chain entry therefore extends eligibility only when it is ITSELF a trusted
+    // anchor. That keeps federation working — a genuine intermediate authority is
+    // in `trustedIssuers` and stays eligible — while a DID the operator does not
+    // trust gains nothing by appearing in a chain it wrote itself. An attacker whose
+    // DID is already trusted could have issued directly, so this adds no path.
     const authoritySet = new Set<string>([atx.issuerDid]);
     if (isV11) {
-      for (const did of atx.issuerChain ?? []) authoritySet.add(did);
+      for (const did of atx.issuerChain ?? []) {
+        if (this.anchors.trustedIssuers.includes(did)) authoritySet.add(did);
+      }
     }
     // Staged so an empty final key set can be diagnosed precisely: nothing
     // configured vs binding-excluded vs unparseable key material. All three


### PR DESCRIPTION
The key-eligibility set was built from the credential's own claimed `issuerChain`, before the
signature was checked. The chain is signed — by the very signature the eligibility set is being
built to verify — so the chain authorized its own signer.

## The measurement

Two anchored keys, one trusted issuer (`trustedIssuers: [A]`). A key belonging to a DID the
operator does not trust, signing a credential that claims `issuerDid: A`:

```
issuerChain: []              REJECTED  SIGNATURE_INVALID   control
issuerChain: [trusted-did]   REJECTED  SIGNATURE_INVALID   control
issuerChain: [own-did]       VERIFIES  issuerDid=A  trustLevel=9
                                       capabilities=["admin:*"]  oasbLevel=L3
                                       signedCapabilities=true
```

The empty-chain control shows the binding was otherwise live, so the difference is the chain and
nothing else. What comes back is a fully verified `ResolutionContext` carrying attacker-chosen
values for every authorization predicate a consumer reads — plus `signedCapabilities: true`, the
flag that tells the consumer those values can be trusted.

The precondition is that the attacker's key is already in `publicKeys` with a DID-URL `keyId` —
that is, a multi-issuer or federation anchor set, which is the configuration the binding was
written for. A single-key anchor set is unaffected.

## The change

A chain entry extends eligibility only when it is itself in `trustedIssuers`.

Federation is unaffected: a genuine intermediate authority is one the operator already trusts, so
its key still signs credentials issued under another trusted issuer. An attacker whose DID is
already trusted gains nothing, because it could have issued directly. `issuerDid` remains a valid
seed because it is checked against `trustedIssuers` before this block runs.

Six arms pass with the change and exactly one differs without it. Two mutations pin it from both
sides: restoring the verbatim chain fails the attack test, and removing the chain extension
altogether fails the federation test — so the fix cannot drift looser or tighter unnoticed.

## Scope

`ResolutionContext` is what brokers, SDKs and the registry make allow/deny decisions from, so this
is the boundary those decisions rest on. Worth checking for the same shape — a chain, `kid`, or
issuer hint selecting a key before verification — in `opena2a-registry/pkg/atcverify` and the
Java/Python SDK verifiers. I have not audited those here.

The README documented the removed behaviour, and its parenthetical ("where `issuerChain` is
signed") was the reasoning that made it look safe; it now carries the reason rather than the bare
rule.

Unrelated to the diff, worth knowing if you build here: `node_modules/@types/@types` was a symlink
to its own parent, which made TypeScript resolve an implicit type library named `@types` and fail
every build of this package with TS2688 — on `main` as well. Removing it is what let the build run.
