### PR TITLE
cli-ui: document the 0.6.0 grammar exports and fix the CHANGELOG import path

### DIFF
--- a/packages/cli-ui/CHANGELOG.md
+++ b/packages/cli-ui/CHANGELOG.md
@@ -43,9 +43,9 @@
   byte-identical to the plain form (zero `\x1b`).
 - The barrel keeps the existing `renderNextSteps` (CTA objects, 0.3.0)
   binding; the grammar's command-list `renderNextSteps` is reachable from
-  `./grammar.js`. Everything else about the export surface is additive —
-  no export was removed or renamed, and `chalk` remains the only runtime
-  dependency.
+  `dist/grammar.js` (imported as `@opena2a/cli-ui/dist/grammar.js`).
+  Everything else about the export surface is additive — no export was
+  removed or renamed, and `chalk` remains the only runtime dependency.
 
 ### Fixed
 - `runTelemetryCommand` no longer prints a toggle hint that cannot work. When

--- a/packages/cli-ui/README.md
+++ b/packages/cli-ui/README.md
@@ -27,6 +27,65 @@ console.log(divider("Findings"));
 console.log(`  ${trustLevelLegend(3)}`);
 ```
 
+## Terminal grammar (0.6.0)
+
+Seven grammar exports render the shared front-door language every OpenA2A CLI speaks (verdict line first, path-up score, bounded next steps):
+
+- `renderVerdict({ verdict, summary })` — the verdict line, always printed first: one line, no leading blank.
+- `renderScore({ score, pathTo100 })` — `72/100 -> 100 by <cmd>` plus a meter; only ever the path up, never a delta (`-5`) or a letter grade (`B+`).
+- `renderFinding(finding)` — severity, title, `file:line`, one sentence of why, a `Verify:` command, a `Fix:` command, at most one URL.
+- `renderNextSteps(commands)` — one to three runnable commands (throws `RangeError` outside that range), first one primary. This is the grammar's command-list variant — see the import note below.
+- `renderProgress(input, sink)` — writes only to the caller-supplied stderr sink and scrubs the home directory to `~` before anything is emitted.
+- `renderError({ what, unchanged, next })` — what happened, what was not changed, and the one command to run next.
+- `envelope(input)` — builds the one `--json` object every front door prints: exactly `schemaVersion`, `tool`, `version`, `verdict`, `score`, `findings[]`, `nextSteps[]` (1-3 commands), `exitCode`, camelCase, no other top-level key.
+
+All of these except `renderNextSteps` are imported from the package barrel:
+
+```ts
+import { renderVerdict, envelope } from "@opena2a/cli-ui";
+
+console.log(renderVerdict({ verdict: "warning", summary: "2 findings need review" }));
+// ⚠ WARNING — 2 findings need review
+
+const json = envelope({
+  tool: "hackmyagent",
+  version: "1.4.2",
+  verdict: "warning",
+  score: 72,
+  nextSteps: ["hackmyagent secure --fix"],
+  exitCode: 1,
+});
+console.log(JSON.stringify(json));
+```
+
+### Importing the grammar's `renderNextSteps`
+
+The barrel keeps the existing 0.3.0 `renderNextSteps` (CTA objects) binding, so `import { renderNextSteps } from "@opena2a/cli-ui"` stays the CTA variant. The grammar's command-list variant is imported from the built module directly:
+
+```ts
+import { renderNextSteps } from "@opena2a/cli-ui/dist/grammar.js";
+
+console.log(renderNextSteps(["hackmyagent secure --fix", "hackmyagent report"]));
+```
+
+### Conformance
+
+`frontDoorConformance(target)` spawns a built CLI front door with a fresh temporary `HOME`, `NO_COLOR=1` and stdin closed, and reports pass/fail with the observed value for the five front-door properties: verdict line first; `--json` envelope parity with the human view; process exit code equals `envelope.exitCode`; zero ANSI bytes under `NO_COLOR` + non-TTY; every cited `nextSteps` / `Verify:` / `Fix:` command parses against the binary's own `--help`. Consumers adopt it as a `cli-grammar-conformance.test.ts` run against their built front door:
+
+```ts
+import { frontDoorConformance } from "@opena2a/cli-ui";
+import { expect, test } from "vitest";
+
+test("front door speaks the CLI grammar", async () => {
+  const result = await frontDoorConformance({
+    bin: "./dist/cli.js",
+    args: ["check", "left-pad"],
+  });
+  const failed = result.properties.filter((p) => !p.pass);
+  expect(failed, JSON.stringify(failed, null, 2)).toEqual([]);
+});
+```
+
 ## Color rules
 
 - Score / meter: green ≥ 70, yellow ≥ 40, red below.


### PR DESCRIPTION
Consumer docs for `@opena2a/cli-ui` 0.6.0 stopped at a dead end: the README named none of the seven grammar exports, and the CHANGELOG pointed at `./grammar.js`, a path that does not resolve from a consumer. Two files, 62 insertions, 3 deletions, no code.

- `packages/cli-ui/README.md`: a "Terminal grammar (0.6.0)" section names `renderVerdict`, `renderScore`, `renderFinding`, `renderNextSteps`, `renderProgress`, `renderError` and `envelope` with what each renders, a worked example against the package barrel, the `dist/grammar.js` import for the grammar's `renderNextSteps` (the barrel keeps the 0.3.0 CTA binding under that name), and the `frontDoorConformance` usage in a vitest.
- `packages/cli-ui/CHANGELOG.md`: the 0.6.0 entry's `./grammar.js` becomes `dist/grammar.js`, imported as `@opena2a/cli-ui/dist/grammar.js`.

Verified: every documented import path resolves against the built package; the old `./grammar.js` path fails with `ERR_MODULE_NOT_FOUND` as before. This is the docs change that rides ahead of the next cli-ui publish; the publish itself is not part of this PR.
