### PR TITLE
ci: pin atx-conformance at the 21-fixture suite and vendor the untrusted-chain-authority fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       # grows; the vendored copies under packages/atx-verify/src/__fixtures__
       # must be refreshed in the same PR or the byte-compare below fails.
       # Same gate pattern as agent-identity-management's Java SDK fixtures.
-      ATX_CONFORMANCE_REF: f4d40a4e33ac15946e90683ad1f1c59122559407
+      ATX_CONFORMANCE_REF: d2b8376daaec47046e54a3035178d706a5edec1d
     steps:
       - uses: actions/checkout@v4
 

--- a/packages/atx-verify/src/__fixtures__/baseline-valid-hybrid.json
+++ b/packages/atx-verify/src/__fixtures__/baseline-valid-hybrid.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
   "name": "atx-v1/baseline-valid-hybrid",
-  "description": "An ATX v1.0 credential carrying both an Ed25519 signature and an ML-DSA-65 signature over the same canonical payload. This is the hybrid signing path the ATX v1.0 spec mandates. A spec-conformant verifier MUST verify BOTH signatures and ACCEPT only when both are valid. NOTE: the current opena2a-registry/pkg/atcverify verifier verifies Ed25519 only and silently ignores ML-DSA-65 signatures; the conformance Go verifier in ../verifiers/go DOES verify both, per spec.",
+  "description": "An ATX v1.0 credential carrying both an Ed25519 signature and an ML-DSA-65 signature over the same canonical payload. This is the hybrid signing path the ATX v1.0 spec mandates. A spec-conformant verifier MUST verify BOTH signatures and ACCEPT only when both are valid. The ML-DSA-65 signature value is a raw FIPS 204 ML-DSA-65 signature (3309 bytes decoded) over the same canonical bytes as the Ed25519 signature; no container or combined-blob framing is used.",
   "spec": [
     {
       "id": "ATX",

--- a/packages/atx-verify/src/__fixtures__/malformed-schema.json
+++ b/packages/atx-verify/src/__fixtures__/malformed-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
   "name": "atx-v1/malformed-schema",
-  "description": "An ATX whose atcVersion claims a version (2.0) that is not the v1.0 supported by this conformance suite. Verifier MUST REJECT at step 1 (schema-version check) with an unsupported-version reason. NOTE: the signature is computed using ATCVersion=\"1.0\" canonical bytes because the production canonicalPayload function hardcodes \"1.0\" in the canonical string regardless of the credential's atcVersion field. This is itself a discrepancy worth noting in the reconciliation log; the conformance fixture intentionally still produces a syntactically reasonable file so verifiers can demonstrate they reject on schema-version alone.",
+  "description": "An ATX whose atcVersion claims a version (2.0) that is not the v1.0 supported by this conformance suite. Verifier MUST REJECT at step 1 (schema-version check) with an unsupported-version reason. NOTE: the signature is computed over v1.0 canonical bytes, whose eleventh field is the literal \"1.0\" independent of the credential's atcVersion field; the fixture is otherwise well formed so that a verifier can demonstrate it rejects on the schema-version check alone.",
   "spec": [
     {
       "id": "ATX",

--- a/packages/atx-verify/src/__fixtures__/v1_1-untrusted-chain-authority.json
+++ b/packages/atx-verify/src/__fixtures__/v1_1-untrusted-chain-authority.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
-  "name": "atx-v1_1/cross-issuer-key",
-  "description": "An ATX v1.1 credential issued by the primary authority but signed by a different trusted authority's key (partner.example). The secondary authority is trusted and its key is configured, and the signature is valid over JCS(TBS), but the secondary is neither the issuer nor present in the signed issuerChain. A spec-conformant verifier binds each signature to a key controlled by the issuer, or by an authority that is both named in the signed issuerChain and in the verifier's trusted issuers, and MUST REJECT with a signature-validation reason.",
+  "name": "atx-v1_1/untrusted-chain-authority",
+  "description": "An ATX v1.1 credential whose issuerDid is the primary authority (did:opena2a:authority:opena2a.org) and whose signed issuerChain names the primary authority and an untrusted authority (did:opena2a:authority:attacker.example). It carries one Ed25519 signature made ONLY by the untrusted authority's key over JCS(TBS), so the chain that names the signer is inside the signed bytes. The verifier trusts only the primary authority as an issuer, but the untrusted key is present in its configured public keys under a DID-URL keyId. A verifier that derives the eligible signing authorities from the credential's own issuerChain wrongly ACCEPTs: the chain names the signer's DID and the signer's key is configured. That chain is signed by the very key whose eligibility is in question, so it cannot vouch for that key. A signature verifies only against a key resolved for an authority the verifier trusts for this credential: the issuerDid, or an authority that is both named in the signed issuerChain and in the verifier's trusted issuers. A chain DID that is not a trusted issuer contributes no eligible key, so no configured key verifies the signature and the verifier MUST REJECT with a signature-validation reason.",
   "spec": [
     {
       "id": "ATX",
@@ -33,18 +33,17 @@
       "keyId": "did:opena2a:authority:opena2a.org#key-1"
     },
     {
-      "role": "issuer-secondary",
-      "path": "vectors/issuer-secondary.json",
+      "role": "issuer-untrusted",
+      "path": "vectors/issuer-untrusted.json",
       "algorithm": "Ed25519",
-      "publicKeyHex": "2043fa51c3d9e4a21a535ccb38bdc4fb56083737d22059d69475e7e43c47f582",
-      "keyId": "did:opena2a:authority:partner.example#key-1"
+      "publicKeyHex": "278117fc144c72340f67d0f2316e8386ceffbf2b2428c9c51fef7c597f1d426e",
+      "keyId": "did:opena2a:authority:attacker.example#key-1"
     }
   ],
   "verifierState": {
     "clockRfc3339": "2026-05-24T00:00:00Z",
     "trustedIssuers": [
-      "did:opena2a:authority:opena2a.org",
-      "did:opena2a:authority:partner.example"
+      "did:opena2a:authority:opena2a.org"
     ],
     "publicKeys": [
       {
@@ -69,11 +68,11 @@
         "keyId": "did:opena2a:authority:opena2a.org#key-3"
       },
       {
-        "role": "issuer-secondary",
-        "path": "vectors/issuer-secondary.json",
+        "role": "issuer-untrusted",
+        "path": "vectors/issuer-untrusted.json",
         "algorithm": "Ed25519",
-        "publicKeyHex": "2043fa51c3d9e4a21a535ccb38bdc4fb56083737d22059d69475e7e43c47f582",
-        "keyId": "did:opena2a:authority:partner.example#key-1"
+        "publicKeyHex": "278117fc144c72340f67d0f2316e8386ceffbf2b2428c9c51fef7c597f1d426e",
+        "keyId": "did:opena2a:authority:attacker.example#key-1"
       }
     ]
   },
@@ -116,14 +115,14 @@
     "expiresAt": "2099-12-31T23:59:59Z",
     "issuerDid": "did:opena2a:authority:opena2a.org",
     "issuerChain": [
-      "did:opena2a:authority:opena2a.org-root",
-      "did:opena2a:authority:opena2a.org"
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:attacker.example"
     ],
     "signatures": [
       {
-        "keyId": "did:opena2a:authority:partner.example#key-1",
+        "keyId": "did:opena2a:authority:attacker.example#key-1",
         "algorithm": "Ed25519",
-        "value": "VIoRLMLXWSQJosyTSMpnORfH1oMv9pfWYoehAwyASHRJ03cL7MuErJ/0vu7jziGur8meBaleSNP3D3ETLTXmBw=="
+        "value": "wckUCFwBI1XfltoMx2NOXK2JhfOHvl4M8plQ/p47e+AKKKdfGiZ/PoQ4dOrGC1b787J1CTZ96/OC9y4PhYc0CQ=="
       }
     ],
     "revoked": false,

--- a/packages/atx-verify/src/conformance.test.ts
+++ b/packages/atx-verify/src/conformance.test.ts
@@ -1,7 +1,7 @@
 /**
  * Conformance gate: run LocalAtxVerifier against the FULL OpenA2A ATX
  * conformance suite (verbatim copies from `atx-conformance/fixtures/` pinned at
- * f4d40a4, including their PINNED Ed25519 signatures and issuer public keys —
+ * d2b8376, including their PINNED Ed25519 signatures and issuer public keys —
  * CI byte-compares the vendored copies against the pinned suite). This proves
  * the verifier accepts/rejects exactly the credentials the Go and Python
  * reference verifiers do.
@@ -43,8 +43,8 @@ interface Fixture {
   expected: { verifyResult: 'ACCEPT' | 'REJECT'; rejectCategory?: string };
 }
 
-/** The suite pinned at atx-conformance f4d40a4 has exactly 20 fixtures. */
-const PINNED_SUITE_SIZE = 20;
+/** The suite pinned at atx-conformance d2b8376 has exactly 21 fixtures. */
+const PINNED_SUITE_SIZE = 21;
 
 const FIXTURES_DIR = new URL('./__fixtures__/', import.meta.url);
 const fixtureFiles = readdirSync(FIXTURES_DIR)
@@ -68,7 +68,7 @@ function expectedCategory(suiteCategory: string): RejectCategory {
   return (suiteCategory === 'PARSE_ERROR' ? 'MALFORMED' : suiteCategory) as RejectCategory;
 }
 
-describe('conformance fixtures (atx-conformance @ f4d40a4, pinned signatures)', () => {
+describe('conformance fixtures (atx-conformance @ d2b8376, pinned signatures)', () => {
   it(`covers the full pinned suite (${PINNED_SUITE_SIZE} fixtures)`, () => {
     expect(fixtureFiles.length).toBe(PINNED_SUITE_SIZE);
   });


### PR DESCRIPTION
## What

Bumps `ATX_CONFORMANCE_REF` from f4d40a4e (20 fixtures) to d2b8376 (21), the suite that ships `fixtures/v1_1-untrusted-chain-authority.json`, the MUST-REJECT case for the trusted-issuer intersection this verifier has carried since #292. Every vendored copy under `packages/atx-verify/src/__fixtures__` is refreshed to that ref byte-for-byte, as the CI byte-compare requires: the new fixture is added and three others pick up the suite's revised descriptions (credential bytes and verdicts unchanged). The conformance test's pinned size moves to 21 and its pinned-ref comments follow.

Same shape as the Registry and AIM pin bumps that landed today (opena2a-org/opena2a-registry#441, opena2a-org/agent-identity-management#465).

## Proof

Local run at this ref: vitest 22 of 22 in `conformance.test.ts`, including `atx-v1_1/untrusted-chain-authority -> REJECT (SIGNATURE_INVALID)` and the 21-count test; 111 of 111 in the package; `tsc`, build and eslint clean; `cmp` of all 21 vendored files against the suite at d2b8376 reports no drift in either direction.

This touches `.github/workflows/ci.yml`, so it needs the gate-file approval.