### PR TITLE
contribute: README matches the shipped API

### DIFF
--- a/packages/contribute/README.md
+++ b/packages/contribute/README.md
@@ -64,12 +64,12 @@ await contribute.flush();
 | `contribute.scanResult(params)` | Queue a scan result event |
 | `contribute.detection(params)` | Queue a detection event |
 | `contribute.flush()` | Submit all queued events to the Registry |
-| `isContributeEnabled()` | Check if contribution is enabled |
+| `isContributeEnabled()` | Check if contribution is enabled (`contribute.enabled: true` in `~/.opena2a/config.json`, written by the parent tool's consent prompt; every call is a no-op until then) |
 | `queueEvent(event)` | Low-level: add an event to the local queue |
 | `getQueuedEvents()` | Low-level: read queued events |
 | `clearQueue()` | Low-level: clear the local queue |
 | `shouldFlush()` | Check if the queue has reached the flush threshold |
-| `buildBatch(events)` | Build a submission batch from queued events |
+| `buildBatch()` | Build a submission batch from the queued events; returns `null` when the queue is empty |
 | `submitBatch(batch)` | Submit a batch to the Registry API |
 | `getContributorToken()` | Get or create an anonymous contributor token |
 


### PR DESCRIPTION
Two README-only P2s from the 0.2.0 fresh-consumer release test, fixed before the `contribute-v0.2.0` tag so the shipped tarball's README matches its own API:

1. The API table documented `buildBatch(events)`; the shipped signature is `buildBatch(): ContributionBatch | null`. A consumer typing what the README said got `TS2554: Expected 0 arguments, but got 1`. The row now shows `buildBatch()` and notes the `null`-on-empty return.
2. The README advertised "Opt-in only" and `isContributeEnabled()` without naming the mechanism. The row now names it: `contribute.enabled: true` in `~/.opena2a/config.json`, written by the parent tool's consent prompt (verified against hackmyagent's `shouldPromptContribute` and `telemetry/opt-in.ts`).

Runtime P3s from the same test are tracked in #299; no code changes here.