### PR TITLE
contribute: 0.2.0 — scan_ping joins the event union; totalChecks is optional

### DIFF
--- a/packages/contribute/README.md
+++ b/packages/contribute/README.md
@@ -32,7 +32,8 @@ await contribute.scanResult({
   packageName: 'my-mcp-server',
   packageVersion: '1.0.0',
   ecosystem: 'npm',
-  totalChecks: 42,
+  totalChecks: 42, // optional since 0.2.0: report a measured count or omit it
+
   passed: 38,
   critical: 0,
   high: 1,

--- a/packages/contribute/__tests__/scan-ping-and-optional-totalchecks.test.ts
+++ b/packages/contribute/__tests__/scan-ping-and-optional-totalchecks.test.ts
@@ -1,0 +1,91 @@
+/**
+ * 0.2.0 widening: `scan_ping` joins the event union, and
+ * `scanSummary.totalChecks` is optional — a tool reports it from a measured
+ * coverage record or omits it; a derived stand-in number is worse than no
+ * number.
+ *
+ * The widening is a type change, so its red-proof is `tsc --noEmit` on a
+ * probe using both new shapes: it fails on 0.1.x and passes here (recorded
+ * in the PR; esbuild-transpiled test runs cannot express a compile error).
+ * These cells pin the RUNTIME contract: both shapes queue, survive
+ * buildBatch, and the omitted field stays omitted — nothing fills it in.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { queueEvent, getQueuedEvents, clearQueue, buildBatch } from '../src/queue.js';
+import type { ContributionEvent } from '../src/types.js';
+
+describe('scan_ping and optional totalChecks (0.2.0)', () => {
+  beforeEach(() => {
+    clearQueue();
+  });
+
+  afterEach(() => {
+    clearQueue();
+  });
+
+  it('a scan_ping event queues and rides the batch unchanged', () => {
+    const ping: ContributionEvent = {
+      type: 'scan_ping',
+      tool: 'hackmyagent',
+      toolVersion: '0.33.0',
+      timestamp: new Date().toISOString(),
+    };
+    queueEvent(ping);
+
+    const events = getQueuedEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('scan_ping');
+
+    const batch = buildBatch();
+    expect(batch?.events[0].type).toBe('scan_ping');
+  });
+
+  it('a scanSummary without totalChecks queues, and nothing fills the field in', () => {
+    queueEvent({
+      type: 'scan_result',
+      tool: 'hackmyagent',
+      toolVersion: '0.33.0',
+      timestamp: new Date().toISOString(),
+      scanSummary: {
+        passed: 12,
+        critical: 0,
+        high: 1,
+        medium: 2,
+        low: 3,
+        score: 87,
+        verdict: 'pass',
+        durationMs: 900,
+      },
+    });
+
+    const [event] = getQueuedEvents();
+    expect(event.scanSummary).toBeDefined();
+    expect('totalChecks' in (event.scanSummary as object)).toBe(false);
+    expect(event.scanSummary?.passed).toBe(12);
+
+    const batch = buildBatch();
+    expect('totalChecks' in (batch!.events[0].scanSummary as object)).toBe(false);
+  });
+
+  it('a scanSummary carrying totalChecks keeps it (the 0.1.x shape is a subset)', () => {
+    queueEvent({
+      type: 'scan_result',
+      tool: 'hackmyagent',
+      toolVersion: '0.33.0',
+      timestamp: new Date().toISOString(),
+      scanSummary: {
+        totalChecks: 147,
+        passed: 145,
+        critical: 0,
+        high: 1,
+        medium: 1,
+        low: 0,
+        score: 95,
+        verdict: 'pass',
+        durationMs: 1200,
+      },
+    });
+
+    expect(getQueuedEvents()[0].scanSummary?.totalChecks).toBe(147);
+  });
+});

--- a/packages/contribute/package.json
+++ b/packages/contribute/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/contribute",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Shared community trust data contribution client for OpenA2A tools",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/contribute/src/index.ts
+++ b/packages/contribute/src/index.ts
@@ -28,7 +28,8 @@ export const contribute = {
     packageName: string;
     packageVersion?: string;
     ecosystem?: string;
-    totalChecks: number;
+    /** From a measured coverage record, or omitted — never a derived stand-in. */
+    totalChecks?: number;
     passed: number;
     critical: number;
     high: number;

--- a/packages/contribute/src/types.ts
+++ b/packages/contribute/src/types.ts
@@ -3,7 +3,7 @@
  * HMA, ai-trust, detect, ARP, BrowserGuard, Secretless.
  */
 export interface ContributionEvent {
-  type: 'scan_result' | 'detection' | 'behavior' | 'interaction' | 'adoption';
+  type: 'scan_result' | 'scan_ping' | 'detection' | 'behavior' | 'interaction' | 'adoption';
   tool: string;
   toolVersion: string;
   timestamp: string;
@@ -15,9 +15,13 @@ export interface ContributionEvent {
     ecosystem?: string;
   };
 
-  /** Anonymized scan summary (no raw findings). */
+  /**
+   * Anonymized scan summary (no raw findings). `totalChecks` is optional
+   * since 0.2.0: a tool reports it from a measured coverage record or omits
+   * it — a derived stand-in number is worse than no number.
+   */
   scanSummary?: {
-    totalChecks: number;
+    totalChecks?: number;
     passed: number;
     critical: number;
     high: number;


### PR DESCRIPTION
## What

Widens `@opena2a/contribute` to 0.2.0, as the first step of the settled-outcome series ruled for the HMA publish/telemetry consumers:

- `'scan_ping'` joins the `ContributionEvent` type union — a tool can report a measured-nothing outcome without fabricating a scan summary.
- `scanSummary.totalChecks` (and the `scanResult` param) becomes optional — a tool reports it from a measured coverage record or omits it; a derived stand-in number is worse than no number. (`packages/cli/src/util/report-submission.ts` currently derives one; migrating writers is the consumers' follow-up, not this PR.)

Type widening only: no runtime branch changes. Version 0.2.0; README example annotated.

## Proof

- Type red-proof (`tsc --noEmit --strict` on a probe using both new shapes): 2 errors on the 0.1.x types, 0 on this branch. (A vitest cell cannot express a compile error — esbuild strips types — so the probe is the red side; the new cells pin the runtime contract.)
- `packages/contribute/__tests__/scan-ping-and-optional-totalchecks.test.ts`: a `scan_ping` event round-trips queue and batch; a summary without `totalChecks` queues and nothing fills the field in; the 0.1.x shape still carries it.
- Package suite via its own script (isolated HOME, sequential): 6 files / 32 passed. Workspace-wide build 0 and typecheck 0 — every in-repo consumer compiles against the widening.
- Self-scan on the built tree: 2 pre-existing CRITICALs, both intentional test usage in cli tests untouched by this diff (`review.test.ts:106` executes the repo-owned report script against a DOM stub, eslint-annotated; `skillguard-checks.test.ts:250` is `eval` inside a SKILL.md fixture string the scanner under test must flag). Recorded, not fixed here.

## After merge

Tag `contribute-v0.2.0` (Trusted Publishing via release.yml OIDC — the trusted publisher for this package is configured; first attested publish of the package), behind /release-test and the daily publish batching check. The hackmyagent consumer bump to `^0.2.0` follows in its own PR.