### PR TITLE
contribute: 0.3.0 — scanSummary carries the settled-outcome extras

### DIFF
--- a/packages/contribute/__tests__/scan-ping-and-optional-totalchecks.test.ts
+++ b/packages/contribute/__tests__/scan-ping-and-optional-totalchecks.test.ts
@@ -67,6 +67,37 @@ describe('scan_ping and optional totalChecks (0.2.0)', () => {
     expect('totalChecks' in (batch!.events[0].scanSummary as object)).toBe(false);
   });
 
+  it('the settled-outcome extras (0.3.0) queue and ride the batch unchanged, and stay absent when omitted', () => {
+    queueEvent({
+      type: 'scan_result',
+      tool: 'hackmyagent',
+      toolVersion: '0.33.0',
+      timestamp: new Date().toISOString(),
+      scanSummary: {
+        passed: 10,
+        critical: 1,
+        high: 0,
+        medium: 0,
+        low: 0,
+        score: 20,
+        verdict: 'fail',
+        durationMs: 400,
+        exitCode: 1,
+        rawScore: 55,
+        scoreClamped: true,
+        suppressed: [{ checkId: 'CONFIG-004', name: 'x', category: 'config', severity: 'high', count: 1, suppressedBy: '.hmaignore' }],
+      },
+    });
+    const [event] = getQueuedEvents();
+    expect(event.scanSummary?.exitCode).toBe(1);
+    expect(event.scanSummary?.rawScore).toBe(55);
+    expect(event.scanSummary?.scoreClamped).toBe(true);
+    expect(event.scanSummary?.suppressed?.[0].checkId).toBe('CONFIG-004');
+    expect('outOfScope' in (event.scanSummary as object)).toBe(false);
+    const batch = buildBatch();
+    expect(batch!.events[0].scanSummary?.suppressed).toHaveLength(1);
+  });
+
   it('a scanSummary carrying totalChecks keeps it (the 0.1.x shape is a subset)', () => {
     queueEvent({
       type: 'scan_result',

--- a/packages/contribute/package.json
+++ b/packages/contribute/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/contribute",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Shared community trust data contribution client for OpenA2A tools",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/contribute/src/index.ts
+++ b/packages/contribute/src/index.ts
@@ -1,4 +1,4 @@
-export type { ContributionEvent, ContributionBatch } from './types.js';
+export type { ContributionEvent, ContributionBatch, SuppressionRow } from './types.js';
 export { getContributorToken } from './contributor.js';
 export { queueEvent, getQueuedEvents, clearQueue, shouldFlush, buildBatch } from './queue.js';
 export { submitBatch } from './client.js';

--- a/packages/contribute/src/types.ts
+++ b/packages/contribute/src/types.ts
@@ -1,4 +1,17 @@
 /**
+ * Identity row for a check the scan suppressed or scoped out: id-level
+ * metadata only — no path, no matched bytes, by construction.
+ */
+export interface SuppressionRow {
+  checkId: string;
+  name: string;
+  category: string;
+  severity: string;
+  count: number;
+  suppressedBy: string;
+}
+
+/**
  * Universal contribution event -- works for all OpenA2A tools:
  * HMA, ai-trust, detect, ARP, BrowserGuard, Secretless.
  */
@@ -30,6 +43,17 @@ export interface ContributionEvent {
     score: number;
     verdict: string;
     durationMs: number;
+    /**
+     * Settled-outcome extras (0.3.0, all optional): the exit code the run
+     * returned, the pre-clamp score and whether the clamp fired, and the
+     * identity rows for suppressed / out-of-scope checks. A tool that has a
+     * settled record reports these; one that does not omits them.
+     */
+    exitCode?: number;
+    rawScore?: number;
+    scoreClamped?: boolean;
+    suppressed?: SuppressionRow[];
+    outOfScope?: SuppressionRow[];
   };
 
   /** Detection summary (for detect, BrowserGuard). */


### PR DESCRIPTION
Completes the shared-type half of the settled-outcome wire contract: `scanSummary` gains optional `exitCode`, `rawScore`, `scoreClamped`, and identity-only `suppressed` / `outOfScope` rows (`SuppressionRow`: checkId, name, category, severity, count, suppressedBy — no path, no matched bytes by construction). 0.2.0 shipped the event-union and `totalChecks` widening only; the ruled contract also lists these summary extras, and the consumer PR (hackmyagent settled-outcome) needs the type before it can send them.

Type change only, no runtime branches. Proof: tsc `--strict` probe using every new key — 0 errors on this branch, 2 on 0.2.0's types; package suite 33/33 via its own script (isolated HOME, sequential); the new cell round-trips the extras through queue and batch and asserts an omitted key stays absent.

After merge: tag `contribute-v0.3.0` (second publish of three today; also the first end-to-end run of the repaired release workflow after #301).