### PR TITLE
test: assemble detector fixtures from parts and guard test sources against whole credential shapes

### DIFF
--- a/packages/cli/__tests__/util/ai-config.test.ts
+++ b/packages/cli/__tests__/util/ai-config.test.ts
@@ -126,7 +126,7 @@ describe('ai-config', () => {
       fs.writeFileSync(path.join(tempDir, 'mcp.json'), JSON.stringify({
         mcpServers: {
           'github': { command: 'node', args: [], env: { TOKEN: 'ghp_' + 'A'.repeat(36) } },
-          'aws': { command: 'node', args: [], env: { KEY: 'AKIA1234567890ABCDEF' } },
+          'aws': { command: 'node', args: [], env: { KEY: 'AKIA' + '1234567890ABCDEF' } },
         },
       }));
 
@@ -184,7 +184,7 @@ describe('ai-config', () => {
     it('detects Google API key (drift) in MCP env', () => {
       fs.writeFileSync(path.join(tempDir, 'mcp.json'), JSON.stringify({
         mcpServers: {
-          'maps': { command: 'node', args: [], env: { GMAP_KEY: 'AIzaSyC8x4iFaKe_Key12345678901234567890abc' } },
+          'maps': { command: 'node', args: [], env: { GMAP_KEY: 'AIza' + 'SyC8x4iFaKe_Key12345678901234567890abc' } },
         },
       }));
 
@@ -192,6 +192,30 @@ describe('ai-config', () => {
       expect(matches.length).toBe(1);
       expect(matches[0].findingId).toBe('DRIFT-001');
       expect(matches[0].severity).toBe('high');
+    });
+
+    it('OPA-12.AC3 still detects the assembled AWS and Google fixture values', () => {
+      fs.writeFileSync(path.join(tempDir, 'mcp.json'), JSON.stringify({
+        mcpServers: {
+          'github': { command: 'node', args: [], env: { TOKEN: 'ghp_' + 'A'.repeat(36) } },
+          'aws': { command: 'node', args: [], env: { KEY: 'AKIA' + '1234567890ABCDEF' } },
+        },
+      }));
+
+      const findings = scanMcpConfig(tempDir);
+      const cred = findings.find(f => f.findingId === 'MCP-CRED');
+      expect(cred).toBeDefined();
+      expect(cred!.items!.length).toBe(2);
+
+      fs.writeFileSync(path.join(tempDir, 'mcp.json'), JSON.stringify({
+        mcpServers: {
+          'maps': { command: 'node', args: [], env: { GMAP_KEY: 'AIza' + 'SyC8x4iFaKe_Key12345678901234567890abc' } },
+        },
+      }));
+
+      const matches = scanMcpCredentials(tempDir);
+      expect(matches.length).toBe(1);
+      expect(matches[0].findingId).toBe('DRIFT-001');
     });
 
     it('detects GitHub token in MCP env', () => {

--- a/packages/credential-patterns/src/patterns.test.ts
+++ b/packages/credential-patterns/src/patterns.test.ts
@@ -11,11 +11,17 @@ import { CONFIG_FILES, CREDENTIAL_PATTERNS, CREDENTIAL_PREFIX_QUICK_CHECK } from
 // Build test tokens dynamically to avoid triggering GitHub Push Protection
 const slackTestToken = ['xox', 'b-1234567890-1234567890-', 'abcdefghijklmnopqrstuvwx'].join('');
 const discordBotToken = ['MTIzNDU2Nzg5MDEyMzQ1Njc4OQ', '.GabcDE.', 'abcdefghijklmnopqrstuvwxyz01234'].join('');
+const anthropicTestKey = ['sk-ant-api03-', 'abc123def456abc123def456abc123'].join('');
+const awsAccessTestKey = ['AKIA', 'IOSFODNN7EXAMPLE'].join('');
+const awsStsTestKey = ['ASIA', 'IOSFODNN7EXAMPLE'].join('');
+const githubPatTestToken = ['ghp_', 'abcdefghijklmnopqrstuvwxyz0123456789'].join('');
+const mongodbSrvTestUri = ['mongodb+srv://', 'user:pass', '@cluster.mongodb.net/db'].join('');
+const googleTestKey = ['AIza', 'SyB-abc_def123456789012345678901234'].join('');
 
 const PATTERN_TEST_CASES: Record<string, { valid: string[]; invalid: string[] }> = {
   // AI/ML
   'anthropic': {
-    valid: ['sk-ant-api03-abc123def456abc123def456abc123'],
+    valid: [anthropicTestKey],
     invalid: ['sk-ant-wrong', 'sk-ant-api-tooshort'],
   },
   'openai-proj': {
@@ -53,11 +59,11 @@ const PATTERN_TEST_CASES: Record<string, { valid: string[]; invalid: string[] }>
 
   // Cloud
   'aws-access': {
-    valid: ['AKIAIOSFODNN7EXAMPLE'],
+    valid: [awsAccessTestKey],
     invalid: ['AKIA123', 'BKIAIOSFODNN7EXAMPLE'],
   },
   'aws-sts': {
-    valid: ['ASIAIOSFODNN7EXAMPLE'],
+    valid: [awsStsTestKey],
     invalid: ['ASIA123', 'BSIAIOSFODNN7EXAMPLE'],
   },
   'aws-secret': {
@@ -141,7 +147,7 @@ const PATTERN_TEST_CASES: Record<string, { valid: string[]; invalid: string[] }>
 
   // Developer
   'github-pat': {
-    valid: ['ghp_abcdefghijklmnopqrstuvwxyz0123456789'],
+    valid: [githubPatTestToken],
     invalid: ['ghp_short', 'ghp_'],
   },
   'github-fine': {
@@ -218,7 +224,7 @@ const PATTERN_TEST_CASES: Record<string, { valid: string[]; invalid: string[] }>
   // cross JSON string boundaries on minified content.
   'mongodb': {
     valid: [
-      'mongodb+srv://user:pass@cluster.mongodb.net/db',
+      mongodbSrvTestUri,
       'mongodb://admin:hunter2@mongo1:27017,mongo2:27017/db',
     ],
     invalid: ['mongodb://lo', 'mongo+srv://x', 'mongodb+srv://cluster.mongodb.net/db'],
@@ -272,7 +278,7 @@ const PATTERN_TEST_CASES: Record<string, { valid: string[]; invalid: string[] }>
 
   // Auth & Crypto
   'google': {
-    valid: ['AIzaSyB-abc_def123456789012345678901234'],
+    valid: [googleTestKey],
     invalid: ['AIzaShort', 'BIzaSyBabc1234567890123456789012345'],
   },
   'google-oauth': {
@@ -443,7 +449,7 @@ describe('CREDENTIAL_PREFIX_QUICK_CHECK', () => {
   it('matches known credential prefixes', () => {
     expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('sk-ant-api03-xxx')).toBe(true);
     expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('sk-proj-xxx')).toBe(true);
-    expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('AKIA1234567890123456')).toBe(true);
+    expect(CREDENTIAL_PREFIX_QUICK_CHECK.test(['AKIA', '1234567890123456'].join(''))).toBe(true);
     expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('ghp_abc')).toBe(true);
     expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('xoxb-123')).toBe(true);
     expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('gsk_abc')).toBe(true);
@@ -460,6 +466,32 @@ describe('CREDENTIAL_PREFIX_QUICK_CHECK', () => {
     // A 'rediss' prefix would make consumers' ${VAR}-skip drop plain
     // redis:// lines before the real pattern runs — a silent miss.
     expect(CREDENTIAL_PREFIX_QUICK_CHECK.test('redis://x')).toBe(true);
+  });
+});
+
+describe('OPA-12 detection preserved for assembled fixtures', () => {
+  // The families whose fixtures were whole in-source literals before being
+  // assembled from parts; the live catalog must still see the assembled values.
+  const AFFECTED_FAMILIES = ['anthropic', 'aws-access', 'aws-sts', 'github-pat', 'mongodb', 'google'];
+
+  it('OPA-12.AC3 each affected family keeps a valid fixture matching the live catalog pattern, and assembled quick-check probes still pass', () => {
+    for (const id of AFFECTED_FAMILIES) {
+      const pattern = CREDENTIAL_PATTERNS.find(p => p.id === id);
+      expect(pattern, `catalog pattern ${id}`).toBeDefined();
+      const matched = PATTERN_TEST_CASES[id].valid.some(v => pattern!.regex.test(v));
+      expect(matched, `family ${id} keeps a valid fixture matching the live pattern`).toBe(true);
+    }
+    expect(/^sk-ant-api\d{2}-/.test(anthropicTestKey)).toBe(true);
+    expect(CREDENTIAL_PREFIX_QUICK_CHECK.test(['AKIA', '1234567890123456'].join(''))).toBe(true);
+  });
+
+  it('OPA-12.AC4 affected-family invalid fixtures still do not match — no detector weakened', () => {
+    for (const id of AFFECTED_FAMILIES) {
+      const pattern = CREDENTIAL_PATTERNS.find(p => p.id === id)!;
+      for (const invalid of PATTERN_TEST_CASES[id].invalid) {
+        expect(pattern.regex.test(invalid), `family ${id} still rejects: ${invalid}`).toBe(false);
+      }
+    }
   });
 });
 

--- a/packages/credential-patterns/src/source-literal-guard.test.ts
+++ b/packages/credential-patterns/src/source-literal-guard.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Source-literal guard: the detector test files must never carry a whole
+ * provider-shaped credential literal in their committed source. Fixtures are
+ * assembled from parts at run time (see slackTestToken above the harness in
+ * patterns.test.ts), so the detectors see the assembled string but the tree —
+ * and GitHub secret scanning — never see a contiguous shape.
+ *
+ * The shape set is carried inline as regexes: a regex literal's source never
+ * forms a contiguous provider-shape string, so this file stays clean under
+ * its own rule.
+ */
+const PROVIDER_SHAPES: RegExp[] = [
+  /(AKIA|ASIA)[0-9A-Z]{16}/,
+  /AIza[0-9A-Za-z_-]{35}/,
+  /xox[abprs]-[0-9A-Za-z-]{20,}/,
+  /ghp_[A-Za-z0-9]{36}/,
+  /github_pat_[A-Za-z0-9_]{22,}/,
+  /sk-ant-[A-Za-z0-9_-]{20,}/,
+  /mongodb\+srv:\/\/[^:/@\s]+:[^@\s]+@[^/\s]+/,
+  /live_[A-Za-z0-9_-]{30,}/,
+];
+
+// Repo-relative scan population: exactly the detector test files this rule
+// covers. protect.test.ts carries no shapes today but stays in scope so a
+// regression there fails here, not in GitHub's alert queue.
+const SCANNED_FILES = [
+  'packages/cli/__tests__/util/ai-config.test.ts',
+  'packages/cli/__tests__/commands/protect.test.ts',
+  'packages/credential-patterns/src/patterns.test.ts',
+];
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+interface ShapeHit {
+  file: string;
+  line: number;
+  shape: string;
+}
+
+function scanFileForProviderShapes(filePath: string): ShapeHit[] {
+  const source = fs.readFileSync(filePath, 'utf8');
+  const hits: ShapeHit[] = [];
+  for (const shape of PROVIDER_SHAPES) {
+    const re = new RegExp(shape.source, 'g');
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(source)) !== null) {
+      hits.push({
+        file: filePath,
+        line: source.slice(0, match.index).split('\n').length,
+        shape: shape.source,
+      });
+      if (re.lastIndex === match.index) re.lastIndex++;
+    }
+  }
+  return hits;
+}
+
+function guardVerdict(files: string[]): { pass: boolean; hits: ShapeHit[] } {
+  const hits = files.flatMap(scanFileForProviderShapes);
+  return { pass: hits.length === 0, hits };
+}
+
+describe('source-literal guard', () => {
+  it('OPA-12.AC1 committed detector test files carry zero contiguous provider-shape literals', () => {
+    const targets = SCANNED_FILES.map(rel => path.join(repoRoot, rel));
+    for (const target of targets) {
+      expect(fs.existsSync(target), `scanned file exists: ${path.relative(repoRoot, target)}`).toBe(true);
+    }
+    const verdict = guardVerdict(targets);
+    const report = verdict.hits.map(h => `${path.relative(repoRoot, h.file)}:${h.line} matches ${h.shape}`);
+    expect(report).toEqual([]);
+    expect(verdict.pass).toBe(true);
+  });
+
+  it('OPA-12.AC2 refuses a scratch copy with a planted provider-shape literal', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opa12-guard-'));
+    try {
+      // Plant into a copy of a real scanned file; the planted value is itself
+      // assembled at plant time so this test's source stays shape-free.
+      const original = path.join(repoRoot, 'packages/credential-patterns/src/patterns.test.ts');
+      const plantedValue = ['AKIA', 'ABCDEFGHIJKLMNOP'].join('');
+      const plantedFile = path.join(tempDir, 'patterns.test.ts');
+      fs.writeFileSync(
+        plantedFile,
+        fs.readFileSync(original, 'utf8') + `\nconst plantedFixture = '${plantedValue}';\n`,
+      );
+
+      const verdict = guardVerdict([plantedFile]);
+      expect(verdict.hits.some(h => h.file === plantedFile)).toBe(true);
+      expect(verdict.pass).toBe(false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
The credential-pattern tests carried whole provider-shaped literals (AWS access key ids, Google API keys, Slack tokens, GitHub PATs, Anthropic keys, MongoDB SRV URIs with userinfo) as fixtures, so GitHub secret scanning kept flagging our own scanner's tests. The fixtures are now assembled from parts at run time (join, concat, repeat), so the detectors see the assembled string while the committed source never carries it. Three files, 166 insertions, 9 deletions, tests only.

- `packages/credential-patterns/src/patterns.test.ts` and `packages/cli/__tests__/util/ai-config.test.ts`: every whole-shape literal replaced by a parts assembly with the same assertion.
- `packages/credential-patterns/src/source-literal-guard.test.ts` (new): reads the test sources and fails naming the file and shape if a whole provider-shaped literal ever returns; the shape set is inline so a weakened detector cannot weaken the guard.

Verification on the branch: `npm ci`, `npm run build`, vitest 280/280 in credential-patterns and 1603/1603 in cli; the guard is red against the previous test sources and green now; the repository's open secret-scanning alert list reads 0. The matching secretless change is a separate PR on that repository.