### PR TITLE
Neutralize review workflow and step names

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,4 +1,4 @@
-name: Claude PR Review
+name: PR Review
 
 on:
   pull_request:
@@ -42,7 +42,7 @@ jobs:
           fi
           echo "full_bytes=$FULL" >> "$GITHUB_OUTPUT"
 
-      - name: Claude review
+      - name: Automated review
         id: review
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Neutralizes the review workflow's display names: the workflow name `Claude PR Review` becomes `PR Review` and the review step `Claude review` becomes `Automated review`, matching the sibling repos' rename of their review check to `Automated code review`.

No branch-protection change is needed here: the required contexts (`review`, `sast`) are job ids and already neutral, and the posted comment header (`### Automated review: VERDICT`) was already neutral. The model API call and its headers are unchanged.
