### PR TITLE
release: delete the dead duplicate publish steps that fail every tag run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,67 +380,6 @@ jobs:
           done < /tmp/published.txt
           exit $rc
 
-      - name: Publish packages (idempotent — skips if version already on npm)
-        id: publish
-        run: |
-          set -e
-          : > /tmp/published.txt
-          : > /tmp/skipped.txt
-          publish_if_new() {
-            local ws="$1"
-            local pkg="$2"
-            local ver
-            ver=$(node -p "require('./$ws/package.json').version")
-            if npm view "$pkg@$ver" version >/dev/null 2>&1; then
-              echo "::notice::$pkg@$ver already on npm — skipping publish"
-              echo "$pkg" >> /tmp/skipped.txt
-            else
-              echo "Publishing $pkg@$ver with provenance..."
-              npm publish --workspace="$ws" --provenance --access public
-              echo "$pkg" >> /tmp/published.txt
-            fi
-          }
-          publish_if_new packages/cli opena2a-cli
-          publish_if_new packages/shared @opena2a/shared
-          publish_if_new packages/cli-ui @opena2a/cli-ui
-          publish_if_new packages/contribute @opena2a/contribute
-          publish_if_new packages/ai-classifier @opena2a/ai-classifier
-          publish_if_new packages/aim-core @opena2a/aim-core
-          publish_if_new packages/registry-client @opena2a/registry-client
-          publish_if_new packages/check-core @opena2a/check-core
-          publish_if_new packages/telemetry @opena2a/telemetry
-          publish_if_new packages/credential-patterns @opena2a/credential-patterns
-          publish_if_new packages/atx-verify @opena2a/atx-verify
-          echo "=== Published this run ==="
-          cat /tmp/published.txt
-          echo "=== Skipped (version already on npm) ==="
-          cat /tmp/skipped.txt
-
-      - name: Verify provenance on newly-published packages
-        run: |
-          verify_attestations() {
-            local pkg="$1"
-            local deadline=$((SECONDS + 300))
-            local attestations=""
-            while [ $SECONDS -lt $deadline ]; do
-              attestations=$(npm view "$pkg" dist.attestations --json 2>&1 || true)
-              if [ -n "$attestations" ] && [ "$attestations" != "null" ] && [ "$attestations" != "{}" ]; then
-                echo "Provenance verified for $pkg"
-                return 0
-              fi
-              echo "Attestations for $pkg not yet visible, retrying in 15s... (elapsed ${SECONDS}s)"
-              sleep 15
-            done
-            echo "::error::Provenance attestations missing from npm for $pkg after 5 minutes"
-            return 1
-          }
-          if [ ! -s /tmp/published.txt ]; then
-            echo "No packages published this run — nothing to verify."
-            exit 0
-          fi
-          while IFS= read -r pkg; do
-            verify_attestations "$pkg" || exit 1
-          done < /tmp/published.txt
 
   # GITHUB RELEASE -- the only job with repo write.
   #


### PR DESCRIPTION
The publish job carried two generations of the same step pair: the hardened tarball-based publish + provenance-verify (no checkout; the manifest is read from inside the tarball) and, sequentially after them, the older workspace-based pair that reads `./packages/*/package.json` from a checkout the job deliberately does not have. Every tag run therefore publishes correctly in the first pair and then dies in the duplicate on `Cannot find module './packages/cli/package.json'`, failing the job and skipping `github-release`.

Measured on run 32981539447 (`contribute-v0.2.0`): `@opena2a/contribute@0.2.0` published WITH SLSA v1 provenance (verified via `npm view dist.attestations`), job red on the duplicate, GitHub release created by hand afterwards.

This deletes the dead pair (lines 383-443; the deleted `id: publish` had no `steps.publish` references — the `github-release` `needs: publish` names the job, which keeps its id). One step of each name remains; YAML parses.