### PR TITLE
Security workflow: npm ci --ignore-scripts in build-tree-audit, sast and license-check

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm audit --audit-level=high
 
   # The job above audits this workspace: `packages/*`, devDependencies, and the
@@ -136,7 +136,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       # Prove the gate can fail before trusting that it passed. Each probe
       # plants one dynamic-evaluation primitive and asserts the lint rejects
       # it; then the probe is removed and the real tree is linted. Without
@@ -167,7 +167,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - name: Check for problematic licenses
         run: |
           npx license-checker --production --failOn 'GPL-2.0;GPL-3.0;AGPL-1.0;AGPL-3.0;SSPL-1.0'


### PR DESCRIPTION
Adds `--ignore-scripts` to the three `npm ci` steps in the Security workflow (`build-tree-audit`, `sast`, `license-check`). Nothing else changes.

Why: `build-tree-audit` has been red on main inside `npm ci`, not inside `npm audit`. `onnxruntime-node`'s postinstall downloads a binary from nuget.org and dies over IPv6 on the runner, so a network fault in an install script none of these jobs needs has been reported as an audit failure. The three jobs install the workspace only to audit the lockfile, lint the sources or check licenses; no install script contributes to any of those results. The two consumer-resolution audits in the same workflow already run with `--ignore-scripts` and are unchanged.

Measured on this head: the file parses (three `npm ci --ignore-scripts` lines at the same three sites; the diff is six lines); the repository's own build and tests pass on the branch. The job's verdict after this change measures the lockfile and the sources, which is what a required context should measure.
